### PR TITLE
chore: add .mli interface files for 10 core library modules

### DIFF
--- a/core/l0_lexer/arena.mli
+++ b/core/l0_lexer/arena.mli
@@ -1,0 +1,1 @@
+../../latex-parse/src/arena.mli

--- a/core/l0_lexer/broker.mli
+++ b/core/l0_lexer/broker.mli
@@ -1,0 +1,1 @@
+../../latex-parse/src/broker.mli

--- a/core/l0_lexer/clock.mli
+++ b/core/l0_lexer/clock.mli
@@ -1,0 +1,1 @@
+../../latex-parse/src/clock.mli

--- a/core/l0_lexer/config.mli
+++ b/core/l0_lexer/config.mli
@@ -1,0 +1,1 @@
+../../latex-parse/src/config.mli

--- a/core/l0_lexer/fd_util.mli
+++ b/core/l0_lexer/fd_util.mli
@@ -1,0 +1,1 @@
+../../latex-parse/src/fd_util.mli

--- a/core/l0_lexer/hedge_timer.mli
+++ b/core/l0_lexer/hedge_timer.mli
@@ -1,0 +1,1 @@
+../../latex-parse/src/hedge_timer.mli

--- a/core/l0_lexer/ipc.mli
+++ b/core/l0_lexer/ipc.mli
@@ -1,0 +1,1 @@
+../../latex-parse/src/ipc.mli

--- a/core/l0_lexer/net_io.mli
+++ b/core/l0_lexer/net_io.mli
@@ -1,0 +1,1 @@
+../../latex-parse/src/net_io.mli

--- a/core/l0_lexer/runtime_main_service.ml
+++ b/core/l0_lexer/runtime_main_service.ml
@@ -154,19 +154,19 @@ let run () =
           st.t_reply_ready,
           hedged,
           "" );
-      if Broker.(pool.requests mod 10_000 = 0) then (
+      if Broker.requests pool mod 10_000 = 0 then (
         Printf.eprintf
           "[hedge] req=%d fired=%d (%.3f%%) wins=%d (%.1f%%) rotations=%d\n%!"
-          Broker.(pool.requests)
-          Broker.(pool.hedge_fired)
+          (Broker.requests pool)
+          (Broker.hedge_fired_count pool)
           (100.0
-          *. float Broker.(pool.hedge_fired)
-          /. float (max 1 Broker.(pool.requests)))
-          Broker.(pool.hedge_wins)
+          *. float (Broker.hedge_fired_count pool)
+          /. float (max 1 (Broker.requests pool)))
+          (Broker.hedge_wins_count pool)
           (100.0
-          *. float Broker.(pool.hedge_wins)
-          /. float (max 1 Broker.(pool.hedge_fired)))
-          Broker.(pool.rotations);
+          *. float (Broker.hedge_wins_count pool)
+          /. float (max 1 (Broker.hedge_fired_count pool)))
+          (Broker.rotations_count pool);
         dump_csv ());
       loop ()
     in

--- a/core/l0_lexer/worker.mli
+++ b/core/l0_lexer/worker.mli
@@ -1,0 +1,1 @@
+../../latex-parse/src/worker.mli

--- a/latex-parse/src/arena.ml
+++ b/latex-parse/src/arena.ml
@@ -15,7 +15,7 @@ type buffers = {
   mutable next_ix : int;
 }
 
-type t = { a : buffers; b : buffers; mutable current : buffers; cap : int }
+type t = { a : buffers; b : buffers; mutable current : buffers }
 
 let create_buffers cap =
   let mk () = Array1.create Int32 c_layout cap in
@@ -31,7 +31,7 @@ let create_buffers cap =
 
 let create ~cap =
   let a = create_buffers cap and b = create_buffers cap in
-  { a; b; current = a; cap }
+  { a; b; current = a }
 
 let swap t =
   t.current <- (if t.current == t.a then t.b else t.a);

