### PR TITLE
Week 13: VPD batch 2 (8 new validators) + Q1 wrap-up

### DIFF
--- a/docs/PROJECT_INDEX.md
+++ b/docs/PROJECT_INDEX.md
@@ -1,13 +1,13 @@
 # LaTeX Perfectionist v25 - Project Index
 
-**Status**: Week 12 of 156 - Q1 Gates Passed (Bootstrap, Perf alpha, Proof beta)
+**Status**: Week 13 of 156 - Q1 Complete (Bootstrap, Perf alpha, Proof beta)
 **Last Updated**: February 2026
 **Project Type**: 3-Year Solo-Developer Project (156 weeks total)
 
 ## Current Status Summary
 
-- 67 validators implemented (33 TYPO hand + 9 VPD-gen + 14 MOD + 2 CMD + 1 EXP + 4 basic + 4 legacy)
-- VPD pipeline operational: rules_v3.yaml → vpd_grammar → vpd_compile → OCaml (E2E verified)
+- 75 validators implemented (33 TYPO hand + 17 VPD-gen + 14 MOD + 2 CMD + 1 EXP + 4 basic + 4 legacy)
+- VPD pipeline operational: rules_v3.yaml → vpd_grammar → vpd_compile → OCaml (23 rules in pipeline)
 - 12 Coq proof files, 0 admits, 0 axioms
 - Performance: p95 ~ 2.96 ms full-doc (target < 25 ms)
 - 31 CI workflows green
@@ -36,7 +36,8 @@ generator/
 ├── vpd_types.ml            # Core VPD type definitions (11 pattern families)
 ├── vpd_parse.ml            # JSON manifest parser
 ├── vpd_emit.ml             # OCaml code emitter
-└── typo_batch1.json        # Batch 1 manifest (9 rules)
+├── typo_batch1.json        # Batch 1 manifest (9 rules)
+└── typo_batch2.json        # Batch 2 manifest (8 rules)
 
 specs/rules/
 ├── rules_v3.yaml           # Authoritative rule catalogue (623 rules)

--- a/docs/WEEKLY_STATUS.md
+++ b/docs/WEEKLY_STATUS.md
@@ -99,10 +99,26 @@ Week 12 — VPD Grammar Front-End + Code Debt
 - CI: 25 workflows with opam retry, all green
 - Tests: 13 dune tests pass (including new test_simd_attestation)
 
-Current State (Post Week 12)
-- Validators: 67 rules (33 TYPO hand + 9 VPD-gen + 14 MOD + 2 CMD + 1 EXP + 4 basic + 4 legacy)
-- VPD Pipeline: rules_v3.yaml → vpd_grammar → vpd_compile → OCaml (E2E verified)
+Week 13 — VPD Batch 2 + Q1 Wrap-Up
+- VPD Batch 2: 8 new validators via VPD pipeline (TYPO-035, 036, 038, 041, 043, 054, 057, 063)
+  - 4 regex-family rules (shouting detection, email detection, en-dash spacing, degree symbol)
+  - 3 multi_substring rules (French punctuation, ldots spacing, smart quotes)
+  - 1 count_substring rule (non-breaking hyphen)
+- VPD-generated section now contains 17 rules (up from 9 in batch 1)
+- vpd_patterns.json expanded to 23 entries (covering all VPD-generated + hand-coded VPD-able rules)
+- typo_batch2.json: standalone batch 2 manifest for provenance tracking
+- E2E test updated: verifies all 23 rules in full manifest + batch 2 regex rules
+- All pilot golden tests pass (39/39), zero regressions
+- Q1 exit criteria met:
+  - dune build, dune runtest --force, dune fmt: all exit 0
+  - TYPO-001 E2E pipeline verified via VPD grammar
+  - Code debt resolved (no dead files, no hardcoded paths, no TODOs)
+
+Current State (Post Week 13 / Q1 Exit)
+- Validators: 75 rules (33 TYPO hand + 17 VPD-gen + 14 MOD + 2 CMD + 1 EXP + 4 basic + 4 legacy)
+- VPD Pipeline: rules_v3.yaml → vpd_grammar → vpd_compile → OCaml (23 rules in vpd_patterns.json)
 - Proofs: 12 files, 0 admits, 0 axioms
 - Performance: p95 ≈ 2.96 ms full-doc (target < 25 ms), edit-window p95 ≈ 0.017 ms
 - CI: 31 workflows covering build, format, tests, proofs, perf, REST, validators, Rust proxy
 - Gates passed: Bootstrap (W1), Perf α (W5), Proof β (W10)
