### PR TITLE
chore: add .mli interfaces for remaining 20 library modules

### DIFF
--- a/core/l0_lexer/barrier.mli
+++ b/core/l0_lexer/barrier.mli
@@ -1,0 +1,1 @@
+../../latex-parse/src/barrier.mli

--- a/core/l0_lexer/gc_prep.mli
+++ b/core/l0_lexer/gc_prep.mli
@@ -1,0 +1,1 @@
+../../latex-parse/src/gc_prep.mli

--- a/core/l0_lexer/meminfo.mli
+++ b/core/l0_lexer/meminfo.mli
@@ -1,0 +1,1 @@
+../../latex-parse/src/meminfo.mli

--- a/core/l0_lexer/mlock.mli
+++ b/core/l0_lexer/mlock.mli
@@ -1,0 +1,1 @@
+../../latex-parse/src/mlock.mli

--- a/core/l0_lexer/pretouch.mli
+++ b/core/l0_lexer/pretouch.mli
@@ -1,0 +1,1 @@
+../../latex-parse/src/pretouch.mli

--- a/core/l0_lexer/real_processor.mli
+++ b/core/l0_lexer/real_processor.mli
@@ -1,0 +1,1 @@
+../../latex-parse/src/real_processor.mli

--- a/core/l0_lexer/service_bracket.mli
+++ b/core/l0_lexer/service_bracket.mli
@@ -1,0 +1,1 @@
+../../latex-parse/src/service_bracket.mli

--- a/core/l0_lexer/simd_guard.mli
+++ b/core/l0_lexer/simd_guard.mli
@@ -1,0 +1,1 @@
+../../latex-parse/src/simd_guard.mli

--- a/latex-parse/src/barrier.mli
+++ b/latex-parse/src/barrier.mli
@@ -1,0 +1,12 @@
+(** Simple one-shot thread synchronisation barrier. *)
+
+type t = { mutex : Mutex.t; cond : Condition.t; ready : bool ref }
+
+val create : unit -> t
+(** Create a new barrier in the unready state. *)
+
+val release : t -> unit
+(** Signal the barrier, waking all waiters. *)
+
+val wait : t -> unit
+(** Block until the barrier is released. *)

--- a/latex-parse/src/catcode.mli
+++ b/latex-parse/src/catcode.mli
@@ -1,0 +1,24 @@
+(** ASCII category-code classifier aligned with the v25_R1 mapping. *)
+
+val cc_escape : int
+val cc_beginGrp : int
+val cc_endGrp : int
+val cc_math : int
+val cc_alignTab : int
+val cc_newline : int
+val cc_param : int
+val cc_superscr : int
+val cc_subscr : int
+val cc_ignored : int
+val cc_space : int
+val cc_letter : int
+val cc_other : int
+val cc_active : int
+val cc_comment : int
+val cc_invalid : int
+
+val is_letter : int -> bool
+(** [is_letter b] is [true] when [b] is an ASCII letter (A-Z, a-z). *)
+
+val classify_ascii : int -> int
+(** Map a byte value to its TeX category code. *)

--- a/latex-parse/src/fast_hash.mli
+++ b/latex-parse/src/fast_hash.mli
@@ -1,0 +1,7 @@
+(** FNV-1a 64-bit hash function. *)
+
+val fnv_offset : int64
+val fnv_prime : int64
+
+val hash64_bytes : bytes -> int64
+(** Hash a byte sequence with FNV-1a 64-bit. *)

--- a/latex-parse/src/fault_injection.mli
+++ b/latex-parse/src/fault_injection.mli
@@ -1,0 +1,45 @@
+(** Fault-injection testing framework for distributed system resilience. *)
+
+type fault_type =
+  | WorkerCrash of int
+  | NetworkDelay of float
+  | MemoryPressure of int
+  | CPUSpike of float
+  | IOBlock of float
+  | RandomWorkerKill
+  | BrokerOverload
+
+type fault_config = {
+  enabled : bool;
+  probability : float;
+  faults : fault_type list;
+  seed : int option;
+}
+
+val configure :
+  enabled:bool ->
+  probability:float ->
+  faults:fault_type list ->
+  seed:int option ->
+  unit
+(** Set the global fault-injection configuration. *)
+
+val inject_fault : fault_type -> unit
+(** Inject a specific fault if the probability check passes. *)
+
+val run_scenario : string -> int list -> string -> unit
+(** [run_scenario name worker_pids socket_path] executes a named fault scenario. *)
+
+val check_recovery : string -> bool
+(** [check_recovery socket_path] attempts a health-check connection and returns
+    [true] if the service responds. *)
+
+val is_enabled : unit -> bool
+val get_probability : unit -> float
+
+val trigger_random_fault : unit -> unit
+(** Pick a random fault from the configured list and inject it. *)
+
+val inject_broker_overload : string -> int -> unit
+(** [inject_broker_overload socket_path request_count] floods the broker with
+    rapid connections for stress testing. *)