--- a/latex-parse/src/arena.mli
+++ b/latex-parse/src/arena.mli
@@ -1,0 +1,34 @@
+(** Double-buffered token arenas backed by Bigarrays.
+
+    Provides zero-copy, GC-free storage for SIMD tokeniser output. The
+    double-buffer design allows the previous result to remain readable while the
+    current request writes into the alternate buffer. *)
+
+open Bigarray
+
+type kinds_t = (int32, int32_elt, c_layout) Array1.t
+type offs_t = (int32, int32_elt, c_layout) Array1.t
+type codes_t = (int32, int32_elt, c_layout) Array1.t
+type issues_t = (int32, int32_elt, c_layout) Array1.t
+
+type buffers = {
+  kinds : kinds_t;
+  offs : offs_t;
+  codes : codes_t;
+  issues : issues_t;
+  lines : offs_t;
+  cols : offs_t;
+  mutable next_ix : int;
+}
+
+type t
+(** Opaque double-buffered arena. *)
+
+val create : cap:int -> t
+(** [create ~cap] allocates two buffer sets, each with room for [cap] tokens. *)
+
+val swap : t -> unit
+(** Switch to the alternate buffer and reset its write index. *)
+
+val current : t -> buffers
+(** Return the currently active buffer set. *)

--- a/latex-parse/src/broker.ml
+++ b/latex-parse/src/broker.ml
@@ -300,3 +300,8 @@ let hedged_call p ~(input : bytes) ~(hedge_ms : int) : svc_result =
         else race ()
       in
       race ()
+
+let requests (p : pool) = p.requests
+let hedge_fired_count (p : pool) = p.hedge_fired
+let hedge_wins_count (p : pool) = p.hedge_wins
+let rotations_count (p : pool) = p.rotations

--- a/latex-parse/src/broker.mli
+++ b/latex-parse/src/broker.mli
@@ -1,0 +1,30 @@
+(** Hedged-RPC broker with worker-pool management.
+
+    Dispatches tokenisation requests to a pool of forked worker processes using
+    a hedged-request strategy: if the primary worker does not reply within
+    [hedge_ms], a secondary is speculatively fired in parallel. *)
+
+type pool
+(** Opaque worker pool. *)
+
+type svc_result = {
+  status : int;
+  n_tokens : int;
+  issues_len : int;
+  origin : [ `P | `H ];
+  hedge_fired : bool;
+}
+
+val init_pool : int array -> pool
+(** [init_pool cores] spawns one worker per core id. *)
+
+val hedged_call : pool -> input:bytes -> hedge_ms:int -> svc_result
+(** Send [input] to the pool with a hedge timeout of [hedge_ms] milliseconds.
+    May raise [Failure] if rescue-after-HUP fails (fatal protocol violation). *)
+
+(** {2 Monitoring accessors} *)
+
+val requests : pool -> int
+val hedge_fired_count : pool -> int
+val hedge_wins_count : pool -> int
+val rotations_count : pool -> int

--- a/latex-parse/src/clock.mli
+++ b/latex-parse/src/clock.mli
@@ -1,0 +1,10 @@
+(** Monotonic clock access via C FFI. *)
+
+val now : unit -> int64
+(** Current monotonic time in nanoseconds. *)
+
+val ns_of_ms : int -> int64
+(** Convert milliseconds to nanoseconds. *)
+
+val ms_of_ns : int64 -> float
+(** Convert nanoseconds to milliseconds (float). *)

--- a/latex-parse/src/config.mli
+++ b/latex-parse/src/config.mli
@@ -1,0 +1,55 @@
+(** Service-wide configuration constants.
+
+    Tuning parameters for the GC, worker lifecycle, arena sizing, networking,
+    and performance invariants. Environment overrides are noted where
+    applicable. *)
+
+(** {2 Memory / page size} *)
+
+val page_bytes : int
+
+(** {2 Hedge timer} *)
+
+val hedge_timer_ms_default : int
+
+(** {2 SIMD guard} *)
+
+val require_simd : bool
+
+(** {2 GC tuning}
+
+    [minor_heap_bytes] respects [L0_MINOR_HEAP_MB] env override. *)
+
+val minor_heap_bytes : int
+val gc_space_overhead : int
+val gc_max_overhead : int
+val gc_full_major_budget_mb : int
+
+(** {2 Worker lifecycle} *)
+
+val worker_alloc_budget_mb : int
+val worker_major_cycles_budget : int
+
+(** {2 Arena capacity} *)
+
+val arenas_tokens_cap : int
+
+(** {2 Service socket} *)
+
+val service_sock_path : string
+
+(** {2 Request limits} *)
+
+val max_req_bytes : int
+
+(** {2 Tail-latency CSV tracing} *)
+
+val tail_csv_path : string
+val tail_trace_keep : int
+val pool_cores : int array
+
+(** {2 A+B microbench invariants (simd_v2 spec)} *)
+
+val ab_expected_tokens_min : int
+val ab_expected_tokens_max : int
+val ab_p999_target_ms : float