+- Next gate: L0-L1 QED (W26) — Phase 2 begins

--- a/generator/typo_batch2.json
+++ b/generator/typo_batch2.json
@@ -1,0 +1,93 @@
+{
+  "version": "0.1.0",
+  "rules": [
+    {
+      "id": "TYPO-035",
+      "description": "French punctuation requires NBSP before ; : ! ?",
+      "layer": "L0",
+      "severity": "Warning",
+      "message": "Space before French punctuation mark; use non-breaking space ~",
+      "pattern": {
+        "family": "multi_substring",
+        "needles": [" ;", " :", " !", " ?"]
+      }
+    },
+    {
+      "id": "TYPO-036",
+      "description": "Suspicious consecutive capitalised words (shouting)",
+      "layer": "L0",
+      "severity": "Info",
+      "message": "Suspicious consecutive capitalised words; check for inadvertent shouting",
+      "pattern": {
+        "family": "regex",
+        "regex": "\\b[A-Z][A-Z]+ [A-Z][A-Z]+ [A-Z][A-Z]+\\b"
+      }
+    },
+    {
+      "id": "TYPO-038",
+      "description": "E-mail address not in \\href",
+      "layer": "L0",
+      "severity": "Info",
+      "message": "Bare e-mail address found; wrap in \\href{mailto:...}",
+      "pattern": {
+        "family": "regex",
+        "regex": "[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]+"
+      }
+    },
+    {
+      "id": "TYPO-041",
+      "description": "Incorrect spacing around \\ldots",
+      "layer": "L0",
+      "severity": "Info",
+      "message": "Incorrect spacing around \\ldots; check for missing space",
+      "pattern": {
+        "family": "multi_substring",
+        "needles": [".\\ldots", "\\ldots.", ",\\ldots"]
+      }
+    },
+    {
+      "id": "TYPO-043",
+      "description": "Smart quotes inside verbatim detected",
+      "layer": "L0",
+      "severity": "Warning",
+      "message": "Smart (curly) quotes detected; verbatim sections require ASCII quotes",
+      "pattern": {
+        "family": "multi_substring",
+        "needles": ["\u201C", "\u201D", "\u2018", "\u2019"]
+      }
+    },
+    {
+      "id": "TYPO-054",
+      "description": "Hair-space required after en-dash in word-word ranges",
+      "layer": "L0",
+      "severity": "Info",
+      "message": "En-dash adjacent to letter without spacing; consider thin space",
+      "pattern": {
+        "family": "regex",
+        "regex": "[a-zA-Z]\u2013[a-zA-Z]"
+      }
+    },
+    {
+      "id": "TYPO-057",
+      "description": "Missing thin-space before degree symbol",
+      "layer": "L0",
+      "severity": "Info",
+      "message": "Number directly adjacent to degree symbol; insert thin space",
+      "pattern": {
+        "family": "regex",
+        "regex": "[0-9]\u00b0"
+      }
+    },
+    {
+      "id": "TYPO-063",
+      "description": "Non-breaking hyphen U+2011 found",
+      "layer": "L0",
+      "severity": "Info",
+      "message": "Non-breaking hyphen U+2011 found; use standard hyphen",
+      "pattern": {
+        "family": "count_substring",
+        "needle": "\u2011"
+      }
+    }
+  ]
+}

--- a/latex-parse/src/validators.ml
+++ b/latex-parse/src/validators.ml
@@ -1534,7 +1534,7 @@ let r_typo_033 : rule =
 
 let rules_pilot : rule list = rules_pilot @ [ r_typo_033 ]
 
