### PR TITLE
chore: .mli interfaces for core-only modules

### DIFF
--- a/core/l0_lexer/alloc_guard.mli
+++ b/core/l0_lexer/alloc_guard.mli
@@ -1,0 +1,11 @@
+(** Hot-path allocation guard for detecting unexpected GC pressure. *)
+
+val enabled : bool ref
+(** When [true], {!with_no_alloc} checks for allocations. Default [false]. *)
+
+val words : unit -> float
+(** Current total allocated words (minor + major - promoted). *)
+
+val with_no_alloc : (unit -> 'a) -> 'a
+(** [with_no_alloc f] runs [f ()]. When {!enabled} is [true], logs a warning to
+    stderr if [f] allocates more than 1.0 words. *)

--- a/core/l0_lexer/catcode.mli
+++ b/core/l0_lexer/catcode.mli
@@ -1,0 +1,37 @@
+(** TeX category codes — wraps the Coq-verified {!Data.Types.Catcode} type and
+    adds integer/char conversion helpers. *)
+
+(** {1 Re-exported from Data.Types.Catcode} *)
+
+type catcode =
+  | Escape
+  | BeginGrp
+  | EndGrp
+  | Math
+  | AlignTab
+  | Newline
+  | Param
+  | Superscr
+  | Subscr
+  | Ignored
+  | Space
+  | Letter
+  | Other
+  | Active
+  | Comment
+  | Invalid
+
+val catcode_to_string : catcode -> string
+val catcode_to_int : catcode -> int
+
+(** {1 Conversion helpers} *)
+
+val of_int_opt : int -> catcode option
+(** [of_int_opt n] returns [Some cat] for [n] in [0..15], [None] otherwise. *)
+
+val of_ascii_code : int -> catcode
+(** [of_ascii_code n] returns the catcode for integer [n], defaulting to
+    {!Other} for out-of-range values. *)
+
+val classify_char : char -> catcode
+(** [classify_char ch] returns the catcode for the character [ch]. *)

--- a/core/l0_lexer/latex_parse_lib.mli
+++ b/core/l0_lexer/latex_parse_lib.mli
@@ -1,0 +1,28 @@
+(** Facade re-exporting all public modules of the [l0_lexer] library.
+
+    Downstream code (e.g. [latex-parse]) refers to modules through
+    [Latex_parse_lib.Config], [Latex_parse_lib.Broker], etc. *)
+
+module Config : module type of Config
+module Clock : module type of Clock
+module Hedge_timer : module type of Hedge_timer
+module Mlock : module type of Mlock
+module Meminfo : module type of Meminfo
+module Gc_prep : module type of Gc_prep
+module Pretouch : module type of Pretouch
+module Arena : module type of Arena
+module Ipc : module type of Ipc
+module Catcode : module type of Catcode
+module Simd_guard : module type of Simd_guard
+module Real_processor : module type of Real_processor
+module Worker : module type of Worker
+module Broker : module type of Broker
+module Service_bracket : module type of Service_bracket
+module Main_service : module type of Runtime_main_service
+module Runtime_main_service : module type of Runtime_main_service
+module Metrics_prometheus : module type of Metrics_prometheus
+module Fault_injection : module type of Fault_injection
+module Barrier : module type of Barrier
+module Percentiles : module type of Percentiles
+module Alloc_guard : module type of Alloc_guard
+module Fast_hash : module type of Fast_hash

--- a/core/l0_lexer/percentiles.mli
+++ b/core/l0_lexer/percentiles.mli
@@ -1,0 +1,11 @@
+(** Percentile computation and tail-latency tracking. *)
+
+val exact : float array -> float -> float
+(** [exact arr q] returns the [q]-th percentile of [arr] (0.0--1.0). The array
+    is copied and sorted internally. *)
+
+type tail_trace = (float * string) list
+(** Association list of [(latency_ms, metadata)] entries. *)
+
+val keep_slowest : int -> tail_trace -> tail_trace
+(** [keep_slowest n xs] retains the [n] entries with the largest latency. *)

--- a/core/l0_lexer/runtime_main_service.mli
+++ b/core/l0_lexer/runtime_main_service.mli
@@ -1,0 +1,5 @@
+(** Unix-domain socket service loop with hedged-request broker integration. *)
+
+val run : unit -> unit
+(** Start the service: bind the socket, spawn the broker pool, and accept
+    connections in a loop. Does not return under normal operation. *)


### PR DESCRIPTION
## Summary
- Adds `.mli` interface files for the 5 remaining library modules in `core/l0_lexer/` that are **not** symlinked from `latex-parse/src/`
- Achieves **100% `.mli` coverage** across both libraries (35 total interface files)

## Files created

| File | What it exposes |
|------|----------------|
| `alloc_guard.mli` | `enabled` ref, `words`, `with_no_alloc` |
| `catcode.mli` | Coq-verified `catcode` type, `catcode_to_string/int`, `of_int_opt`, `of_ascii_code`, `classify_char` |
| `percentiles.mli` | `exact`, `tail_trace` type, `keep_slowest` |
| `runtime_main_service.mli` | `run` entry point only (hides all internal helpers) |
| `latex_parse_lib.mli` | Facade re-exporting all 23 sub-modules |

## Test plan
- [x] `dune build` — clean, no warnings
- [x] `dune fmt` — formatting clean
- [x] `dune runtest` — all tests pass