--- a/latex-parse/src/gc_prep.mli
+++ b/latex-parse/src/gc_prep.mli
@@ -1,0 +1,15 @@
+(** GC tuning utilities for major-heap drainage and allocation-budget
+    management. *)
+
+val words_total : unit -> float
+(** Total allocated words (minor + major). *)
+
+val drain_major : ?slice:int -> unit -> unit
+(** Drain the major heap by calling [Gc.major_slice] in a loop. *)
+
+val prepay : unit -> unit
+(** Trigger a full major cycle if accumulated allocations exceed the configured
+    budget. *)
+
+val init_gc : unit -> unit
+(** Set GC parameters from {!Config} and perform an initial drain. *)

--- a/latex-parse/src/meminfo.mli
+++ b/latex-parse/src/meminfo.mli
@@ -1,0 +1,4 @@
+(** Process memory statistics via platform FFI. *)
+
+val rss_mb : unit -> float
+(** Current resident set size in megabytes. *)

--- a/latex-parse/src/metrics_prometheus.mli
+++ b/latex-parse/src/metrics_prometheus.mli
@@ -1,0 +1,16 @@
+(** Minimal Prometheus metrics exporter.
+
+    Enable with [L0_PROM=1]. Configuration:
+    - [L0_PROM_ADDR="HOST:PORT"] (default 127.0.0.1:9109)
+    - [L0_PROM_UDS="/path/to/socket"] (Unix domain socket, takes precedence) *)
+
+val on_request : unit -> unit
+val on_error : unit -> unit
+val on_hedge_fired : unit -> unit
+val on_hedge_win : unit -> unit
+val on_rotation : unit -> unit
+val observe_latency : float -> unit
+
+val serve : unit -> unit
+(** Start the HTTP metrics server in the current thread. Does not return under
+    normal operation. *)

--- a/latex-parse/src/mlock.mli
+++ b/latex-parse/src/mlock.mli
@@ -1,0 +1,6 @@
+(** Lock process memory pages to prevent swapping.
+
+    Respects [L0_NO_MLOCK=1] to skip locking in CI or constrained environments. *)
+
+val init : unit -> unit
+(** Call [mlockall] unless [L0_NO_MLOCK=1] is set. Silently ignores errors. *)

--- a/latex-parse/src/parser_l2.mli
+++ b/latex-parse/src/parser_l2.mli
@@ -1,0 +1,16 @@
+(** LaTeX parser for commands, groups, and structural elements. *)
+
+type cmd = { name : string; opts : string list; args : string list }
+type node = Word of string | Cmd of cmd | Group of node list
+
+val normalize_ws : string -> string
+(** Collapse runs of whitespace to a single space and trim. *)
+
+val normalize_punct : string -> string
+(** Remove spurious spaces around punctuation and brackets. *)
+
+val parse : string -> node list
+(** Parse a LaTeX source string into a node tree. *)
+
+val serialize : node list -> string
+(** Render a node tree back to normalised LaTeX source. *)

--- a/latex-parse/src/pretouch.mli
+++ b/latex-parse/src/pretouch.mli
@@ -1,0 +1,13 @@
+(** Pre-touch memory pages to force physical allocation and reduce latency
+    spikes. *)
+
+val pre_touch_bytes : bytes -> page:int -> unit
+(** Touch every [page]-th byte of a [bytes] buffer. *)
+
+val pre_touch_ba_1 :
+  ('a, 'b, Bigarray.c_layout) Bigarray.Array1.t ->
+  elem_bytes:int ->
+  elems:int ->
+  page:int ->
+  unit
+(** Touch elements of a Bigarray at page-stride intervals. *)

--- a/latex-parse/src/real_processor.mli
+++ b/latex-parse/src/real_processor.mli
@@ -1,0 +1,6 @@
+(** High-performance SIMD tokeniser integration. *)
+
+val run : bytes -> Arena.buffers -> int * int * int
+(** [run input out] tokenises [input] into the pre-allocated [out] buffers.
+    Returns [(status, n_tokens, issues_len)] where [status = 0] indicates
+    success. *)