-(* BEGIN VPD-generated validators v0.1.0 — DO NOT EDIT BELOW THIS LINE *)
+(* BEGIN VPD-generated validators v0.2.0 — DO NOT EDIT BELOW THIS LINE *)
 
 (* Spurious space before footnote command \footnote *)
 let r_typo_034 : rule =
@@ -1552,6 +1552,53 @@ let r_typo_034 : rule =
   in
   { id = "TYPO-034"; run }
 
+(* French punctuation requires NBSP before ; : ! ? *)
+let r_typo_035 : rule =
+  let run s =
+    let cnt =
+      count_substring s " ;"
+      + count_substring s " :"
+      + count_substring s " !"
+      + count_substring s " ?"
+    in
+    if cnt > 0 then
+      Some
+        {
+          id = "TYPO-035";
+          severity = Warning;
+          message =
+            "Space before French punctuation mark; use non-breaking space ~";
+          count = cnt;
+        }
+    else None
+  in
+  { id = "TYPO-035"; run }
+
+(* Suspicious consecutive capitalised words (shouting) *)
+let r_typo_036 : rule =
+  let run s =
+    let re = Str.regexp "\\b[A-Z][A-Z]+ [A-Z][A-Z]+ [A-Z][A-Z]+\\b" in
+    let rec loop i acc =
+      try
+        ignore (Str.search_forward re s i);
+        loop (Str.match_end ()) (acc + 1)
+      with Not_found -> acc
+    in
+    let cnt = loop 0 0 in
+    if cnt > 0 then
+      Some
+        {
+          id = "TYPO-036";
+          severity = Info;
+          message =
+            "Suspicious consecutive capitalised words; check for inadvertent \
+             shouting";
+          count = cnt;
+        }
+    else None
+  in
+  { id = "TYPO-036"; run }
+
 (* Space before comma *)
 let r_typo_037 : rule =
   let run s =
@@ -1568,6 +1615,49 @@ let r_typo_037 : rule =
   in
   { id = "TYPO-037"; run }
 
+(* E-mail address not in \href *)
+let r_typo_038 : rule =
+  let run s =
+    let re = Str.regexp "[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]+" in
+    let rec loop i acc =
+      try
+        ignore (Str.search_forward re s i);
+        loop (Str.match_end ()) (acc + 1)
+      with Not_found -> acc
+    in
+    let cnt = loop 0 0 in
+    if cnt > 0 then
+      Some
+        {
+          id = "TYPO-038";
+          severity = Info;
+          message = "Bare e-mail address found; wrap in \\href{mailto:...}";
+          count = cnt;
+        }
+    else None
+  in
+  { id = "TYPO-038"; run }
+
+(* Incorrect spacing around \ldots *)
+let r_typo_041 : rule =
+  let run s =
+    let cnt =
+      count_substring s ".\\ldots"
+      + count_substring s "\\ldots."
+      + count_substring s ",\\ldots"
+    in
+    if cnt > 0 then
+      Some
+        {
+          id = "TYPO-041";
+          severity = Info;
+          message = "Incorrect spacing around \\ldots; check for missing space";
+          count = cnt;
+        }
+    else None
+  in
+  { id = "TYPO-041"; run }
+
 (* Multiple consecutive question marks ?? *)
 let r_typo_042 : rule =
   let run s =
@@ -1583,6 +1673,29 @@ let r_typo_042 : rule =
     else None
   in
   { id = "TYPO-042"; run }
+
+(* Smart quotes inside verbatim detected *)
+let r_typo_043 : rule =
+  let run s =
+    let cnt =
+      count_substring s "\xe2\x80\x9c"
+      + count_substring s "\xe2\x80\x9d"
+      + count_substring s "\xe2\x80\x98"
+      + count_substring s "\xe2\x80\x99"
+    in
+    if cnt > 0 then
+      Some
+        {
+          id = "TYPO-043";
+          severity = Warning;
+          message =
+            "Smart (curly) quotes detected; verbatim sections require ASCII \
+             quotes";
+          count = cnt;
+        }
+    else None
+  in
+  { id = "TYPO-043"; run }
 
 (* En-dash used as minus sign in text *)
 let r_typo_048 : rule =
