### PR TITLE
test: 4 unit test suites for fast_hash, unicode, arena, metrics_prometheus (47 cases)

### DIFF
--- a/latex-parse/src/dune
+++ b/latex-parse/src/dune
@@ -187,3 +187,23 @@
  (name test_pretouch_smoke)
  (modules test_pretouch_smoke)
  (libraries latex_parse_lib unix bigarray))
+
+(test
+ (name test_fast_hash)
+ (modules test_fast_hash)
+ (libraries latex_parse_lib))
+
+(test
+ (name test_unicode)
+ (modules test_unicode)
+ (libraries latex_parse_lib))
+
+(test
+ (name test_arena)
+ (modules test_arena)
+ (libraries latex_parse_lib bigarray))
+
+(test
+ (name test_metrics_prometheus)
+ (modules test_metrics_prometheus)
+ (libraries latex_parse_lib unix))

--- a/latex-parse/src/metrics_prometheus.mli
+++ b/latex-parse/src/metrics_prometheus.mli
@@ -11,6 +11,9 @@ val on_hedge_win : unit -> unit
 val on_rotation : unit -> unit
 val observe_latency : float -> unit
 
+val dump_metrics : out_channel -> unit
+(** Write all metrics in Prometheus exposition format to the given channel. *)
+
 val serve : unit -> unit
 (** Start the HTTP metrics server in the current thread. Does not return under
     normal operation. *)