--- a/latex-parse/src/rest_simple_expander.mli
+++ b/latex-parse/src/rest_simple_expander.mli
@@ -1,0 +1,20 @@
+(** Simple LaTeX control-sequence expander with configurable stripping rules. *)
+
+type cfg = { strip_controls : string list; bfseries_until_brace : bool }
+
+val default : cfg
+(** Default configuration: strips [textbf], [emph], [section]; handles
+    [bfseries]. *)
+
+val of_json : Yojson.Safe.t -> cfg
+(** Parse a configuration from JSON, falling back to {!default} on error. *)
+
+val expand_once : cfg -> string -> string
+(** Single-pass expansion: strip configured commands once. *)
+
+val expand_fix : cfg -> string -> string
+(** Fixed-point expansion: iterate {!expand_once} until stable. *)
+
+val expand_and_tokenize :
+  cfg -> string -> string * Latex_parse_lib.Tokenizer_lite.tok list
+(** Expand to fixed point, then tokenise the result. *)

--- a/latex-parse/src/service_bracket.mli
+++ b/latex-parse/src/service_bracket.mli
@@ -1,0 +1,21 @@
+(** Request-response timing instrumentation for service latency measurement. *)
+
+type stamps = {
+  mutable t_in_start : int64;
+  mutable t_in_done : int64;
+  mutable t_proc_start : int64;
+  mutable t_hedge_fire : int64;
+  mutable t_first_reply : int64;
+  mutable t_reply_ready : int64;
+}
+
+val make : unit -> stamps
+(** Create a zeroed timestamp record. *)
+
+val measure_bytes_in_to_reply_ready :
+  recv:(unit -> bytes) ->
+  process:(bytes -> 'r) ->
+  format:('r -> bytes) ->
+  send:(bytes -> unit) ->
+  float * stamps
+(** Run the recv/process/format/send pipeline, returning (elapsed_ms, stamps). *)

--- a/latex-parse/src/simd_guard.mli
+++ b/latex-parse/src/simd_guard.mli
@@ -1,0 +1,7 @@
+(** SIMD availability detection and fail-fast requirement checks. *)
+
+val available : unit -> bool
+(** [true] if the current CPU supports the required SIMD instruction set. *)
+
+val require : unit -> unit
+(** Abort the process immediately if SIMD is unavailable. *)

--- a/latex-parse/src/tokenizer_lite.mli
+++ b/latex-parse/src/tokenizer_lite.mli
@@ -1,0 +1,19 @@
+(** Lightweight tokeniser for LaTeX-like syntax. *)
+
+type kind =
+  | Word
+  | Space
+  | Newline
+  | Command
+  | Bracket_open
+  | Bracket_close
+  | Quote
+  | Symbol
+
+type tok = { kind : kind; s : int; e : int; ch : char option }
+
+val is_letter : char -> bool
+(** [true] for ASCII letters and digits. *)
+
+val tokenize : string -> tok list
+(** Tokenise a source string into a flat list of tokens. *)

--- a/latex-parse/src/unicode.mli
+++ b/latex-parse/src/unicode.mli
@@ -1,0 +1,20 @@
+(** UTF-8 detection utilities for typographic characters. *)
+
+val has_curly_quote : string -> bool
+(** [true] if the string contains any Unicode curly quote (U+2018..U+201D). *)
+
+val has_en_dash : string -> bool
+(** [true] if the string contains U+2013 EN DASH. *)
+
+val has_em_dash : string -> bool
+(** [true] if the string contains U+2014 EM DASH. *)
+
+val has_ellipsis_char : string -> bool
+(** [true] if the string contains U+2026 HORIZONTAL ELLIPSIS. *)
+
+val count_utf8_seq : string -> int -> int -> int -> int
+(** [count_utf8_seq s a b c] counts occurrences of the 3-byte UTF-8 sequence
+    [(a, b, c)] in [s]. *)
+
+val count_en_dash : string -> int
+val count_em_dash : string -> int

--- a/latex-parse/src/validators.mli
+++ b/latex-parse/src/validators.mli
@@ -1,0 +1,28 @@
+(** LaTeX validation rules for typography, style, and modernisation. *)
+
+type severity = Error | Warning | Info
+
+type result = {
+  id : string;
+  severity : severity;
+  message : string;
+  count : int;
+}
+
+type rule = { id : string; run : string -> result option }
+type layer = L0 | L1 | L2 | L3 | L4
+
+val severity_to_string : severity -> string
+
+val strip_math_segments : string -> string
+(** Remove math-mode content (inline and display) from a LaTeX source string. *)
+
+val run_all : string -> result list
+(** Run all active rules against the source and return triggered results. *)
+
+val run_all_with_timings : string -> result list * float * (string * float) list
+(** Like {!run_all} but returns [(results, total_ms, per_rule_timings)]. *)
+
+val run_all_with_timings_for_layer :
+  string -> layer -> result list * float * (string * float) list
+(** Like {!run_all_with_timings} but restricted to rules for the given layer. *)

--- a/latex-parse/src/validators_context.mli
+++ b/latex-parse/src/validators_context.mli
@@ -1,0 +1,12 @@
+(** Per-thread context storage for LaTeX command spans used by validators. *)
+
+type post_command = { name : string; s : int; e : int }
+
+val set_post_commands : post_command list -> unit
+(** Store the command list for the current thread. *)
+
+val get_post_commands : unit -> post_command list
+(** Retrieve the command list for the current thread (empty if unset). *)
+
+val clear : unit -> unit
+(** Remove the stored commands for the current thread. *)

--- a/latex-parse/src/validators_metrics.mli
+++ b/latex-parse/src/validators_metrics.mli
@@ -1,0 +1,7 @@
+(** Prometheus metrics aggregation for validator rule execution. *)
+
+val record : id:string -> count:int -> dur_ms:float -> unit
+(** Record a rule evaluation with its hit count and duration. *)
+
+val dump_prometheus : out_channel -> unit
+(** Write all accumulated rule metrics in Prometheus text format. *)

--- a/latex-parse/src/xxh64.mli
+++ b/latex-parse/src/xxh64.mli
@@ -1,0 +1,14 @@
+(** XXH64 hash with optional SIMD acceleration.
+
+    Provides a bit-exact scalar implementation and an FFI-backed SIMD path
+    selectable at runtime via [L0_USE_SIMD_XXH=1]. *)
+
+val hash64 : ?seed:int64 -> bytes -> int64
+(** Preferred entry point. Uses SIMD when [L0_USE_SIMD_XXH=1], falls back to
+    scalar on error or when unset. *)
+
+val hash64_bytes : ?seed:int64 -> bytes -> int64
+(** Pure-OCaml scalar XXH64. *)
+
+val hash64_bytes_simd : ?seed:int64 -> bytes -> int64
+(** FFI-backed SIMD XXH64. *)


### PR DESCRIPTION
## Summary

- Completes `.mli` coverage for **all 30 non-test, non-executable library modules** (20 new in this PR, 10 from PR #90)
- **20 new `.mli` files** in `latex-parse/src/` with doc comments
- **8 new `.mli` symlinks** in `core/l0_lexer/` matching the existing pattern
- Every library module in the project now has a typed interface

## Modules covered

| Category | Modules |
|----------|---------|
| FFI wrappers | `meminfo`, `mlock`, `simd_guard` |
| GC / memory | `gc_prep`, `pretouch`, `barrier` |
| Hashing | `fast_hash`, `xxh64` |
| Data / tokenisation | `catcode`, `unicode`, `tokenizer_lite` |
| Service infra | `service_bracket`, `real_processor`, `rest_simple_expander` |
| Validation | `validators`, `validators_context`, `validators_metrics`, `parser_l2` |
| Testing | `fault_injection`, `metrics_prometheus` |

## What's hidden by the new interfaces

| Module | Hidden internals |
|--------|-----------------|
| `xxh64` | `rotl64`, `get32_le`, `get64_le`, `round`, `merge_round`, `avalanche`, prime constants |
| `validators` | All 60+ individual rule definitions, helper functions, rule lists |
| `metrics_prometheus` | Counters, histogram buckets, `dump_metrics`, `parse_addr` |
| `validators_metrics` | Internal `T.agg` type, mutex, hash table |
| `fault_injection` | `should_inject_fault`, all `inject_*` helpers except `inject_broker_overload` |

## Test plan

- [x] `dune build` — clean, no warnings
- [x] `dune fmt` — no formatting changes
- [x] `dune runtest` — all tests pass (including catcode-selftest, parser-l2, strip-math, tok-props, simd-attest)
- [x] All `.mli` symlinks verified: `ls -la core/l0_lexer/*.mli` shows 17 total, 0 non-symlinks