@@ -1658,6 +1771,30 @@ let r_typo_053 : rule =
   in
   { id = "TYPO-053"; run }
 
+(* Hair-space required after en-dash in word-word ranges *)
+let r_typo_054 : rule =
+  let run s =
+    let re = Str.regexp "[a-zA-Z]\xe2\x80\x93[a-zA-Z]" in
+    let rec loop i acc =
+      try
+        ignore (Str.search_forward re s i);
+        loop (Str.match_end ()) (acc + 1)
+      with Not_found -> acc
+    in
+    let cnt = loop 0 0 in
+    if cnt > 0 then
+      Some
+        {
+          id = "TYPO-054";
+          severity = Info;
+          message =
+            "En-dash adjacent to letter without spacing; consider thin space";
+          count = cnt;
+        }
+    else None
+  in
+  { id = "TYPO-054"; run }
+
 (* Consecutive thin-spaces prohibited *)
 let r_typo_055 : rule =
   let run s =
@@ -1674,6 +1811,30 @@ let r_typo_055 : rule =
     else None
   in
   { id = "TYPO-055"; run }
+
+(* Missing thin-space before degree symbol *)
+let r_typo_057 : rule =
+  let run s =
+    let re = Str.regexp "[0-9]\xc2\xb0" in
+    let rec loop i acc =
+      try
+        ignore (Str.search_forward re s i);
+        loop (Str.match_end ()) (acc + 1)
+      with Not_found -> acc
+    in
+    let cnt = loop 0 0 in
+    if cnt > 0 then
+      Some
+        {
+          id = "TYPO-057";
+          severity = Info;
+          message =
+            "Number directly adjacent to degree symbol; insert thin space";
+          count = cnt;
+        }
+    else None
+  in
+  { id = "TYPO-057"; run }
 
 (* Unicode multiplication sign in text *)
 let r_typo_061 : rule =
@@ -1693,17 +1854,41 @@ let r_typo_061 : rule =
   in
   { id = "TYPO-061"; run }
 
+(* Non-breaking hyphen U+2011 found *)
+let r_typo_063 : rule =
+  let run s =
+    let cnt = count_substring s "\xe2\x80\x91" in
+    if cnt > 0 then
+      Some
+        {
+          id = "TYPO-063";
+          severity = Info;
+          message = "Non-breaking hyphen U+2011 found; use standard hyphen";
+          count = cnt;
+        }
+    else None
+  in
+  { id = "TYPO-063"; run }
+
 let rules_vpd_gen : rule list =
   [
     r_typo_034;
+    r_typo_035;
+    r_typo_036;
     r_typo_037;
+    r_typo_038;
+    r_typo_041;
     r_typo_042;
+    r_typo_043;
     r_typo_048;
     r_typo_051;
     r_typo_052;
     r_typo_053;
+    r_typo_054;
     r_typo_055;
+    r_typo_057;
     r_typo_061;
+    r_typo_063;
   ]
 
 (* END VPD-generated validators *)

--- a/scripts/test_vpd_e2e.sh
+++ b/scripts/test_vpd_e2e.sh
@@ -40,11 +40,24 @@ FULL=$(./_build/default/generator/vpd_compile.exe "$MANIFEST" --internal)
 RULE_COUNT=$(echo "$FULL" | grep -c 'let r_typo_')
 echo "[vpd-e2e] Full manifest generated $RULE_COUNT rules"
 
-# Verify all 6 rules present
-for id in TYPO-001 TYPO-004 TYPO-005 TYPO-006 TYPO-023 TYPO-030; do
+# Verify all 23 VPD-patterned rules present
+for id in TYPO-001 TYPO-004 TYPO-005 TYPO-006 TYPO-023 TYPO-030 \
+          TYPO-034 TYPO-035 TYPO-036 TYPO-037 TYPO-038 TYPO-041 \
+          TYPO-042 TYPO-043 TYPO-048 TYPO-051 TYPO-052 TYPO-053 \
+          TYPO-054 TYPO-055 TYPO-057 TYPO-061 TYPO-063; do
   echo "$FULL" | grep -q "\"$id\"" || { echo "FAIL: missing $id"; exit 1; }
 done