--- a/latex-parse/src/fd_util.mli
+++ b/latex-parse/src/fd_util.mli
@@ -1,0 +1,6 @@
+(** Safe conversion between {!Unix.file_descr} and [int] via C stubs.
+
+    Avoids [Obj.magic] by performing the identity conversion in C. *)
+
+val fd_to_int : Unix.file_descr -> int
+val int_to_fd : int -> Unix.file_descr

--- a/latex-parse/src/hedge_timer.mli
+++ b/latex-parse/src/hedge_timer.mli
@@ -1,0 +1,18 @@
+(** Hedge timer for speculative RPC retries.
+
+    Wraps a timerfd (Linux) or kqueue timer (macOS) via C FFI. *)
+
+type t
+(** Opaque timer handle. *)
+
+val create : unit -> t
+(** Create a new hedge timer. *)
+
+val arm : t -> ns:int64 -> unit
+(** Arm the timer to fire after [ns] nanoseconds. *)
+
+val wait_two : t -> fd1:int -> fd2:int -> int * int
+(** [wait_two t ~fd1 ~fd2] waits for either [fd1], [fd2], or the timer to become
+    ready. Returns [(timer_fired, ready_fd)] where [timer_fired] is [1] if the
+    timer expired and [ready_fd] is the file descriptor that became readable (or
+    [-1] if none). *)

--- a/latex-parse/src/ipc.mli
+++ b/latex-parse/src/ipc.mli
@@ -1,0 +1,42 @@
+(** Binary IPC protocol for the tokeniser service.
+
+    Defines a 16-byte big-endian header followed by a variable-length payload.
+    Three message types are supported: request, response, and cancel. *)
+
+type msg_ty = Req | Resp | Cancel
+type header = { ty : msg_ty; req_id : int64; len : int }
+
+val header_bytes : int
+(** Size of the on-wire header (16 bytes). *)
+
+(** {2 Writing} *)
+
+val write_header : Unix.file_descr -> header -> unit
+
+val write_req : Unix.file_descr -> req_id:int64 -> bytes:bytes -> unit
+(** Write a length-prefixed request payload. *)
+
+val write_resp :
+  Unix.file_descr ->
+  req_id:int64 ->
+  status:int ->
+  n_tokens:int ->
+  issues_len:int ->
+  alloc_mb10:int ->
+  major_cycles:int ->
+  unit
+
+val write_cancel : Unix.file_descr -> req_id:int64 -> unit
+
+(** {2 Reading} *)
+
+val read_header : Unix.file_descr -> header option
+(** Returns [None] on EOF or protocol error. *)
+
+type any =
+  | Any_req of int64 * bytes
+  | Any_resp of int64 * int * int * int * int * int
+  | Any_cancel of int64
+  | Any_hup  (** Decoded message. [Any_hup] indicates connection close. *)
+
+val read_any : Unix.file_descr -> any

--- a/latex-parse/src/main_service.ml
+++ b/latex-parse/src/main_service.ml
@@ -249,19 +249,19 @@ let run () =
           st.t_reply_ready,
           hedged,
           "" );
-      if Latex_parse_lib.Broker.(pool.requests mod 10_000 = 0) then (
+      if Latex_parse_lib.Broker.requests pool mod 10_000 = 0 then (
         Printf.eprintf
           "[hedge] req=%d fired=%d (%.3f%%) wins=%d (%.1f%%) rotations=%d\n%!"
-          Latex_parse_lib.Broker.(pool.requests)
-          Latex_parse_lib.Broker.(pool.hedge_fired)
+          (Latex_parse_lib.Broker.requests pool)
+          (Latex_parse_lib.Broker.hedge_fired_count pool)
           (100.0
-          *. float Latex_parse_lib.Broker.(pool.hedge_fired)
-          /. float (max 1 Latex_parse_lib.Broker.(pool.requests)))
-          Latex_parse_lib.Broker.(pool.hedge_wins)
+          *. float (Latex_parse_lib.Broker.hedge_fired_count pool)
+          /. float (max 1 (Latex_parse_lib.Broker.requests pool)))
+          (Latex_parse_lib.Broker.hedge_wins_count pool)
           (100.0
-          *. float Latex_parse_lib.Broker.(pool.hedge_wins)
-          /. float (max 1 Latex_parse_lib.Broker.(pool.hedge_fired)))
-          Latex_parse_lib.Broker.(pool.rotations);
+          *. float (Latex_parse_lib.Broker.hedge_wins_count pool)
+          /. float (max 1 (Latex_parse_lib.Broker.hedge_fired_count pool)))
+          (Latex_parse_lib.Broker.rotations_count pool);
         dump_csv ());
       loop ()
     in