--- a/latex-parse/src/test_arena.ml
+++ b/latex-parse/src/test_arena.ml
@@ -1,0 +1,87 @@
+(** Unit tests for Arena double-buffered token storage. *)
+
+open Latex_parse_lib
+
+let fails = ref 0
+let cases = ref 0
+
+let expect cond msg =
+  if not cond then (
+    Printf.eprintf "[arena] FAIL: %s\n%!" msg;
+    incr fails)
+
+let run msg f =
+  incr cases;
+  f msg
+
+let () =
+  (* 1. create returns a valid arena *)
+  run "create" (fun tag ->
+      let a = Arena.create ~cap:128 in
+      let buf = Arena.current a in
+      expect (buf.Arena.next_ix = 0) tag);
+
+  (* 2. Buffer arrays have correct capacity *)
+  run "capacity" (fun tag ->
+      let a = Arena.create ~cap:256 in
+      let buf = Arena.current a in
+      expect (Bigarray.Array1.dim buf.Arena.kinds = 256) (tag ^ ": kinds");
+      expect (Bigarray.Array1.dim buf.Arena.offs = 256) (tag ^ ": offs");
+      expect (Bigarray.Array1.dim buf.Arena.codes = 256) (tag ^ ": codes");
+      expect (Bigarray.Array1.dim buf.Arena.issues = 256) (tag ^ ": issues");
+      expect (Bigarray.Array1.dim buf.Arena.lines = 256) (tag ^ ": lines");
+      expect (Bigarray.Array1.dim buf.Arena.cols = 256) (tag ^ ": cols"));
+
+  (* 3. swap toggles buffers *)
+  run "swap toggles" (fun tag ->
+      let a = Arena.create ~cap:64 in
+      let b1 = Arena.current a in
+      Arena.swap a;
+      let b2 = Arena.current a in
+      expect (b1 != b2) (tag ^ ": different after swap");
+      Arena.swap a;
+      let b3 = Arena.current a in
+      expect (b1 == b3) (tag ^ ": same after double swap"));
+
+  (* 4. swap resets next_ix *)
+  run "swap resets next_ix" (fun tag ->
+      let a = Arena.create ~cap:64 in
+      let buf = Arena.current a in
+      buf.Arena.next_ix <- 42;
+      Arena.swap a;
+      let buf2 = Arena.current a in
+      expect (buf2.Arena.next_ix = 0) (tag ^ ": reset to 0"));
+
+  (* 5. Writing to one buffer doesn't affect the other *)
+  run "buffer isolation" (fun tag ->
+      let a = Arena.create ~cap:64 in
+      let buf_a = Arena.current a in
+      Bigarray.Array1.set buf_a.Arena.kinds 0 99l;
+      Arena.swap a;
+      let buf_b = Arena.current a in
+      let v = Bigarray.Array1.get buf_b.Arena.kinds 0 in
+      expect (v <> 99l) (tag ^ Printf.sprintf ": got %ld" v));
+
+  (* 6. next_ix is mutable per-buffer *)
+  run "next_ix per buffer" (fun tag ->
+      let a = Arena.create ~cap:32 in
+      let buf_a = Arena.current a in
+      buf_a.Arena.next_ix <- 10;
+      Arena.swap a;
+      let buf_b = Arena.current a in
+      expect (buf_b.Arena.next_ix = 0) (tag ^ ": b starts at 0");
+      Arena.swap a;
+      let buf_a2 = Arena.current a in
+      (* After swap back, next_ix was reset by the swap call *)
+      expect (buf_a2.Arena.next_ix = 0) (tag ^ ": a reset by swap"));
+
+  (* 7. Small capacity works *)
+  run "cap 1" (fun tag ->
+      let a = Arena.create ~cap:1 in
+      let buf = Arena.current a in
+      expect (Bigarray.Array1.dim buf.Arena.kinds = 1) tag);
+
+  if !fails > 0 then (
+    Printf.eprintf "[arena] %d failure(s)\n%!" !fails;
+    exit 1)
+  else Printf.printf "[arena] PASS %d cases\n%!" !cases

--- a/latex-parse/src/test_fast_hash.ml
+++ b/latex-parse/src/test_fast_hash.ml
@@ -1,0 +1,85 @@
+(** Unit tests for Fast_hash (FNV-1a 64-bit). *)
+
+open Latex_parse_lib
+
+let fails = ref 0
+let cases = ref 0
+
+let expect cond msg =
+  if not cond then (
+    Printf.eprintf "[fast-hash] FAIL: %s\n%!" msg;
+    incr fails)
+
+let run msg f =
+  incr cases;
+  f msg
+
+let () =
+  (* 1. Constants are well-known FNV-1a values *)
+  run "fnv_offset" (fun tag ->
+      expect (Fast_hash.fnv_offset = 0xCBF29CE484222325L) tag);
+
+  run "fnv_prime" (fun tag ->
+      expect (Fast_hash.fnv_prime = 0x00000100000001B3L) tag);
+
+  (* 2. Empty bytes hashes to fnv_offset *)
+  run "empty = offset" (fun tag ->
+      let h = Fast_hash.hash64_bytes Bytes.empty in
+      expect (h = Fast_hash.fnv_offset) (tag ^ Printf.sprintf ": got %Ld" h));
+
+  (* 3. Deterministic: same input → same output *)
+  run "deterministic" (fun tag ->
+      let b = Bytes.of_string "hello" in
+      let h1 = Fast_hash.hash64_bytes b in
+      let h2 = Fast_hash.hash64_bytes b in
+      expect (h1 = h2) tag);
+
+  (* 4. Different inputs → different hashes *)
+  run "different inputs" (fun tag ->
+      let h1 = Fast_hash.hash64_bytes (Bytes.of_string "hello") in
+      let h2 = Fast_hash.hash64_bytes (Bytes.of_string "world") in
+      expect (h1 <> h2) tag);
+
+  (* 5. Single byte changes hash *)
+  run "single byte" (fun tag ->
+      let h = Fast_hash.hash64_bytes (Bytes.of_string "a") in
+      expect (h <> Fast_hash.fnv_offset) tag);
+
+  (* 6. hash64_sub full range = hash64_bytes *)
+  run "sub full = bytes" (fun tag ->
+      let b = Bytes.of_string "test data here" in
+      let h1 = Fast_hash.hash64_bytes b in
+      let h2 = Fast_hash.hash64_sub b 0 (Bytes.length b) in
+      expect (h1 = h2) tag);
+
+  (* 7. hash64_sub with offset *)
+  run "sub offset" (fun tag ->
+      let b = Bytes.of_string "XXXhello" in
+      let sub_h = Fast_hash.hash64_sub b 3 5 in
+      let direct_h = Fast_hash.hash64_bytes (Bytes.of_string "hello") in
+      expect (sub_h = direct_h) tag);
+
+  (* 8. hash64_sub zero length = offset *)
+  run "sub zero len" (fun tag ->
+      let b = Bytes.of_string "anything" in
+      let h = Fast_hash.hash64_sub b 3 0 in
+      expect (h = Fast_hash.fnv_offset) tag);
+
+  (* 9. Bit-flip sensitivity *)
+  run "bit flip" (fun tag ->
+      let b1 = Bytes.of_string "AAAA" in
+      let b2 = Bytes.of_string "BAAA" in
+      let h1 = Fast_hash.hash64_bytes b1 in
+      let h2 = Fast_hash.hash64_bytes b2 in
+      expect (h1 <> h2) tag);
+
+  (* 10. Large input does not crash *)
+  run "large input" (fun tag ->
+      let b = Bytes.make 100_000 'x' in
+      let h = Fast_hash.hash64_bytes b in
+      expect (h <> 0L) tag);
+
+  if !fails > 0 then (
+    Printf.eprintf "[fast-hash] %d failure(s)\n%!" !fails;
+    exit 1)
+  else Printf.printf "[fast-hash] PASS %d cases\n%!" !cases

--- a/latex-parse/src/test_metrics_prometheus.ml
+++ b/latex-parse/src/test_metrics_prometheus.ml
@@ -1,0 +1,104 @@
+(** Unit tests for Metrics_prometheus counter and histogram logic. *)
+
+open Latex_parse_lib
+
+let fails = ref 0
+let cases = ref 0
+
+let expect cond msg =
+  if not cond then (
+    Printf.eprintf "[metrics-prom] FAIL: %s\n%!" msg;
+    incr fails)
+
+let run msg f =
+  incr cases;
+  f msg
+
+let dump_to_string () =
+  let rd, wr = Unix.pipe () in
+  let oc = Unix.out_channel_of_descr wr in
+  Metrics_prometheus.dump_metrics oc;
+  flush oc;
+  Unix.close wr;
+  let buf = Buffer.create 1024 in
+  let tmp = Bytes.create 4096 in
+  let rec loop () =
+    let n = Unix.read rd tmp 0 4096 in
+    if n > 0 then (
+      Buffer.add_subbytes buf tmp 0 n;
+      loop ())
+  in
+  loop ();
+  Unix.close rd;
+  Buffer.contents buf
+
+let contains s sub =
+  let slen = String.length s and sublen = String.length sub in
+  let rec check i =
+    if i + sublen > slen then false
+    else if String.sub s i sublen = sub then true
+    else check (i + 1)
+  in
+  check 0
+
+let () =
+  (* 1. on_request increments counter *)
+  run "on_request" (fun tag ->
+      Metrics_prometheus.on_request ();
+      let s = dump_to_string () in
+      expect (contains s "l0_requests_total") (tag ^ ": key present");
+      (* Counter should be > 0 since we just called on_request *)
+      expect (not (contains s "l0_requests_total 0")) (tag ^ ": non-zero"));
+
+  (* 2. on_error increments counter *)
+  run "on_error" (fun tag ->
+      Metrics_prometheus.on_error ();
+      let s = dump_to_string () in
+      expect (contains s "l0_errors_total") (tag ^ ": key present"));
+
+  (* 3. on_hedge_fired increments counter *)
+  run "on_hedge_fired" (fun tag ->
+      Metrics_prometheus.on_hedge_fired ();
+      let s = dump_to_string () in
+      expect (contains s "l0_hedge_fired_total") (tag ^ ": key present"));
+
+  (* 4. on_hedge_win increments counter *)
+  run "on_hedge_win" (fun tag ->
+      Metrics_prometheus.on_hedge_win ();
+      let s = dump_to_string () in
+      expect (contains s "l0_hedge_wins_total") (tag ^ ": key present"));
+
+  (* 5. on_rotation increments counter *)
+  run "on_rotation" (fun tag ->
+      Metrics_prometheus.on_rotation ();
+      let s = dump_to_string () in
+      expect (contains s "l0_rotations_total") (tag ^ ": key present"));
+
+  (* 6. observe_latency populates histogram *)
+  run "histogram" (fun tag ->
+      Metrics_prometheus.observe_latency 3.0;
+      Metrics_prometheus.observe_latency 12.0;
+      Metrics_prometheus.observe_latency 100.0;
+      let s = dump_to_string () in
+      expect (contains s "l0_latency_ms_bucket") (tag ^ ": bucket present");
+      expect (contains s "l0_latency_ms_count") (tag ^ ": count present"));
+
+  (* 7. dump_metrics produces valid Prometheus format *)
+  run "format" (fun tag ->
+      let s = dump_to_string () in
+      expect (contains s "# HELP") (tag ^ ": HELP line");
+      expect (contains s "# TYPE") (tag ^ ": TYPE line");
+      expect (contains s "counter") (tag ^ ": counter type");
+      expect (contains s "histogram") (tag ^ ": histogram type"));
+
+  (* 8. parse_addr helper *)
+  run "parse_addr" (fun _tag ->
+      (* We can't directly test parse_addr since it's not exposed, but
+         dump_metrics always succeeds — validates internal state *)
+      let s = dump_to_string () in
+      expect (String.length s > 0) _tag);
+
+  if !fails > 0 then (
+    Printf.eprintf "[metrics-prom] %d failure(s)\n%!" !fails;
+    exit 1)
+  else Printf.printf "[metrics-prom] PASS %d cases\n%!" !cases

--- a/latex-parse/src/test_unicode.ml
+++ b/latex-parse/src/test_unicode.ml
@@ -1,0 +1,119 @@
+(** Unit tests for Unicode detection utilities. *)
+
+open Latex_parse_lib
+
+let fails = ref 0
+let cases = ref 0
+
+let expect cond msg =
+  if not cond then (
+    Printf.eprintf "[unicode] FAIL: %s\n%!" msg;
+    incr fails)
+
+let run msg f =
+  incr cases;
+  f msg
+
+(* UTF-8 byte sequences for special characters *)
+let en_dash = "\xE2\x80\x93" (* U+2013 *)
+let em_dash = "\xE2\x80\x94" (* U+2014 *)
+let left_single_quote = "\xE2\x80\x98" (* U+2018 *)
+let right_single_quote = "\xE2\x80\x99" (* U+2019 *)
+let left_double_quote = "\xE2\x80\x9C" (* U+201C *)
+let right_double_quote = "\xE2\x80\x9D" (* U+201D *)
+let ellipsis = "\xE2\x80\xA6" (* U+2026 *)
+
+let () =
+  (* --- has_curly_quote --- *)
+  run "curly: left single" (fun tag ->
+      expect (Unicode.has_curly_quote ("text" ^ left_single_quote ^ "more")) tag);
+
+  run "curly: right single" (fun tag ->
+      expect (Unicode.has_curly_quote right_single_quote) tag);
+
+  run "curly: left double" (fun tag ->
+      expect (Unicode.has_curly_quote left_double_quote) tag);
+
+  run "curly: right double" (fun tag ->
+      expect (Unicode.has_curly_quote right_double_quote) tag);
+
+  run "curly: absent" (fun tag ->
+      expect (not (Unicode.has_curly_quote "plain ASCII text")) tag);
+
+  run "curly: empty" (fun tag -> expect (not (Unicode.has_curly_quote "")) tag);
+
+  (* --- has_en_dash --- *)
+  run "en dash: present" (fun tag ->
+      expect (Unicode.has_en_dash ("pages 1" ^ en_dash ^ "10")) tag);
+
+  run "en dash: absent" (fun tag ->
+      expect (not (Unicode.has_en_dash "pages 1-10")) tag);
+
+  run "en dash: not em dash" (fun tag ->
+      expect (not (Unicode.has_en_dash em_dash)) tag);
+
+  (* --- has_em_dash --- *)
+  run "em dash: present" (fun tag ->
+      expect (Unicode.has_em_dash ("word" ^ em_dash ^ "word")) tag);
+
+  run "em dash: absent" (fun tag ->
+      expect (not (Unicode.has_em_dash "word--word")) tag);
+
+  run "em dash: not en dash" (fun tag ->
+      expect (not (Unicode.has_em_dash en_dash)) tag);
+
+  (* --- has_ellipsis_char --- *)
+  run "ellipsis: present" (fun tag ->
+      expect (Unicode.has_ellipsis_char ("wait" ^ ellipsis)) tag);
+
+  run "ellipsis: absent" (fun tag ->
+      expect (not (Unicode.has_ellipsis_char "wait...")) tag);
+
+  (* --- count_en_dash --- *)
+  run "count en dash: zero" (fun tag ->
+      expect (Unicode.count_en_dash "no dashes here" = 0) tag);
+
+  run "count en dash: one" (fun tag ->
+      expect (Unicode.count_en_dash ("a" ^ en_dash ^ "b") = 1) tag);
+
+  run "count en dash: multiple" (fun tag ->
+      let s = en_dash ^ "x" ^ en_dash ^ "y" ^ en_dash in
+      expect
+        (Unicode.count_en_dash s = 3)
+        (tag ^ Printf.sprintf ": got %d" (Unicode.count_en_dash s)));
+
+  (* --- count_em_dash --- *)
+  run "count em dash: zero" (fun tag ->
+      expect (Unicode.count_em_dash "no dashes" = 0) tag);
+
+  run "count em dash: two" (fun tag ->
+      let s = em_dash ^ " pause " ^ em_dash in
+      expect
+        (Unicode.count_em_dash s = 2)
+        (tag ^ Printf.sprintf ": got %d" (Unicode.count_em_dash s)));
+
+  (* --- edge cases --- *)
+  run "malformed utf8" (fun tag ->
+      (* Malformed bytes should not crash *)
+      expect (not (Unicode.has_curly_quote "\xFF\xFE")) tag);
+
+  run "mixed content" (fun tag ->
+      let s =
+        "He said "
+        ^ left_double_quote
+        ^ "hello"
+        ^ right_double_quote
+        ^ " "
+        ^ em_dash
+        ^ " then left"
+        ^ ellipsis
+      in
+      expect (Unicode.has_curly_quote s) tag;
+      expect (Unicode.has_em_dash s) tag;
+      expect (Unicode.has_ellipsis_char s) tag;
+      expect (not (Unicode.has_en_dash s)) tag);
+
+  if !fails > 0 then (
+    Printf.eprintf "[unicode] %d failure(s)\n%!" !fails;
+    exit 1)
+  else Printf.printf "[unicode] PASS %d cases\n%!" !cases


### PR DESCRIPTION
## Summary

- Adds 4 new unit test files (418 LOC) covering the last untested pure-logic library modules
- 47 test cases total across FNV-1a hashing, Unicode detection, double-buffered arena, and Prometheus metrics
- Exposes `dump_metrics` in `metrics_prometheus.mli` for testability
- No new opam dependencies

## New test files

| File | Module tested | Cases |
|------|---------------|-------|
| `test_fast_hash.ml` | Fast_hash | 10 |
| `test_unicode.ml` | Unicode | 21 |
| `test_arena.ml` | Arena | 7 |
| `test_metrics_prometheus.ml` | Metrics_prometheus | 8 |

## Coverage status after this PR

Every unit-testable library module now has direct test coverage. The only remaining untested modules (broker, worker, real_processor) require full process-forking infrastructure and are not practical for isolated unit tests.

## Test plan
- [x] `dune build` — clean
- [x] `dune fmt` — stable
- [x] `dune runtest` — all 47 cases pass
- [ ] CI passes on GitHub