-echo "[vpd-e2e] PASS: all 6 rules present in full manifest"
+echo "[vpd-e2e] PASS: all 23 rules present in full manifest"
+
+# ── Test 2b: Batch 2 regex rules compile correctly ─────────────────
+
+echo "[vpd-e2e] Checking batch 2 regex rules..."
+echo "$FULL" | grep -q 'Str.regexp' || { echo "FAIL: no Str.regexp in generated code"; exit 1; }
+echo "$FULL" | grep -q '"TYPO-036"' || { echo "FAIL: missing TYPO-036 (shouting)"; exit 1; }
+echo "$FULL" | grep -q '"TYPO-038"' || { echo "FAIL: missing TYPO-038 (email)"; exit 1; }
+echo "$FULL" | grep -q '"TYPO-054"' || { echo "FAIL: missing TYPO-054 (en-dash)"; exit 1; }
+echo "$FULL" | grep -q '"TYPO-057"' || { echo "FAIL: missing TYPO-057 (degree)"; exit 1; }
+echo "[vpd-e2e] PASS: batch 2 regex rules verified"
 
 # ── Test 3: --validate flag ───────────────────────────────────────────
 

--- a/specs/rules/vpd_patterns.json
+++ b/specs/rules/vpd_patterns.json
@@ -52,5 +52,158 @@
       "family": "count_substring",
       "needle": "----"
     }