--- a/latex-parse/src/net_io.mli
+++ b/latex-parse/src/net_io.mli
@@ -1,0 +1,22 @@
+(** Robust socket I/O helpers.
+
+    All functions retry on {!Unix.EINTR} and return [Error] on EOF or
+    short-write instead of raising exceptions. *)
+
+(** I/O error conditions. *)
+type error = Eof | Short_write
+
+val error_to_string : error -> string
+
+(** {2 Result-returning API} *)
+
+val read_exact : Unix.file_descr -> bytes -> int -> int -> (unit, error) result
+val write_all : Unix.file_descr -> bytes -> int -> int -> (unit, error) result
+
+(** {2 Exception-raising convenience wrappers}
+
+    Use these when callers already have a top-level [try ... with] that converts
+    exceptions to connection-close / error-result behaviour. *)
+
+val read_exact_exn : Unix.file_descr -> bytes -> int -> int -> unit
+val write_all_exn : Unix.file_descr -> bytes -> int -> int -> unit

--- a/latex-parse/src/service_payload.mli
+++ b/latex-parse/src/service_payload.mli
@@ -1,0 +1,7 @@
+(** Parsing of the 13-byte service response payload. *)
+
+type origin = Primary | Hedge | Unknown
+type t = { status : int; n_tokens : int; issues_len : int; origin : origin }
+
+val parse_payload : bytes -> (t, string) result
+(** Decode a 13-byte response. Returns [Error] if the length is wrong. *)

--- a/latex-parse/src/worker.mli
+++ b/latex-parse/src/worker.mli
@@ -1,0 +1,10 @@
+(** SIMD tokeniser worker process.
+
+    Each worker runs in a forked child process, listening for IPC requests on
+    the given file descriptor, performing SIMD tokenisation, and replying with
+    results. Workers self-retire after exceeding allocation or major-cycle
+    budgets. *)
+
+val start_loop : Unix.file_descr -> core:int -> unit
+(** [start_loop fd ~core] enters the request loop. Does not return under normal
+    operation (exits the process on HUP or retirement). *)


### PR DESCRIPTION
## Summary

- **10 `.mli` interface files** added for the most critical library modules: `net_io`, `config`, `clock`, `fd_util`, `hedge_timer`, `arena`, `ipc`, `service_payload`, `broker`, and `worker`
- Enforces API contracts and hides implementation internals (e.g. `broker.pool` is now abstract, `ipc` hides wire-encoding helpers, `arena` hides double-buffer representation)
- 9 `.mli` symlinks created in `core/l0_lexer/` matching the existing `.ml` symlink pattern
- Broker pool stats migrated from direct record field access to accessor functions (`requests`, `hedge_fired_count`, `hedge_wins_count`, `rotations_count`)

## What's hidden by the new interfaces

| Module | Hidden internals |
|--------|-----------------|
| `broker` | `wstate`, `worker` record, `spawn_worker`, `pick_hot/secondary`, `update_on_resp`, `maybe_rotate`, `drain_one_ready`, `rescue_once` |
| `ipc` | `put_u8`, `be32_put/get`, `be64_put`, `ty_to_u32`, `u32_to_ty` |
| `arena` | `create_buffers`, internal `{ a; b; current }` representation |
| `hedge_timer` | Internal `{ k : Unix.file_descr }` representation |
| `worker` | `stats`, `rng`, fault injection, `state` record — only `start_loop` exposed |
| `clock` | `now_ns` external (only `now` wrapper exposed) |

## Minor fixes included

- Removed unused `arena.cap` field (was stored but never read after construction; hidden type triggered warning 69)
- Added type annotations to broker accessor functions to disambiguate from `svc_result` field names

## Test plan

- [x] `dune build` — clean, no warnings
- [x] `dune fmt` — no formatting changes
- [x] `dune runtest` — all tests pass
- [x] `.mli` symlinks verified intact: `ls -la core/l0_lexer/*.mli`