+  },
+  "TYPO-034": {
+    "layer": "L0",
+    "severity": "Info",
+    "message": "Spurious space before \\footnote",
+    "pattern": {
+      "family": "count_substring",
+      "needle": " \\footnote"
+    }
+  },
+  "TYPO-035": {
+    "layer": "L0",
+    "severity": "Warning",
+    "message": "Space before French punctuation mark; use non-breaking space ~",
+    "pattern": {
+      "family": "multi_substring",
+      "needles": [" ;", " :", " !", " ?"]
+    }
+  },
+  "TYPO-036": {
+    "layer": "L0",
+    "severity": "Info",
+    "message": "Suspicious consecutive capitalised words; check for inadvertent shouting",
+    "pattern": {
+      "family": "regex",
+      "regex": "\\b[A-Z][A-Z]+ [A-Z][A-Z]+ [A-Z][A-Z]+\\b"
+    }
+  },
+  "TYPO-037": {
+    "layer": "L0",
+    "severity": "Info",
+    "message": "Space before comma",
+    "pattern": {
+      "family": "count_substring",
+      "needle": " ,"
+    }
+  },
+  "TYPO-038": {
+    "layer": "L0",
+    "severity": "Info",
+    "message": "Bare e-mail address found; wrap in \\href{mailto:...}",
+    "pattern": {
+      "family": "regex",
+      "regex": "[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]+"
+    }
+  },
+  "TYPO-041": {
+    "layer": "L0",
+    "severity": "Info",
+    "message": "Incorrect spacing around \\ldots; check for missing space",
+    "pattern": {
+      "family": "multi_substring",
+      "needles": [".\\ldots", "\\ldots.", ",\\ldots"]
+    }
+  },
+  "TYPO-042": {
+    "layer": "L0",
+    "severity": "Info",
+    "message": "Multiple consecutive question marks",
+    "pattern": {
+      "family": "count_substring",
+      "needle": "??"
+    }
+  },
+  "TYPO-043": {
+    "layer": "L0",
+    "severity": "Warning",
+    "message": "Smart (curly) quotes detected; verbatim sections require ASCII quotes",
+    "pattern": {
+      "family": "multi_substring",
+      "needles": ["\u201C", "\u201D", "\u2018", "\u2019"]
+    }
+  },
+  "TYPO-048": {
+    "layer": "L0",
+    "severity": "Info",
+    "message": "En-dash character used where minus sign expected",
+    "pattern": {
+      "family": "custom",
+      "body": "fun s -> let s = strip_math_segments s in Unicode.count_en_dash s"
+    }
+  },
+  "TYPO-051": {
+    "layer": "L0",
+    "severity": "Warning",
+    "message": "Thin space U+2009 found; prefer \\thinspace or \\, macro",
+    "pattern": {
+      "family": "count_substring",
+      "needle": "\u2009"
+    }
+  },
+  "TYPO-052": {
+    "layer": "L0",
+    "severity": "Warning",
+    "message": "Unescaped < or > in text; use \\textless / \\textgreater",
+    "pattern": {
+      "family": "custom",
+      "body": "fun s -> let s = strip_math_segments s in count_char s '<' + count_char s '>'"
+    }
+  },
+  "TYPO-053": {
+    "layer": "L0",
+    "severity": "Warning",
+    "message": "Unicode midline ellipsis U+22EF found; use \\cdots instead",
+    "pattern": {
+      "family": "count_substring",
+      "needle": "\u22EF"
+    }
+  },
+  "TYPO-054": {
+    "layer": "L0",
+    "severity": "Info",
+    "message": "En-dash adjacent to letter without spacing; consider thin space",
+    "pattern": {
+      "family": "regex",
+      "regex": "[a-zA-Z]\u2013[a-zA-Z]"
+    }
+  },
+  "TYPO-055": {
+    "layer": "L0",
+    "severity": "Info",
+    "message": "Consecutive \\, thin-spaces detected; collapse into single space",
+    "pattern": {
+      "family": "count_substring",
+      "needle": "\\,\\,"
+    }
+  },
+  "TYPO-057": {
+    "layer": "L0",
+    "severity": "Info",
+    "message": "Number directly adjacent to degree symbol; insert thin space",
+    "pattern": {
+      "family": "regex",
+      "regex": "[0-9]\u00b0"
+    }
+  },
+  "TYPO-061": {
+    "layer": "L0",
+    "severity": "Info",
+    "message": "Unicode multiplication sign found; prefer \\times in math mode",
+    "pattern": {
+      "family": "count_substring_strip_math",
+      "needle": "\u00D7"
+    }
+  },
+  "TYPO-063": {
+    "layer": "L0",
+    "severity": "Info",
+    "message": "Non-breaking hyphen U+2011 found; use standard hyphen",
+    "pattern": {
+      "family": "count_substring",
+      "needle": "\u2011"
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Add 8 new VPD-generated validators (TYPO-035, 036, 038, 041, 043, 054, 057, 063) bringing VPD-generated total from 9 to 17
- Expand `vpd_patterns.json` to 23 entries covering all VPD-able rules (batch 1 + batch 2 + hand-coded equivalents)
- New `generator/typo_batch2.json` batch manifest with 4 regex-family, 3 multi_substring, and 1 count_substring rules
- Update E2E tests to verify full 23-rule manifest + batch 2 regex rules
- Total validators: 75 (up from 67)
- Q1 exit criteria met: build/test/fmt all green, TYPO-001 E2E verified, code debt resolved

## New VPD Rules (Batch 2)
| Rule | Family | Description |
|------|--------|-------------|
| TYPO-035 | multi_substring | French NBSP before `;:!?` |
| TYPO-036 | regex | Consecutive capitalised words (shouting) |
| TYPO-038 | regex | Bare e-mail not in `\href` |
| TYPO-041 | multi_substring | Incorrect `\ldots` spacing |
| TYPO-043 | multi_substring | Smart quotes in verbatim |
| TYPO-054 | regex | En-dash spacing in word ranges |
| TYPO-057 | regex | Missing thin-space before degree symbol |
| TYPO-063 | count_substring | Non-breaking hyphen U+2011 |

## Test plan
- [x] `dune build @all` clean
- [x] `dune runtest --force` — 13 tests pass
- [x] `dune fmt` — no changes
- [x] `scripts/test_vpd_e2e.sh` — all 23 rules verified, batch 2 regex checks pass
- [x] Pilot golden smoke: 39/39 pass, zero regressions