### PR TITLE
feat: L1 macro expander with v25r2 + argsafe catalogue support

### DIFF
--- a/latex-parse/data/macro_catalogue.argsafe.v25r1.json
+++ b/latex-parse/data/macro_catalogue.argsafe.v25r1.json
@@ -1,0 +1,434 @@
+{
+  "catalog": {
+    "id": "macro_catalogue.argsafe",
+    "version": "v25-R1",
+    "policy": {
+      "profile": "latex-epsilon",
+      "notes": "Only expansion-safe, deterministic, side-effect-free macros allowed at L1."
+    },
+    "macros": [
+      {
+        "name": "textbf",
+        "mode": "text",
+        "category": "style",
+        "epsilon_allowed": true,
+        "args": {
+          "positional": 1,
+          "optional": [],
+          "kinds": [
+            "text"
+          ]
+        },
+        "template": {
+          "kind": "inline",
+          "body": "{\\bfseries $1}"
+        },
+        "examples": []
+      },
+      {
+        "name": "textit",
+        "mode": "text",
+        "category": "style",
+        "epsilon_allowed": true,
+        "args": {
+          "positional": 1,
+          "optional": [],
+          "kinds": [
+            "text"
+          ]
+        },
+        "template": {
+          "kind": "inline",
+          "body": "{\\itshape $1}"
+        },
+        "examples": []
+      },
+      {
+        "name": "texttt",
+        "mode": "text",
+        "category": "style",
+        "epsilon_allowed": true,
+        "args": {
+          "positional": 1,
+          "optional": [],
+          "kinds": [
+            "text"
+          ]
+        },
+        "template": {
+          "kind": "inline",
+          "body": "{\\ttfamily $1}"
+        },
+        "examples": []
+      },
+      {
+        "name": "textsf",
+        "mode": "text",
+        "category": "style",
+        "epsilon_allowed": true,
+        "args": {
+          "positional": 1,
+          "optional": [],
+          "kinds": [
+            "text"
+          ]
+        },
+        "template": {
+          "kind": "inline",
+          "body": "{\\sffamily $1}"
+        },
+        "examples": []
+      },
+      {
+        "name": "textsc",
+        "mode": "text",
+        "category": "style",
+        "epsilon_allowed": true,
+        "args": {
+          "positional": 1,
+          "optional": [],
+          "kinds": [
+            "text"
+          ]
+        },
+        "template": {
+          "kind": "inline",
+          "body": "{\\scshape $1}"
+        },
+        "examples": []
+      },
+      {
+        "name": "textmd",
+        "mode": "text",
+        "category": "style",
+        "epsilon_allowed": true,
+        "args": {
+          "positional": 1,
+          "optional": [],
+          "kinds": [
+            "text"
+          ]
+        },
+        "template": {
+          "kind": "inline",
+          "body": "{\\mdseries $1}"
+        },
+        "examples": []
+      },
+      {
+        "name": "textnormal",
+        "mode": "text",
+        "category": "style",
+        "epsilon_allowed": true,
+        "args": {
+          "positional": 1,
+          "optional": [],
+          "kinds": [
+            "text"
+          ]
+        },
+        "template": {
+          "kind": "inline",
+          "body": "{\\normalfont $1}"
+        },
+        "examples": [],
+        "notes": "Resets family/series/shape; safe in epsilon profile."
+      },
+      {
+        "name": "textrm",
+        "mode": "text",
+        "category": "style",
+        "epsilon_allowed": true,
+        "args": {
+          "positional": 1,
+          "optional": [],
+          "kinds": [
+            "text"
+          ]
+        },
+        "template": {
+          "kind": "inline",
+          "body": "{\\rmfamily $1}"
+        },
+        "examples": []
+      },
+      {
+        "name": "textsl",
+        "mode": "text",
+        "category": "style",
+        "epsilon_allowed": true,
+        "args": {
+          "positional": 1,
+          "optional": [],
+          "kinds": [
+            "text"
+          ]
+        },
+        "template": {
+          "kind": "inline",
+          "body": "{\\slshape $1}"
+        },
+        "examples": []
+      },
+      {
+        "name": "textup",
+        "mode": "text",
+        "category": "style",
+        "epsilon_allowed": true,
+        "args": {
+          "positional": 1,
+          "optional": [],
+          "kinds": [
+            "text"
+          ]
+        },
+        "template": {
+          "kind": "inline",
+          "body": "{\\upshape $1}"
+        },
+        "examples": []
+      },
+      {
+        "name": "emph",
+        "mode": "text",
+        "category": "emphasis",
+        "epsilon_allowed": true,
+        "args": {
+          "positional": 1,
+          "optional": [],
+          "kinds": [
+            "text"
+          ]
+        },
+        "template": {
+          "kind": "inline",
+          "body": "{\\itshape $1}"
+        },
+        "examples": [],
+        "notes": "In TeX, \\emph toggles; in epsilon we model it as a pure wrapper using \\itshape."
+      },
+      {
+        "name": "mbox",
+        "mode": "text",
+        "category": "boxing",
+        "epsilon_allowed": true,
+        "args": {
+          "positional": 1,
+          "optional": [],
+          "kinds": [
+            "text"
+          ]
+        },
+        "template": {
+          "kind": "builtin",
+          "builtin": "mbox"
+        },
+        "examples": [],
+        "notes": "Represents a no-break box; handled as L1 builtin to avoid layout semantics here."
+      },
+      {
+        "name": "verb",
+        "mode": "text",
+        "category": "verbatim",
+        "epsilon_allowed": true,
+        "args": {
+          "positional": 1,
+          "optional": [],
+          "kinds": [
+            "verbatim-delim"
+          ]
+        },
+        "template": {
+          "kind": "builtin",
+          "builtin": "verb"
+        },
+        "examples": [],
+        "notes": "Delimiter after \\verb is treated specially; expanded by L1 builtin verb handler."
+      },
+      {
+        "name": "verb*",
+        "mode": "text",
+        "category": "verbatim",
+        "epsilon_allowed": true,
+        "args": {
+          "positional": 1,
+          "optional": [],
+          "kinds": [
+            "verbatim-delim"
+          ]
+        },
+        "template": {
+          "kind": "builtin",
+          "builtin": "verb_star"
+        },
+        "examples": [],
+        "notes": "Star variant shows spaces visibly; handled by builtin verb* handler."
+      },
+      {
+        "name": "textsuperscript",
+        "mode": "text",
+        "category": "boxing",
+        "epsilon_allowed": true,
+        "args": {
+          "positional": 1,
+          "optional": [],
+          "kinds": [
+            "text"
+          ]
+        },
+        "template": {
+          "kind": "builtin",
+          "builtin": "textsuperscript"
+        },
+        "examples": [],
+        "notes": "Rendered as a raised box in later layers; L1 records a semantic wrapper."
+      },
+      {
+        "name": "textsubscript",
+        "mode": "text",
+        "category": "boxing",
+        "epsilon_allowed": true,
+        "args": {
+          "positional": 1,
+          "optional": [],
+          "kinds": [
+            "text"
+          ]
+        },
+        "template": {
+          "kind": "builtin",
+          "builtin": "textsubscript"
+        },
+        "examples": [],
+        "notes": "Rendered as a lowered box in later layers; L1 records a semantic wrapper."
+      },
+      {
+        "name": "mathrm",
+        "mode": "math",
+        "category": "mathstyle",
+        "epsilon_allowed": true,
+        "args": {
+          "positional": 1,
+          "optional": [],
+          "kinds": [
+            "math"
+          ]
+        },
+        "template": {
+          "kind": "inline",
+          "body": "{\\mathrm{$1}}"
+        },
+        "examples": []
+      },
+      {
+        "name": "mathbf",
+        "mode": "math",
+        "category": "mathstyle",
+        "epsilon_allowed": true,
+        "args": {
+          "positional": 1,
+          "optional": [],
+          "kinds": [
+            "math"
+          ]
+        },
+        "template": {
+          "kind": "inline",
+          "body": "{\\mathbf{$1}}"
+        },
+        "examples": []
+      },
+      {
+        "name": "mathsf",
+        "mode": "math",
+        "category": "mathstyle",
+        "epsilon_allowed": true,
+        "args": {
+          "positional": 1,
+          "optional": [],
+          "kinds": [
+            "math"
+          ]
+        },
+        "template": {
+          "kind": "inline",
+          "body": "{\\mathsf{$1}}"
+        },
+        "examples": []
+      },
+      {
+        "name": "mathtt",
+        "mode": "math",
+        "category": "mathstyle",
+        "epsilon_allowed": true,
+        "args": {
+          "positional": 1,
+          "optional": [],
+          "kinds": [
+            "math"
+          ]
+        },
+        "template": {
+          "kind": "inline",
+          "body": "{\\mathtt{$1}}"
+        },
+        "examples": []
+      },
+      {
+        "name": "mathit",
+        "mode": "math",
+        "category": "mathstyle",
+        "epsilon_allowed": true,
+        "args": {
+          "positional": 1,
+          "optional": [],
+          "kinds": [
+            "math"
+          ]
+        },
+        "template": {
+          "kind": "inline",
+          "body": "{\\mathit{$1}}"
+        },
+        "examples": []
+      },
+      {
+        "name": "mathnormal",
+        "mode": "math",
+        "category": "mathstyle",
+        "epsilon_allowed": true,
+        "args": {
+          "positional": 1,
+          "optional": [],
+          "kinds": [
+            "math"
+          ]
+        },
+        "template": {
+          "kind": "inline",
+          "body": "{\\mathnormal{$1}}"
+        },
+        "examples": []
+      },
+      {
+        "name": "ensuremath",
+        "mode": "both",
+        "category": "mathstyle",
+        "epsilon_allowed": true,
+        "args": {
+          "positional": 1,
+          "optional": [],
+          "kinds": [
+            "math-or-text"
+          ]
+        },
+        "template": {
+          "kind": "builtin",
+          "builtin": "ensuremath"
+        },
+        "examples": [],
+        "notes": "If outside math, wraps in $...$; otherwise passes through. Implemented as L1 builtin."
+      }
+    ]
+  }
+}

--- a/latex-parse/data/macro_catalogue.v25r2.json
+++ b/latex-parse/data/macro_catalogue.v25r2.json
@@ -1,0 +1,9204 @@
+{
+  "schema_version": "v25r2",
+  "created_at": "2025-08-11T21:22:26.461820Z",
+  "counts": {
+    "total": 383,
+    "math": 240,
+    "text": 119,
+    "any": 24
+  },
+  "macros": [
+    {
+      "name": "AA",
+      "mode": "text",
+      "category": "text-symbol",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "Å"
+        }
+      ],
+      "body": [
+        {
+          "TText": "Å"
+        }
+      ],
+      "expand_in_math": false,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "AE",
+      "mode": "text",
+      "category": "text-symbol",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "Æ"
+        }
+      ],
+      "body": [
+        {
+          "TText": "Æ"
+        }
+      ],
+      "expand_in_math": false,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "Bbbk",
+      "mode": "text",
+      "category": "text-symbol",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "𝕜"
+        }
+      ],
+      "body": [
+        {
+          "TText": "𝕜"
+        }
+      ],
+      "expand_in_math": false,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "Box",
+      "mode": "text",
+      "category": "text-symbol",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "□"
+        }
+      ],
+      "body": [
+        {
+          "TText": "□"
+        }
+      ],
+      "expand_in_math": false,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "Bumpeq",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "≎"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "≎"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "DH",
+      "mode": "text",
+      "category": "text-symbol",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "Ð"
+        }
+      ],
+      "body": [
+        {
+          "TText": "Ð"
+        }
+      ],
+      "expand_in_math": false,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "Delta",
+      "mode": "math",
+      "category": "greek-letter",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "Δ"
+        }
+      ],
+      "body": [
+        {
+          "TText": "Δ"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "Diamond",
+      "mode": "text",
+      "category": "text-symbol",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "◇"
+        }
+      ],
+      "body": [
+        {
+          "TText": "◇"
+        }
+      ],
+      "expand_in_math": false,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "Downarrow",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "⇓"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "⇓"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "Gamma",
+      "mode": "math",
+      "category": "greek-letter",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "Γ"
+        }
+      ],
+      "body": [
+        {
+          "TText": "Γ"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "Im",
+      "mode": "math",
+      "category": "text-symbol",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "ℑ"
+        }
+      ],
+      "body": [
+        {
+          "TText": "ℑ"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "L",
+      "mode": "text",
+      "category": "text-symbol",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "Ł"
+        }
+      ],
+      "body": [
+        {
+          "TText": "Ł"
+        }
+      ],
+      "expand_in_math": false,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "Lambda",
+      "mode": "math",
+      "category": "greek-letter",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "Λ"
+        }
+      ],
+      "body": [
+        {
+          "TText": "Λ"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "Leftarrow",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "⇐"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "⇐"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "Leftrightarrow",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "⇔"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "⇔"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "Longleftarrow",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "⟸"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "⟸"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "Longleftrightarrow",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "⟺"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "⟺"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "Longrightarrow",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "⟹"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "⟹"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "O",
+      "mode": "text",
+      "category": "text-symbol",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "Ø"
+        }
+      ],
+      "body": [
+        {
+          "TText": "Ø"
+        }
+      ],
+      "expand_in_math": false,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "OE",
+      "mode": "text",
+      "category": "text-symbol",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "Œ"
+        }
+      ],
+      "body": [
+        {
+          "TText": "Œ"
+        }
+      ],
+      "expand_in_math": false,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "Omega",
+      "mode": "math",
+      "category": "greek-letter",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "Ω"
+        }
+      ],
+      "body": [
+        {
+          "TText": "Ω"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "Phi",
+      "mode": "math",
+      "category": "greek-letter",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "Φ"
+        }
+      ],
+      "body": [
+        {
+          "TText": "Φ"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "Pi",
+      "mode": "math",
+      "category": "greek-letter",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "Π"
+        }
+      ],
+      "body": [
+        {
+          "TText": "Π"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "Psi",
+      "mode": "math",
+      "category": "greek-letter",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "Ψ"
+        }
+      ],
+      "body": [
+        {
+          "TText": "Ψ"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "Re",
+      "mode": "math",
+      "category": "text-symbol",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "ℜ"
+        }
+      ],
+      "body": [
+        {
+          "TText": "ℜ"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "Rightarrow",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "⇒"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "⇒"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "Sigma",
+      "mode": "math",
+      "category": "greek-letter",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "Σ"
+        }
+      ],
+      "body": [
+        {
+          "TText": "Σ"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "Subset",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "⋐"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "⋐"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "Supset",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "⋑"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "⋑"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "TH",
+      "mode": "text",
+      "category": "text-symbol",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "Þ"
+        }
+      ],
+      "body": [
+        {
+          "TText": "Þ"
+        }
+      ],
+      "expand_in_math": false,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "Theta",
+      "mode": "math",
+      "category": "greek-letter",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "Θ"
+        }
+      ],
+      "body": [
+        {
+          "TText": "Θ"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "Uparrow",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "⇑"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "⇑"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "Updownarrow",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "⇕"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "⇕"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "Upsilon",
+      "mode": "math",
+      "category": "greek-letter",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "Υ"
+        }
+      ],
+      "body": [
+        {
+          "TText": "Υ"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "VDash",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "⊫"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "⊫"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "Vdash",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "⊩"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "⊩"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "Vvdash",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "⊪"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "⊪"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "Xi",
+      "mode": "math",
+      "category": "greek-letter",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "Ξ"
+        }
+      ],
+      "body": [
+        {
+          "TText": "Ξ"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "aa",
+      "mode": "text",
+      "category": "text-symbol",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "å"
+        }
+      ],
+      "body": [
+        {
+          "TText": "å"
+        }
+      ],
+      "expand_in_math": false,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "ae",
+      "mode": "text",
+      "category": "text-symbol",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "æ"
+        }
+      ],
+      "body": [
+        {
+          "TText": "æ"
+        }
+      ],
+      "expand_in_math": false,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "aleph",
+      "mode": "text",
+      "category": "text-symbol",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "ℵ"
+        }
+      ],
+      "body": [
+        {
+          "TText": "ℵ"
+        }
+      ],
+      "expand_in_math": false,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "alpha",
+      "mode": "math",
+      "category": "greek-letter",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "α"
+        }
+      ],
+      "body": [
+        {
+          "TText": "α"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "angle",
+      "mode": "math",
+      "category": "text-symbol",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "∠"
+        }
+      ],
+      "body": [
+        {
+          "TText": "∠"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "angstrom",
+      "mode": "text",
+      "category": "text-symbol",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "Å"
+        }
+      ],
+      "body": [
+        {
+          "TText": "Å"
+        }
+      ],
+      "expand_in_math": false,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "approx",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "≈"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "≈"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "ast",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "∗"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "∗"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "backsimeq",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "⋍"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "⋍"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "because",
+      "mode": "text",
+      "category": "text-symbol",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "∵"
+        }
+      ],
+      "body": [
+        {
+          "TText": "∵"
+        }
+      ],
+      "expand_in_math": false,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "beta",
+      "mode": "math",
+      "category": "greek-letter",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "β"
+        }
+      ],
+      "body": [
+        {
+          "TText": "β"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "beth",
+      "mode": "text",
+      "category": "text-symbol",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "ℶ"
+        }
+      ],
+      "body": [
+        {
+          "TText": "ℶ"
+        }
+      ],
+      "expand_in_math": false,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "bigcap",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "⋂"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "⋂"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "bigcirc",
+      "mode": "text",
+      "category": "text-symbol",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "○"
+        }
+      ],
+      "body": [
+        {
+          "TText": "○"
+        }
+      ],
+      "expand_in_math": false,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "bigcup",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "⋃"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "⋃"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "bigodot",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "⨀"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "⨀"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "bigoplus",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "⨁"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "⨁"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "bigotimes",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "⨂"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "⨂"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "bigsqcup",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "⨆"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "⨆"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "bigstar",
+      "mode": "text",
+      "category": "text-symbol",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "★"
+        }
+      ],
+      "body": [
+        {
+          "TText": "★"
+        }
+      ],
+      "expand_in_math": false,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "biguplus",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "⨄"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "⨄"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "blacklozenge",
+      "mode": "text",
+      "category": "text-symbol",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "◆"
+        }
+      ],
+      "body": [
+        {
+          "TText": "◆"
+        }
+      ],
+      "expand_in_math": false,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "blacksquare",
+      "mode": "text",
+      "category": "text-symbol",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "■"
+        }
+      ],
+      "body": [
+        {
+          "TText": "■"
+        }
+      ],
+      "expand_in_math": false,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "blacktriangle",
+      "mode": "text",
+      "category": "text-symbol",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "▲"
+        }
+      ],
+      "body": [
+        {
+          "TText": "▲"
+        }
+      ],
+      "expand_in_math": false,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "blacktriangledown",
+      "mode": "text",
+      "category": "text-symbol",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "▼"
+        }
+      ],
+      "body": [
+        {
+          "TText": "▼"
+        }
+      ],
+      "expand_in_math": false,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "blacktriangleleft",
+      "mode": "text",
+      "category": "text-symbol",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "◂"
+        }
+      ],
+      "body": [
+        {
+          "TText": "◂"
+        }
+      ],
+      "expand_in_math": false,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "blacktriangleright",
+      "mode": "text",
+      "category": "text-symbol",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "▸"
+        }
+      ],
+      "body": [
+        {
+          "TText": "▸"
+        }
+      ],
+      "expand_in_math": false,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "boxdot",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "⊡"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "⊡"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "boxminus",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "⊟"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "⊟"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "boxplus",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "⊞"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "⊞"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "boxtimes",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "⊠"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "⊠"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "bullet",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "∙"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "∙"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "bumpeq",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "≏"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "≏"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "cap",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "∩"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "∩"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "cdot",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "⋅"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "⋅"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "cdots",
+      "mode": "math",
+      "category": "ellipsis",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "⋯"
+        }
+      ],
+      "body": [
+        {
+          "TText": "⋯"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "chi",
+      "mode": "math",
+      "category": "greek-letter",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "χ"
+        }
+      ],
+      "body": [
+        {
+          "TText": "χ"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "circ",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "∘"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "∘"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "circeq",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "≗"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "≗"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "circlearrowleft",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "↺"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "↺"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "circlearrowright",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "↻"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "↻"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "clubsuit",
+      "mode": "text",
+      "category": "text-symbol",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "♣"
+        }
+      ],
+      "body": [
+        {
+          "TText": "♣"
+        }
+      ],
+      "expand_in_math": false,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "coloneqq",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "≔"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "≔"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "cong",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "≅"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "≅"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "coprod",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "∐"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "∐"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "cup",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "∪"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "∪"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "curvearrowleft",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "↶"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "↶"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "curvearrowright",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "↷"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "↷"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "daleth",
+      "mode": "text",
+      "category": "text-symbol",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "ℸ"
+        }
+      ],
+      "body": [
+        {
+          "TText": "ℸ"
+        }
+      ],
+      "expand_in_math": false,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "dashleftarrow",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "⇠"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "⇠"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "dashrightarrow",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "⇢"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "⇢"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "dashv",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "⊣"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "⊣"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "ddots",
+      "mode": "math",
+      "category": "ellipsis",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "⋱"
+        }
+      ],
+      "body": [
+        {
+          "TText": "⋱"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "degree",
+      "mode": "text",
+      "category": "text-symbol",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "°"
+        }
+      ],
+      "body": [
+        {
+          "TText": "°"
+        }
+      ],
+      "expand_in_math": false,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "delta",
+      "mode": "math",
+      "category": "greek-letter",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "δ"
+        }
+      ],
+      "body": [
+        {
+          "TText": "δ"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "dh",
+      "mode": "text",
+      "category": "text-symbol",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "ð"
+        }
+      ],
+      "body": [
+        {
+          "TText": "ð"
+        }
+      ],
+      "expand_in_math": false,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "diamondsuit",
+      "mode": "text",
+      "category": "text-symbol",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "♦"
+        }
+      ],
+      "body": [
+        {
+          "TText": "♦"
+        }
+      ],
+      "expand_in_math": false,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "div",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "÷"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "÷"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "doteq",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "≐"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "≐"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "doteqdot",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "≑"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "≑"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "downarrow",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "↓"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "↓"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "downdownarrows",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "⇊"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "⇊"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "ell",
+      "mode": "text",
+      "category": "text-symbol",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "ℓ"
+        }
+      ],
+      "body": [
+        {
+          "TText": "ℓ"
+        }
+      ],
+      "expand_in_math": false,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "emptyset",
+      "mode": "text",
+      "category": "text-symbol",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "∅"
+        }
+      ],
+      "body": [
+        {
+          "TText": "∅"
+        }
+      ],
+      "expand_in_math": false,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "epsilon",
+      "mode": "math",
+      "category": "greek-letter",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "ε"
+        }
+      ],
+      "body": [
+        {
+          "TText": "ε"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "eqcirc",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "≖"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "≖"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "eqqcolon",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "≕"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "≕"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "eqsim",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "≂"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "≂"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "eqslantgtr",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "⪖"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "⪖"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "eqslantless",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "⪕"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "⪕"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "equiv",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "≡"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "≡"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "eta",
+      "mode": "math",
+      "category": "greek-letter",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "η"
+        }
+      ],
+      "body": [
+        {
+          "TText": "η"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "fallingdotseq",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "≒"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "≒"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "flat",
+      "mode": "text",
+      "category": "text-symbol",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "♭"
+        }
+      ],
+      "body": [
+        {
+          "TText": "♭"
+        }
+      ],
+      "expand_in_math": false,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "frown",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "⌢"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "⌢"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "gamma",
+      "mode": "math",
+      "category": "greek-letter",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "γ"
+        }
+      ],
+      "body": [
+        {
+          "TText": "γ"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "ge",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "≥"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "≥"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "geq",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "≥"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "≥"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "geqq",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "≧"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "≧"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "geqslant",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "⩾"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "⩾"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "gg",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "≫"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "≫"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "ggg",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "⋙"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "⋙"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "gimel",
+      "mode": "text",
+      "category": "text-symbol",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "ℷ"
+        }
+      ],
+      "body": [
+        {
+          "TText": "ℷ"
+        }
+      ],
+      "expand_in_math": false,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "gtrapprox",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "⪆"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "⪆"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "gtrsim",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "≳"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "≳"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "hbar",
+      "mode": "text",
+      "category": "text-symbol",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "ℏ"
+        }
+      ],
+      "body": [
+        {
+          "TText": "ℏ"
+        }
+      ],
+      "expand_in_math": false,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "heartsuit",
+      "mode": "text",
+      "category": "text-symbol",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "♥"
+        }
+      ],
+      "body": [
+        {
+          "TText": "♥"
+        }
+      ],
+      "expand_in_math": false,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "hookleftarrow",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "↩"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "↩"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "hookrightarrow",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "↪"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "↪"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "iiint",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "∭"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "∭"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "iint",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "∬"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "∬"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "imath",
+      "mode": "text",
+      "category": "text-symbol",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "ı"
+        }
+      ],
+      "body": [
+        {
+          "TText": "ı"
+        }
+      ],
+      "expand_in_math": false,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "in",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "∈"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "∈"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "infty",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "∞"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "∞"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "int",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "∫"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "∫"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "iota",
+      "mode": "math",
+      "category": "greek-letter",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "ι"
+        }
+      ],
+      "body": [
+        {
+          "TText": "ι"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "jmath",
+      "mode": "text",
+      "category": "text-symbol",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "ȷ"
+        }
+      ],
+      "body": [
+        {
+          "TText": "ȷ"
+        }
+      ],
+      "expand_in_math": false,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "kappa",
+      "mode": "math",
+      "category": "greek-letter",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "κ"
+        }
+      ],
+      "body": [
+        {
+          "TText": "κ"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "l",
+      "mode": "text",
+      "category": "text-symbol",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "ł"
+        }
+      ],
+      "body": [
+        {
+          "TText": "ł"
+        }
+      ],
+      "expand_in_math": false,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "lVert",
+      "mode": "any",
+      "category": "delimiter",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TDelim": "‖"
+        }
+      ],
+      "body": [
+        {
+          "TDelim": "‖"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "lambda",
+      "mode": "math",
+      "category": "greek-letter",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "λ"
+        }
+      ],
+      "body": [
+        {
+          "TText": "λ"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "langle",
+      "mode": "any",
+      "category": "delimiter",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TDelim": "⟨"
+        }
+      ],
+      "body": [
+        {
+          "TDelim": "⟨"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "lbag",
+      "mode": "any",
+      "category": "delimiter",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TDelim": "⟅"
+        }
+      ],
+      "body": [
+        {
+          "TDelim": "⟅"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "lbrace",
+      "mode": "any",
+      "category": "delimiter",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TDelim": "{"
+        }
+      ],
+      "body": [
+        {
+          "TDelim": "{"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "lbrack",
+      "mode": "any",
+      "category": "delimiter",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TDelim": "["
+        }
+      ],
+      "body": [
+        {
+          "TDelim": "["
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "lceil",
+      "mode": "math",
+      "category": "delimiter",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TDelim": "⌈"
+        }
+      ],
+      "body": [
+        {
+          "TDelim": "⌈"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "ldots",
+      "mode": "math",
+      "category": "ellipsis",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "…"
+        }
+      ],
+      "body": [
+        {
+          "TText": "…"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "le",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "≤"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "≤"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "leadsto",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "⇝"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "⇝"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "leftarrow",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "←"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "←"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "leftarrowtail",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "↢"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "↢"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "leftleftarrows",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "⇇"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "⇇"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "leftrightarrow",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "↔"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "↔"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "leftrightarrows",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "⇆"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "⇆"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "leftrightharpoons",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "⇋"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "⇋"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "leftrightsquigarrow",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "↭"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "↭"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "leftsquigarrow",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "↜"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "↜"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "leq",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "≤"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "≤"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "leqq",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "≦"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "≦"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "leqslant",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "⩽"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "⩽"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "lessapprox",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "⪅"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "⪅"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "lesssim",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "≲"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "≲"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "lfloor",
+      "mode": "math",
+      "category": "delimiter",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TDelim": "⌊"
+        }
+      ],
+      "body": [
+        {
+          "TDelim": "⌊"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "ll",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "≪"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "≪"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "llangle",
+      "mode": "any",
+      "category": "delimiter",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TDelim": "⟪"
+        }
+      ],
+      "body": [
+        {
+          "TDelim": "⟪"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "llbracket",
+      "mode": "any",
+      "category": "delimiter",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TDelim": "⟦"
+        }
+      ],
+      "body": [
+        {
+          "TDelim": "⟦"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "llcorner",
+      "mode": "any",
+      "category": "delimiter",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TDelim": "⌞"
+        }
+      ],
+      "body": [
+        {
+          "TDelim": "⌞"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "lll",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "⋘"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "⋘"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "llparenthesis",
+      "mode": "any",
+      "category": "delimiter",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TDelim": "⦅"
+        }
+      ],
+      "body": [
+        {
+          "TDelim": "⦅"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "longleftarrow",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "⟵"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "⟵"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "longleftrightarrow",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "⟷"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "⟷"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "longmapsto",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "⟼"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "⟼"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "longrightarrow",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "⟶"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "⟶"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "longrightsquigarrow",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "⟿"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "⟿"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "looparrowleft",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "↫"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "↫"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "looparrowright",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "↬"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "↬"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "lozenge",
+      "mode": "text",
+      "category": "text-symbol",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "◊"
+        }
+      ],
+      "body": [
+        {
+          "TText": "◊"
+        }
+      ],
+      "expand_in_math": false,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "lparen",
+      "mode": "any",
+      "category": "delimiter",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TDelim": "("
+        }
+      ],
+      "body": [
+        {
+          "TDelim": "("
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "lrcorner",
+      "mode": "any",
+      "category": "delimiter",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TDelim": "⌟"
+        }
+      ],
+      "body": [
+        {
+          "TDelim": "⌟"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "lvert",
+      "mode": "any",
+      "category": "delimiter",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TDelim": "|"
+        }
+      ],
+      "body": [
+        {
+          "TDelim": "|"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "mapsfrom",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "↤"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "↤"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "mapsto",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "↦"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "↦"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "measuredangle",
+      "mode": "text",
+      "category": "text-symbol",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "∡"
+        }
+      ],
+      "body": [
+        {
+          "TText": "∡"
+        }
+      ],
+      "expand_in_math": false,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "mho",
+      "mode": "text",
+      "category": "text-symbol",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "℧"
+        }
+      ],
+      "body": [
+        {
+          "TText": "℧"
+        }
+      ],
+      "expand_in_math": false,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "micro",
+      "mode": "text",
+      "category": "text-symbol",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "µ"
+        }
+      ],
+      "body": [
+        {
+          "TText": "µ"
+        }
+      ],
+      "expand_in_math": false,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "models",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "⊧"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "⊧"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "mu",
+      "mode": "math",
+      "category": "greek-letter",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "μ"
+        }
+      ],
+      "body": [
+        {
+          "TText": "μ"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "multimap",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "⊸"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "⊸"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "nLeftarrow",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "⇍"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "⇍"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "nLeftrightarrow",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "⇎"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "⇎"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "nRightarrow",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "⇏"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "⇏"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "nVDash",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "⊯"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "⊯"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "nVdash",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "⊮"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "⊮"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "nabla",
+      "mode": "math",
+      "category": "text-symbol",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "∇"
+        }
+      ],
+      "body": [
+        {
+          "TText": "∇"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "natural",
+      "mode": "text",
+      "category": "text-symbol",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "♮"
+        }
+      ],
+      "body": [
+        {
+          "TText": "♮"
+        }
+      ],
+      "expand_in_math": false,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "ncong",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "≇"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "≇"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "ne",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "≠"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "≠"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "nearrow",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "↗"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "↗"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "neq",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "≠"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "≠"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "nequiv",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "≢"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "≢"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "ngeq",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "≱"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "≱"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "ngtr",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "≯"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "≯"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "ni",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "∋"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "∋"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "nleftarrow",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "↚"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "↚"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "nleftrightarrow",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "↮"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "↮"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "nleq",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "≰"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "≰"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "nless",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "≮"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "≮"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "nmid",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "∤"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "∤"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "notin",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "∉"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "∉"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "notni",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "∌"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "∌"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "nparallel",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "∦"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "∦"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "nprec",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "⊀"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "⊀"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "npreceq",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "⋠"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "⋠"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "nrightarrow",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "↛"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "↛"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "nsim",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "≁"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "≁"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "nsubseteq",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "⊈"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "⊈"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "nsucc",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "⊁"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "⊁"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "nsucceq",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "⋡"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "⋡"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "nsupseteq",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "⊉"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "⊉"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "ntriangleleft",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "⋪"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "⋪"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "ntrianglelefteq",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "⋬"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "⋬"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "ntriangleright",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "⋫"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "⋫"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "ntrianglerighteq",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "⋭"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "⋭"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "nu",
+      "mode": "math",
+      "category": "greek-letter",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "ν"
+        }
+      ],
+      "body": [
+        {
+          "TText": "ν"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "nvDash",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "⊭"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "⊭"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "nvdash",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "⊬"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "⊬"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "nwarrow",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "↖"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "↖"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "o",
+      "mode": "text",
+      "category": "text-symbol",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "ø"
+        }
+      ],
+      "body": [
+        {
+          "TText": "ø"
+        }
+      ],
+      "expand_in_math": false,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "odot",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "⊙"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "⊙"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "oe",
+      "mode": "text",
+      "category": "text-symbol",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "œ"
+        }
+      ],
+      "body": [
+        {
+          "TText": "œ"
+        }
+      ],
+      "expand_in_math": false,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "ohm",
+      "mode": "text",
+      "category": "text-symbol",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "Ω"
+        }
+      ],
+      "body": [
+        {
+          "TText": "Ω"
+        }
+      ],
+      "expand_in_math": false,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "oint",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "∮"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "∮"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "omega",
+      "mode": "math",
+      "category": "greek-letter",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "ω"
+        }
+      ],
+      "body": [
+        {
+          "TText": "ω"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "omicron",
+      "mode": "text",
+      "category": "text-symbol",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "ο"
+        }
+      ],
+      "body": [
+        {
+          "TText": "ο"
+        }
+      ],
+      "expand_in_math": false,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "ominus",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "⊖"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "⊖"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "oplus",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "⊕"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "⊕"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "oslash",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "⊘"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "⊘"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "otimes",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "⊗"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "⊗"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "owns",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "∋"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "∋"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "parallel",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "∥"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "∥"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "partial",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "∂"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "∂"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "perp",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "⊥"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "⊥"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "phi",
+      "mode": "math",
+      "category": "greek-letter",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "φ"
+        }
+      ],
+      "body": [
+        {
+          "TText": "φ"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "pi",
+      "mode": "math",
+      "category": "greek-letter",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "π"
+        }
+      ],
+      "body": [
+        {
+          "TText": "π"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "prec",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "≺"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "≺"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "preceq",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "≼"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "≼"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "precsim",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "≾"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "≾"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "prod",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "∏"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "∏"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "propto",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "∝"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "∝"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "psi",
+      "mode": "math",
+      "category": "greek-letter",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "ψ"
+        }
+      ],
+      "body": [
+        {
+          "TText": "ψ"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "rVert",
+      "mode": "any",
+      "category": "delimiter",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TDelim": "‖"
+        }
+      ],
+      "body": [
+        {
+          "TDelim": "‖"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "rangle",
+      "mode": "any",
+      "category": "delimiter",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TDelim": "⟩"
+        }
+      ],
+      "body": [
+        {
+          "TDelim": "⟩"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "rbag",
+      "mode": "any",
+      "category": "delimiter",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TDelim": "⟆"
+        }
+      ],
+      "body": [
+        {
+          "TDelim": "⟆"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "rbrace",
+      "mode": "any",
+      "category": "delimiter",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TDelim": "}"
+        }
+      ],
+      "body": [
+        {
+          "TDelim": "}"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "rbrack",
+      "mode": "any",
+      "category": "delimiter",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TDelim": "]"
+        }
+      ],
+      "body": [
+        {
+          "TDelim": "]"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "rceil",
+      "mode": "math",
+      "category": "delimiter",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TDelim": "⌉"
+        }
+      ],
+      "body": [
+        {
+          "TDelim": "⌉"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "rfloor",
+      "mode": "math",
+      "category": "delimiter",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TDelim": "⌋"
+        }
+      ],
+      "body": [
+        {
+          "TDelim": "⌋"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "rho",
+      "mode": "math",
+      "category": "greek-letter",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "ρ"
+        }
+      ],
+      "body": [
+        {
+          "TText": "ρ"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "rightarrow",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "→"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "→"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "rightarrowtail",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "↣"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "↣"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "rightleftarrows",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "⇄"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "⇄"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "rightrightarrows",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "⇉"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "⇉"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "rightsquigarrow",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "⇝"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "⇝"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "risingdotseq",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "≓"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "≓"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "rparen",
+      "mode": "any",
+      "category": "delimiter",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TDelim": ")"
+        }
+      ],
+      "body": [
+        {
+          "TDelim": ")"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "rrangle",
+      "mode": "any",
+      "category": "delimiter",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TDelim": "⟫"
+        }
+      ],
+      "body": [
+        {
+          "TDelim": "⟫"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "rrbracket",
+      "mode": "any",
+      "category": "delimiter",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TDelim": "⟧"
+        }
+      ],
+      "body": [
+        {
+          "TDelim": "⟧"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "rrparenthesis",
+      "mode": "any",
+      "category": "delimiter",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TDelim": "⦆"
+        }
+      ],
+      "body": [
+        {
+          "TDelim": "⦆"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "rvert",
+      "mode": "any",
+      "category": "delimiter",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TDelim": "|"
+        }
+      ],
+      "body": [
+        {
+          "TDelim": "|"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "searrow",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "↘"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "↘"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "setminus",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "∖"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "∖"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "sharp",
+      "mode": "text",
+      "category": "text-symbol",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "♯"
+        }
+      ],
+      "body": [
+        {
+          "TText": "♯"
+        }
+      ],
+      "expand_in_math": false,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "sigma",
+      "mode": "math",
+      "category": "greek-letter",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "σ"
+        }
+      ],
+      "body": [
+        {
+          "TText": "σ"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "sim",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "∼"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "∼"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "simeq",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "≃"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "≃"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "smile",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "⌣"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "⌣"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "spadesuit",
+      "mode": "text",
+      "category": "text-symbol",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "♠"
+        }
+      ],
+      "body": [
+        {
+          "TText": "♠"
+        }
+      ],
+      "expand_in_math": false,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "sqrt",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "√"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "√"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "square",
+      "mode": "text",
+      "category": "text-symbol",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "□"
+        }
+      ],
+      "body": [
+        {
+          "TText": "□"
+        }
+      ],
+      "expand_in_math": false,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "ss",
+      "mode": "text",
+      "category": "text-symbol",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "ß"
+        }
+      ],
+      "body": [
+        {
+          "TText": "ß"
+        }
+      ],
+      "expand_in_math": false,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "star",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "⋆"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "⋆"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "subset",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "⊂"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "⊂"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "subseteq",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "⊆"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "⊆"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "subsetneq",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "⊊"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "⊊"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "succ",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "≻"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "≻"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "succeq",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "≽"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "≽"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "succsim",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "≿"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "≿"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "sum",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "∑"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "∑"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "supset",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "⊃"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "⊃"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "supseteq",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "⊇"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "⊇"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "supsetneq",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "⊋"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "⊋"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "swarrow",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "↙"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "↙"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "tau",
+      "mode": "math",
+      "category": "greek-letter",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "τ"
+        }
+      ],
+      "body": [
+        {
+          "TText": "τ"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "textasciitilde",
+      "mode": "text",
+      "category": "text-symbol",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "~"
+        }
+      ],
+      "body": [
+        {
+          "TText": "~"
+        }
+      ],
+      "expand_in_math": false,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "textasteriskcentered",
+      "mode": "text",
+      "category": "text-symbol",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "⁎"
+        }
+      ],
+      "body": [
+        {
+          "TText": "⁎"
+        }
+      ],
+      "expand_in_math": false,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "textaustral",
+      "mode": "text",
+      "category": "text-symbol",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "₳"
+        }
+      ],
+      "body": [
+        {
+          "TText": "₳"
+        }
+      ],
+      "expand_in_math": false,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "textbackslash",
+      "mode": "text",
+      "category": "text-symbol",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "\\"
+        }
+      ],
+      "body": [
+        {
+          "TText": "\\"
+        }
+      ],
+      "expand_in_math": false,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "textbar",
+      "mode": "text",
+      "category": "text-symbol",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "|"
+        }
+      ],
+      "body": [
+        {
+          "TText": "|"
+        }
+      ],
+      "expand_in_math": false,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "textbullet",
+      "mode": "text",
+      "category": "text-symbol",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "•"
+        }
+      ],
+      "body": [
+        {
+          "TText": "•"
+        }
+      ],
+      "expand_in_math": false,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "textcedi",
+      "mode": "text",
+      "category": "text-symbol",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "₵"
+        }
+      ],
+      "body": [
+        {
+          "TText": "₵"
+        }
+      ],
+      "expand_in_math": false,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "textcent",
+      "mode": "text",
+      "category": "text-symbol",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "¢"
+        }
+      ],
+      "body": [
+        {
+          "TText": "¢"
+        }
+      ],
+      "expand_in_math": false,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "textcopyright",
+      "mode": "text",
+      "category": "text-symbol",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "©"
+        }
+      ],
+      "body": [
+        {
+          "TText": "©"
+        }
+      ],
+      "expand_in_math": false,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "textdagger",
+      "mode": "text",
+      "category": "text-symbol",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "†"
+        }
+      ],
+      "body": [
+        {
+          "TText": "†"
+        }
+      ],
+      "expand_in_math": false,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "textdaggerdbl",
+      "mode": "text",
+      "category": "text-symbol",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "‡"
+        }
+      ],
+      "body": [
+        {
+          "TText": "‡"
+        }
+      ],
+      "expand_in_math": false,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "textdegree",
+      "mode": "text",
+      "category": "text-symbol",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "°"
+        }
+      ],
+      "body": [
+        {
+          "TText": "°"
+        }
+      ],
+      "expand_in_math": false,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "textdollar",
+      "mode": "text",
+      "category": "text-symbol",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "$"
+        }
+      ],
+      "body": [
+        {
+          "TText": "$"
+        }
+      ],
+      "expand_in_math": false,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "textdong",
+      "mode": "text",
+      "category": "text-symbol",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "₫"
+        }
+      ],
+      "body": [
+        {
+          "TText": "₫"
+        }
+      ],
+      "expand_in_math": false,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "textdoubleprime",
+      "mode": "text",
+      "category": "text-symbol",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "″"
+        }
+      ],
+      "body": [
+        {
+          "TText": "″"
+        }
+      ],
+      "expand_in_math": false,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "textellipsis",
+      "mode": "text",
+      "category": "text-symbol",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "…"
+        }
+      ],
+      "body": [
+        {
+          "TText": "…"
+        }
+      ],
+      "expand_in_math": false,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "textemdash",
+      "mode": "text",
+      "category": "text-symbol",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "—"
+        }
+      ],
+      "body": [
+        {
+          "TText": "—"
+        }
+      ],
+      "expand_in_math": false,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "textendash",
+      "mode": "text",
+      "category": "text-symbol",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "–"
+        }
+      ],
+      "body": [
+        {
+          "TText": "–"
+        }
+      ],
+      "expand_in_math": false,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "textestimated",
+      "mode": "text",
+      "category": "text-symbol",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "℮"
+        }
+      ],
+      "body": [
+        {
+          "TText": "℮"
+        }
+      ],
+      "expand_in_math": false,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "texteuro",
+      "mode": "text",
+      "category": "text-symbol",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "€"
+        }
+      ],
+      "body": [
+        {
+          "TText": "€"
+        }
+      ],
+      "expand_in_math": false,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "textflorin",
+      "mode": "text",
+      "category": "text-symbol",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "ƒ"
+        }
+      ],
+      "body": [
+        {
+          "TText": "ƒ"
+        }
+      ],
+      "expand_in_math": false,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "textgreater",
+      "mode": "text",
+      "category": "text-symbol",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": ">"
+        }
+      ],
+      "body": [
+        {
+          "TText": ">"
+        }
+      ],
+      "expand_in_math": false,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "textguarani",
+      "mode": "text",
+      "category": "text-symbol",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "₲"
+        }
+      ],
+      "body": [
+        {
+          "TText": "₲"
+        }
+      ],
+      "expand_in_math": false,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "texthryvnia",
+      "mode": "text",
+      "category": "text-symbol",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "₴"
+        }
+      ],
+      "body": [
+        {
+          "TText": "₴"
+        }
+      ],
+      "expand_in_math": false,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "textkip",
+      "mode": "text",
+      "category": "text-symbol",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "₭"
+        }
+      ],
+      "body": [
+        {
+          "TText": "₭"
+        }
+      ],
+      "expand_in_math": false,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "textless",
+      "mode": "text",
+      "category": "text-symbol",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "<"
+        }
+      ],
+      "body": [
+        {
+          "TText": "<"
+        }
+      ],
+      "expand_in_math": false,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "textlira",
+      "mode": "text",
+      "category": "text-symbol",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "₤"
+        }
+      ],
+      "body": [
+        {
+          "TText": "₤"
+        }
+      ],
+      "expand_in_math": false,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "textmanat",
+      "mode": "text",
+      "category": "text-symbol",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "₼"
+        }
+      ],
+      "body": [
+        {
+          "TText": "₼"
+        }
+      ],
+      "expand_in_math": false,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "textmill",
+      "mode": "text",
+      "category": "text-symbol",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "₥"
+        }
+      ],
+      "body": [
+        {
+          "TText": "₥"
+        }
+      ],
+      "expand_in_math": false,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "textminus",
+      "mode": "text",
+      "category": "text-symbol",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "−"
+        }
+      ],
+      "body": [
+        {
+          "TText": "−"
+        }
+      ],
+      "expand_in_math": false,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "textnaira",
+      "mode": "text",
+      "category": "text-symbol",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "₦"
+        }
+      ],
+      "body": [
+        {
+          "TText": "₦"
+        }
+      ],
+      "expand_in_math": false,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "textnumero",
+      "mode": "text",
+      "category": "text-symbol",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "№"
+        }
+      ],
+      "body": [
+        {
+          "TText": "№"
+        }
+      ],
+      "expand_in_math": false,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "textonehalf",
+      "mode": "text",
+      "category": "text-symbol",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "½"
+        }
+      ],
+      "body": [
+        {
+          "TText": "½"
+        }
+      ],
+      "expand_in_math": false,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "textonequarter",
+      "mode": "text",
+      "category": "text-symbol",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "¼"
+        }
+      ],
+      "body": [
+        {
+          "TText": "¼"
+        }
+      ],
+      "expand_in_math": false,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "textparagraph",
+      "mode": "text",
+      "category": "text-symbol",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "¶"
+        }
+      ],
+      "body": [
+        {
+          "TText": "¶"
+        }
+      ],
+      "expand_in_math": false,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "textperiodcentered",
+      "mode": "text",
+      "category": "text-symbol",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "·"
+        }
+      ],
+      "body": [
+        {
+          "TText": "·"
+        }
+      ],
+      "expand_in_math": false,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "textpertenthousand",
+      "mode": "text",
+      "category": "text-symbol",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "‱"
+        }
+      ],
+      "body": [
+        {
+          "TText": "‱"
+        }
+      ],
+      "expand_in_math": false,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "textperthousand",
+      "mode": "text",
+      "category": "text-symbol",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "‰"
+        }
+      ],
+      "body": [
+        {
+          "TText": "‰"
+        }
+      ],
+      "expand_in_math": false,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "textpeso",
+      "mode": "text",
+      "category": "text-symbol",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "₱"
+        }
+      ],
+      "body": [
+        {
+          "TText": "₱"
+        }
+      ],
+      "expand_in_math": false,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "textprime",
+      "mode": "text",
+      "category": "text-symbol",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "′"
+        }
+      ],
+      "body": [
+        {
+          "TText": "′"
+        }
+      ],
+      "expand_in_math": false,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "textquotedbl",
+      "mode": "text",
+      "category": "text-symbol",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "\""
+        }
+      ],
+      "body": [
+        {
+          "TText": "\""
+        }
+      ],
+      "expand_in_math": false,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "textquotesingle",
+      "mode": "text",
+      "category": "text-symbol",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "'"
+        }
+      ],
+      "body": [
+        {
+          "TText": "'"
+        }
+      ],
+      "expand_in_math": false,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "textregistered",
+      "mode": "text",
+      "category": "text-symbol",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "®"
+        }
+      ],
+      "body": [
+        {
+          "TText": "®"
+        }
+      ],
+      "expand_in_math": false,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "textruble",
+      "mode": "text",
+      "category": "text-symbol",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "₽"
+        }
+      ],
+      "body": [
+        {
+          "TText": "₽"
+        }
+      ],
+      "expand_in_math": false,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "textrupee",
+      "mode": "text",
+      "category": "text-symbol",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "₹"
+        }
+      ],
+      "body": [
+        {
+          "TText": "₹"
+        }
+      ],
+      "expand_in_math": false,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "textsection",
+      "mode": "text",
+      "category": "text-symbol",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "§"
+        }
+      ],
+      "body": [
+        {
+          "TText": "§"
+        }
+      ],
+      "expand_in_math": false,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "textsheqel",
+      "mode": "text",
+      "category": "text-symbol",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "₪"
+        }
+      ],
+      "body": [
+        {
+          "TText": "₪"
+        }
+      ],
+      "expand_in_math": false,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "textsterling",
+      "mode": "text",
+      "category": "text-symbol",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "£"
+        }
+      ],
+      "body": [
+        {
+          "TText": "£"
+        }
+      ],
+      "expand_in_math": false,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "texttenge",
+      "mode": "text",
+      "category": "text-symbol",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "₸"
+        }
+      ],
+      "body": [
+        {
+          "TText": "₸"
+        }
+      ],
+      "expand_in_math": false,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "textthreequarters",
+      "mode": "text",
+      "category": "text-symbol",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "¾"
+        }
+      ],
+      "body": [
+        {
+          "TText": "¾"
+        }
+      ],
+      "expand_in_math": false,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "texttrademark",
+      "mode": "text",
+      "category": "text-symbol",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "™"
+        }
+      ],
+      "body": [
+        {
+          "TText": "™"
+        }
+      ],
+      "expand_in_math": false,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "texttripleprime",
+      "mode": "text",
+      "category": "text-symbol",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "‴"
+        }
+      ],
+      "body": [
+        {
+          "TText": "‴"
+        }
+      ],
+      "expand_in_math": false,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "texttugrik",
+      "mode": "text",
+      "category": "text-symbol",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "₮"
+        }
+      ],
+      "body": [
+        {
+          "TText": "₮"
+        }
+      ],
+      "expand_in_math": false,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "textturkishlira",
+      "mode": "text",
+      "category": "text-symbol",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "₺"
+        }
+      ],
+      "body": [
+        {
+          "TText": "₺"
+        }
+      ],
+      "expand_in_math": false,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "textunderscore",
+      "mode": "text",
+      "category": "text-symbol",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "_"
+        }
+      ],
+      "body": [
+        {
+          "TText": "_"
+        }
+      ],
+      "expand_in_math": false,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "textwon",
+      "mode": "text",
+      "category": "text-symbol",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "₩"
+        }
+      ],
+      "body": [
+        {
+          "TText": "₩"
+        }
+      ],
+      "expand_in_math": false,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "textyen",
+      "mode": "text",
+      "category": "text-symbol",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "¥"
+        }
+      ],
+      "body": [
+        {
+          "TText": "¥"
+        }
+      ],
+      "expand_in_math": false,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "th",
+      "mode": "text",
+      "category": "text-symbol",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "þ"
+        }
+      ],
+      "body": [
+        {
+          "TText": "þ"
+        }
+      ],
+      "expand_in_math": false,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "therefore",
+      "mode": "text",
+      "category": "text-symbol",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "∴"
+        }
+      ],
+      "body": [
+        {
+          "TText": "∴"
+        }
+      ],
+      "expand_in_math": false,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "theta",
+      "mode": "math",
+      "category": "greek-letter",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "θ"
+        }
+      ],
+      "body": [
+        {
+          "TText": "θ"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "times",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "×"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "×"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "triangle",
+      "mode": "math",
+      "category": "text-symbol",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "△"
+        }
+      ],
+      "body": [
+        {
+          "TText": "△"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "triangledown",
+      "mode": "text",
+      "category": "text-symbol",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "▽"
+        }
+      ],
+      "body": [
+        {
+          "TText": "▽"
+        }
+      ],
+      "expand_in_math": false,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "triangleleft",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "◁"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "◁"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "trianglelefteq",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "⊴"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "⊴"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "triangleq",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "≜"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "≜"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "triangleright",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "▷"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "▷"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "trianglerighteq",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "⊵"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "⊵"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "twoheadleftarrow",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "↞"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "↞"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "twoheadrightarrow",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "↠"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "↠"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "ulcorner",
+      "mode": "any",
+      "category": "delimiter",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TDelim": "⌜"
+        }
+      ],
+      "body": [
+        {
+          "TDelim": "⌜"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "uparrow",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "↑"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "↑"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "updownarrow",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "↕"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "↕"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "uplus",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "⊎"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "⊎"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "upsilon",
+      "mode": "math",
+      "category": "greek-letter",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "υ"
+        }
+      ],
+      "body": [
+        {
+          "TText": "υ"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "upuparrows",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "⇈"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "⇈"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "urcorner",
+      "mode": "any",
+      "category": "delimiter",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TDelim": "⌝"
+        }
+      ],
+      "body": [
+        {
+          "TDelim": "⌝"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "vDash",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "⊨"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "⊨"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "varepsilon",
+      "mode": "text",
+      "category": "text-symbol",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "ϵ"
+        }
+      ],
+      "body": [
+        {
+          "TText": "ϵ"
+        }
+      ],
+      "expand_in_math": false,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "varnothing",
+      "mode": "text",
+      "category": "text-symbol",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "∅"
+        }
+      ],
+      "body": [
+        {
+          "TText": "∅"
+        }
+      ],
+      "expand_in_math": false,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "varphi",
+      "mode": "text",
+      "category": "text-symbol",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "ϕ"
+        }
+      ],
+      "body": [
+        {
+          "TText": "ϕ"
+        }
+      ],
+      "expand_in_math": false,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "varpi",
+      "mode": "text",
+      "category": "text-symbol",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "ϖ"
+        }
+      ],
+      "body": [
+        {
+          "TText": "ϖ"
+        }
+      ],
+      "expand_in_math": false,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "varrho",
+      "mode": "text",
+      "category": "text-symbol",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "ϱ"
+        }
+      ],
+      "body": [
+        {
+          "TText": "ϱ"
+        }
+      ],
+      "expand_in_math": false,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "varsigma",
+      "mode": "text",
+      "category": "text-symbol",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "ς"
+        }
+      ],
+      "body": [
+        {
+          "TText": "ς"
+        }
+      ],
+      "expand_in_math": false,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "vartheta",
+      "mode": "text",
+      "category": "text-symbol",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "ϑ"
+        }
+      ],
+      "body": [
+        {
+          "TText": "ϑ"
+        }
+      ],
+      "expand_in_math": false,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "vdash",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "⊢"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "⊢"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "vdots",
+      "mode": "math",
+      "category": "ellipsis",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "⋮"
+        }
+      ],
+      "body": [
+        {
+          "TText": "⋮"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "vee",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "∨"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "∨"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "wedge",
+      "mode": "math",
+      "category": "math-operator",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TOp": "∧"
+        }
+      ],
+      "body": [
+        {
+          "TOp": "∧"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "wp",
+      "mode": "text",
+      "category": "text-symbol",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "℘"
+        }
+      ],
+      "body": [
+        {
+          "TText": "℘"
+        }
+      ],
+      "expand_in_math": false,
+      "expand_in_text": true,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "xi",
+      "mode": "math",
+      "category": "greek-letter",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "ξ"
+        }
+      ],
+      "body": [
+        {
+          "TText": "ξ"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    },
+    {
+      "name": "zeta",
+      "mode": "math",
+      "category": "greek-letter",
+      "arity": 0,
+      "safety": "pure",
+      "side_effects": [],
+      "expansion": [
+        {
+          "TText": "ζ"
+        }
+      ],
+      "body": [
+        {
+          "TText": "ζ"
+        }
+      ],
+      "expand_in_math": true,
+      "expand_in_text": false,
+      "non_expandable": true,
+      "notes": "",
+      "source": "derived-from:v1-catalogue",
+      "_legacy_single_token": true
+    }
+  ]
+}

--- a/latex-parse/src/dune
+++ b/latex-parse/src/dune
@@ -30,8 +30,9 @@
   unicode
   parser_l2
   fd_util
-  net_io)
- (libraries unix threads str uutf)
+  net_io
+  macro_catalogue)
+ (libraries unix threads str uutf yojson)
  (foreign_stubs
   (language c)
   (names
@@ -207,3 +208,11 @@
  (name test_metrics_prometheus)
  (modules test_metrics_prometheus)
  (libraries latex_parse_lib unix))
+
+(test
+ (name test_macro_catalogue)
+ (modules test_macro_catalogue)
+ (libraries latex_parse_lib)
+ (deps
+  ../data/macro_catalogue.v25r2.json
+  ../data/macro_catalogue.argsafe.v25r1.json))

--- a/latex-parse/src/macro_catalogue.ml
+++ b/latex-parse/src/macro_catalogue.ml
@@ -1,0 +1,446 @@
+(** Production L1 macro expander with v25r2 + argsafe catalogue support.
+
+    Loads 383 symbol macros (arity-0, Unicode expansions) and 23 argumentful
+    macros (epsilon-safe templates) from JSON catalogues. Performs mode-aware
+    expansion with bounded iteration. *)
+
+(* ── Token types ────────────────────────────────────────────────────── *)
+
+type token = TText of string | TOp of string | TDelim of string
+
+type mode =
+  | Math
+  | Text
+  | Any
+  | Both
+      (** [Math] = expand only in math context, [Text] = only in text context,
+          [Any]/[Both] = expand in either context. *)
+
+(* ── Catalogue entry types ──────────────────────────────────────────── *)
+
+type symbol_entry = {
+  name : string;
+  mode : mode;
+  expansion : token list;
+  expand_in_math : bool;
+  expand_in_text : bool;
+}
+
+type template = Inline of string | Builtin of string
+
+type argsafe_entry = {
+  name : string;
+  mode : mode;
+  category : string;
+  positional : int;
+  kinds : string list;
+  template : template;
+}
+
+type entry = Symbol of symbol_entry | Argsafe of argsafe_entry
+
+type catalogue = {
+  symbols : (string, symbol_entry) Hashtbl.t;
+  argsafe : (string, argsafe_entry) Hashtbl.t;
+  all_names : (string, entry) Hashtbl.t;
+}
+
+(* ── Helpers ────────────────────────────────────────────────────────── *)
+
+let token_to_string = function TText s | TOp s | TDelim s -> s
+let is_letter c = ('a' <= c && c <= 'z') || ('A' <= c && c <= 'Z')
+
+let take_ident s i =
+  let n = String.length s in
+  let j = ref i in
+  while !j < n && is_letter s.[!j] do
+    incr j
+  done;
+  !j
+
+(** Find balanced brace block starting at position [i]. Returns
+    [Some (content_offset, content_length)] or [None]. *)
+let find_brace_block s i =
+  let n = String.length s in
+  if i >= n || s.[i] <> '{' then None
+  else
+    let j = ref (i + 1) in
+    let depth = ref 1 in
+    while !j < n && !depth > 0 do
+      (match s.[!j] with '{' -> incr depth | '}' -> decr depth | _ -> ());
+      incr j
+    done;
+    if !depth = 0 then Some (i + 1, !j - i - 2) else None
+
+(* ── JSON loaders ───────────────────────────────────────────────────── *)
+
+module Y = Yojson.Safe
+module U = Yojson.Safe.Util
+
+let mode_of_string = function
+  | "math" -> Math
+  | "text" -> Text
+  | "any" -> Any
+  | "both" -> Both
+  | s -> failwith ("macro_catalogue: unknown mode: " ^ s)
+
+let token_of_json = function
+  | `Assoc [ ("TText", `String s) ] -> TText s
+  | `Assoc [ ("TOp", `String s) ] -> TOp s
+  | `Assoc [ ("TDelim", `String s) ] -> TDelim s
+  | j -> failwith ("macro_catalogue: bad token: " ^ Y.to_string j)
+
+let string_field k j =
+  try U.to_string (U.member k j)
+  with _ -> failwith ("macro_catalogue: missing string field: " ^ k)
+
+let int_field k j =
+  try U.to_int (U.member k j)
+  with _ -> failwith ("macro_catalogue: missing int field: " ^ k)
+
+let bool_field_opt k default j =
+  try match U.member k j with `Bool b -> b | `Null -> default | _ -> default
+  with _ -> default
+
+(** Load v25r2 symbol catalogue (383 arity-0 macros). *)
+let load_v25r2 path =
+  let json = Y.from_file path in
+  let macros =
+    try U.to_list (U.member "macros" json) with _ -> failwith "missing macros"
+  in
+  List.map
+    (fun j ->
+      let name = string_field "name" j in
+      let mode = mode_of_string (string_field "mode" j) in
+      let expansion_json =
+        try U.to_list (U.member "expansion" j)
+        with _ -> (
+          try U.to_list (U.member "body" j)
+          with _ -> failwith ("no expansion for " ^ name))
+      in
+      let expansion = List.map token_of_json expansion_json in
+      let expand_in_math = bool_field_opt "expand_in_math" true j in
+      let expand_in_text = bool_field_opt "expand_in_text" true j in
+      { name; mode; expansion; expand_in_math; expand_in_text })
+    macros
+
+(** Load argsafe catalogue (23 argumentful epsilon-safe macros). *)
+let load_argsafe path =
+  let json = Y.from_file path in
+  let cat =
+    try U.member "catalog" json
+    with _ -> failwith "missing catalog in argsafe"
+  in
+  let macros =
+    try U.to_list (U.member "macros" cat) with _ -> failwith "missing macros"
+  in
+  List.map
+    (fun j ->
+      let name = string_field "name" j in
+      let mode =
+        let s = string_field "mode" j in
+        match s with
+        | "text" -> Text
+        | "math" -> Math
+        | "both" -> Both
+        | _ -> mode_of_string s
+      in
+      let category = string_field "category" j in
+      let args = U.member "args" j in
+      let positional = int_field "positional" args in
+      let kinds =
+        try
+          U.to_list (U.member "kinds" args)
+          |> List.filter_map (function `String s -> Some s | _ -> None)
+        with _ -> []
+      in
+      let templ = U.member "template" j in
+      let template =
+        match string_field "kind" templ with
+        | "inline" -> Inline (string_field "body" templ)
+        | "builtin" -> Builtin (string_field "builtin" templ)
+        | k -> failwith ("unknown template kind: " ^ k)
+      in
+      { name; mode; category; positional; kinds; template })
+    macros
+
+(* ── Epsilon safety validation ──────────────────────────────────────── *)
+
+let allowed_inline_css =
+  [
+    "\\bfseries";
+    "\\itshape";
+    "\\ttfamily";
+    "\\sffamily";
+    "\\scshape";
+    "\\mdseries";
+    "\\normalfont";
+    "\\rmfamily";
+    "\\slshape";
+    "\\upshape";
+    "\\mathrm";
+    "\\mathbf";
+    "\\mathsf";
+    "\\mathtt";
+    "\\mathit";
+    "\\mathnormal";
+  ]
+
+let eps_inline_safe (s : string) : bool =
+  (* Strip $1..$3 placeholders, then check remaining characters are only braces,
+     spaces, and allowed control sequences. *)
+  let buf = Buffer.create (String.length s) in
+  let n = String.length s in
+  let i = ref 0 in
+  while !i < n do
+    if !i + 1 < n && s.[!i] = '$' && s.[!i + 1] >= '1' && s.[!i + 1] <= '3' then
+      i := !i + 2
+    else (
+      Buffer.add_char buf s.[!i];
+      incr i)
+  done;
+  let s' = Buffer.contents buf in
+  let n' = String.length s' in
+  let pos = ref 0 in
+  let ok = ref true in
+  while !pos < n' && !ok do
+    let c = s'.[!pos] in
+    if c = '{' || c = '}' || c = ' ' then incr pos
+    else if c = '\\' then
+      let j = take_ident s' (!pos + 1) in
+      if j > !pos + 1 then
+        let cs = String.sub s' !pos (j - !pos) in
+        if List.mem cs allowed_inline_css then pos := j else ok := false
+      else ok := false
+    else ok := false
+  done;
+  !ok
+
+let validate_epsilon (m : argsafe_entry) : bool * string option =
+  match m.template with
+  | Builtin "verb"
+  | Builtin "verb_star"
+  | Builtin "mbox"
+  | Builtin "textsuperscript"
+  | Builtin "textsubscript"
+  | Builtin "ensuremath" ->
+      (true, None)
+  | Builtin other -> (false, Some ("unknown builtin " ^ other))
+  | Inline body ->
+      if eps_inline_safe body then (true, None)
+      else (false, Some ("inline template not epsilon-safe: " ^ body))
+
+(* ── Catalogue construction ─────────────────────────────────────────── *)
+
+let create sym_list arg_list =
+  let symbols = Hashtbl.create (List.length sym_list) in
+  let argsafe = Hashtbl.create (List.length arg_list) in
+  let all_names =
+    Hashtbl.create (List.length sym_list + List.length arg_list)
+  in
+  List.iter
+    (fun (e : symbol_entry) ->
+      Hashtbl.replace symbols e.name e;
+      Hashtbl.replace all_names e.name (Symbol e))
+    sym_list;
+  List.iter
+    (fun (e : argsafe_entry) ->
+      Hashtbl.replace argsafe e.name e;
+      Hashtbl.replace all_names e.name (Argsafe e))
+    arg_list;
+  { symbols; argsafe; all_names }
+
+let load ~v25r2_path ~argsafe_path =
+  let sym_list = load_v25r2 v25r2_path in
+  let arg_list = load_argsafe argsafe_path in
+  (* Validate epsilon safety for all argsafe entries *)
+  List.iter
+    (fun (m : argsafe_entry) ->
+      let ok, reason = validate_epsilon m in
+      if not ok then
+        Printf.eprintf
+          "[macro-catalogue] WARNING: %s failed epsilon check: %s\n%!" m.name
+          (Option.value ~default:"unknown" reason))
+    arg_list;
+  create sym_list arg_list
+
+(* ── Query ──────────────────────────────────────────────────────────── *)
+
+let symbol_count cat = Hashtbl.length cat.symbols
+let argsafe_count cat = Hashtbl.length cat.argsafe
+
+let lookup cat name =
+  match Hashtbl.find_opt cat.all_names name with
+  | Some _ as r -> r
+  | None -> None
+
+(* ── Expansion engine ───────────────────────────────────────────────── *)
+
+let max_expansions = 256
+
+(** Should we expand a symbol entry given the current math/text context? *)
+let should_expand_symbol (e : symbol_entry) ~in_math =
+  if in_math then
+    e.expand_in_math
+    && (e.mode = Math || e.mode = Any || e.mode = Both || e.mode = Text)
+  else
+    e.expand_in_text
+    && (e.mode = Text || e.mode = Any || e.mode = Both || e.mode = Math)
+
+(** Should we expand an argsafe entry given the current math/text context? *)
+let should_expand_argsafe (e : argsafe_entry) ~in_math =
+  match e.mode with Both | Any -> true | Math -> in_math | Text -> not in_math
+
+(** Apply an inline template by substituting $1 with the argument content. *)
+let apply_inline_template body arg =
+  let buf = Buffer.create (String.length body + String.length arg) in
+  let n = String.length body in
+  let i = ref 0 in
+  while !i < n do
+    if !i + 1 < n && body.[!i] = '$' && body.[!i + 1] = '1' then (
+      Buffer.add_string buf arg;
+      i := !i + 2)
+    else (
+      Buffer.add_char buf body.[!i];
+      incr i)
+  done;
+  Buffer.contents buf
+
+(** Apply a builtin template to the parsed argument. *)
+let apply_builtin builtin_name arg =
+  match builtin_name with
+  | "mbox" | "textsuperscript" | "textsubscript" | "ensuremath" -> arg
+  | "verb" | "verb_star" -> arg
+  | _ -> arg (* unknown builtins: passthrough *)
+
+(** Single-pass expansion: scans the string, expanding known macros once.
+    Returns the expanded string. Tracks math/text context for mode filtering. *)
+let expand_once cat s =
+  let buf = Buffer.create (String.length s + 64) in
+  let n = String.length s in
+  let i = ref 0 in
+  let in_math = ref false in
+  let math_delim =
+    ref
+      ' ' (* '$' for $...$, 'D' for $$...$$, '[' for \[...\], '(' for \(...\) *)
+  in
+  while !i < n do
+    let c = s.[!i] in
+    (* Math-mode tracking *)
+    if c = '$' then
+      if !i + 1 < n && s.[!i + 1] = '$' then
+        if (* $$ display math toggle *)
+           !in_math && !math_delim = 'D' then (
+          in_math := false;
+          Buffer.add_string buf "$$";
+          i := !i + 2)
+        else if not !in_math then (
+          in_math := true;
+          math_delim := 'D';
+          Buffer.add_string buf "$$";
+          i := !i + 2)
+        else (
+          Buffer.add_char buf c;
+          incr i)
+      else if !in_math && !math_delim = '$' then (
+        (* Closing inline math $ *)
+        in_math := false;
+        Buffer.add_char buf c;
+        incr i)
+      else if not !in_math then (
+        (* Opening inline math $ *)
+        in_math := true;
+        math_delim := '$';
+        Buffer.add_char buf c;
+        incr i)
+      else (
+        Buffer.add_char buf c;
+        incr i)
+    else if c = '\\' then
+      let j = take_ident s (!i + 1) in
+      if j > !i + 1 then
+        let name = String.sub s (!i + 1) (j - (!i + 1)) in
+        (* Check for \[, \], \(, \) delimiters *)
+        if false then ()
+        else
+          (* Look up in catalogue *)
+          match Hashtbl.find_opt cat.argsafe name with
+          | Some e when should_expand_argsafe e ~in_math:!in_math ->
+              (* Try to parse argument *)
+              let consumed = ref false in
+              (if e.positional >= 1 then
+                 match find_brace_block s j with
+                 | Some (off, len) ->
+                     let arg = String.sub s off len in
+                     let result =
+                       match e.template with
+                       | Inline body -> apply_inline_template body arg
+                       | Builtin b -> apply_builtin b arg
+                     in
+                     Buffer.add_string buf result;
+                     i := j + len + 2;
+                     consumed := true
+                 | None -> ());
+              if not !consumed then (
+                Buffer.add_char buf c;
+                incr i)
+          | _ -> (
+              match Hashtbl.find_opt cat.symbols name with
+              | Some e when should_expand_symbol e ~in_math:!in_math ->
+                  let expanded =
+                    String.concat "" (List.map token_to_string e.expansion)
+                  in
+                  Buffer.add_string buf expanded;
+                  i := j
+              | _ ->
+                  (* Not in catalogue or mode mismatch: pass through *)
+                  Buffer.add_char buf c;
+                  incr i)
+      else if (* Check for \[ \] \( \) *)
+              !i + 1 < n then
+        let next = s.[!i + 1] in
+        if next = '[' && not !in_math then (
+          in_math := true;
+          math_delim := '[';
+          Buffer.add_string buf "\\[";
+          i := !i + 2)
+        else if next = ']' && !in_math && !math_delim = '[' then (
+          in_math := false;
+          Buffer.add_string buf "\\]";
+          i := !i + 2)
+        else if next = '(' && not !in_math then (
+          in_math := true;
+          math_delim := '(';
+          Buffer.add_string buf "\\(";
+          i := !i + 2)
+        else if next = ')' && !in_math && !math_delim = '(' then (
+          in_math := false;
+          Buffer.add_string buf "\\)";
+          i := !i + 2)
+        else (
+          Buffer.add_char buf c;
+          incr i)
+      else (
+        Buffer.add_char buf c;
+        incr i)
+    else (
+      Buffer.add_char buf c;
+      incr i)
+  done;
+  Buffer.contents buf
+
+(** Iterate [expand_once] until fixed point or max iterations reached. *)
+let expand cat s =
+  let rec loop s n =
+    if n >= max_expansions then s
+    else
+      let s' = expand_once cat s in
+      if String.equal s s' then s else loop s' (n + 1)
+  in
+  loop s 0
+
+(** Expand to fixed point, then tokenise the result. *)
+let expand_and_tokenize cat s =
+  let expanded = expand cat s in
+  let tokens = Tokenizer_lite.tokenize expanded in
+  (expanded, tokens)

--- a/latex-parse/src/macro_catalogue.mli
+++ b/latex-parse/src/macro_catalogue.mli
@@ -1,0 +1,81 @@
+(** Production L1 macro expander with v25r2 + argsafe catalogue support.
+
+    Loads 383 symbol macros (arity-0, Unicode expansions) and 23 argumentful
+    macros (epsilon-safe templates) from JSON catalogues. Performs mode-aware
+    expansion with bounded iteration (max 256 rounds). *)
+
+(** {1 Token types} *)
+
+type token = TText of string | TOp of string | TDelim of string
+
+val token_to_string : token -> string
+(** Extract the string payload from any token variant. *)
+
+(** {1 Catalogue types} *)
+
+type mode = Math | Text | Any | Both
+
+type symbol_entry = {
+  name : string;
+  mode : mode;
+  expansion : token list;
+  expand_in_math : bool;
+  expand_in_text : bool;
+}
+
+type template = Inline of string | Builtin of string
+
+type argsafe_entry = {
+  name : string;
+  mode : mode;
+  category : string;
+  positional : int;
+  kinds : string list;
+  template : template;
+}
+
+type entry = Symbol of symbol_entry | Argsafe of argsafe_entry
+
+type catalogue
+(** Opaque handle to the loaded macro catalogue (hash tables). *)
+
+(** {1 Loading} *)
+
+val load : v25r2_path:string -> argsafe_path:string -> catalogue
+(** Load both catalogues from JSON files. Validates epsilon-safety for all
+    argsafe entries at load time (warnings on stderr). *)
+
+val load_v25r2 : string -> symbol_entry list
+(** Parse the v25r2 JSON catalogue to a list of symbol entries. *)
+
+val load_argsafe : string -> argsafe_entry list
+(** Parse the argsafe JSON catalogue to a list of argumentful entries. *)
+
+val create : symbol_entry list -> argsafe_entry list -> catalogue
+(** Build a catalogue from pre-parsed entry lists. *)
+
+(** {1 Query} *)
+
+val symbol_count : catalogue -> int
+(** Number of symbol (arity-0) entries. *)
+
+val argsafe_count : catalogue -> int
+(** Number of argumentful entries. *)
+
+val lookup : catalogue -> string -> entry option
+(** Look up a macro by name (without backslash). *)
+
+(** {1 Expansion} *)
+
+val expand : catalogue -> string -> string
+(** Expand all known macros to fixed point (max 256 iterations). Tracks
+    math/text context via [$], [$$], [\[], [\(] delimiters. *)
+
+val expand_and_tokenize :
+  catalogue -> string -> string * Tokenizer_lite.tok list
+(** Expand to fixed point, then tokenise the result. *)
+
+(** {1 Validation} *)
+
+val validate_epsilon : argsafe_entry -> bool * string option
+(** Check whether an argsafe entry passes epsilon-safety validation. *)

--- a/latex-parse/src/rest_simple_expander.mli
+++ b/latex-parse/src/rest_simple_expander.mli
@@ -1,19 +1,38 @@
-(** Simple LaTeX control-sequence expander with configurable stripping rules. *)
+(** Simple LaTeX control-sequence expander with configurable stripping rules.
 
-type cfg = { strip_controls : string list; bfseries_until_brace : bool }
+    Supports two modes:
+    - Legacy: strip a fixed list of commands (backward compatible)
+    - Catalogue: delegate to {!Latex_parse_lib.Macro_catalogue.expand} for full
+      v25r2 + argsafe expansion *)
+
+type cfg = {
+  strip_controls : string list;
+  bfseries_until_brace : bool;
+  catalogue : Latex_parse_lib.Macro_catalogue.catalogue option;
+}
 
 val default : cfg
 (** Default configuration: strips [textbf], [emph], [section]; handles
-    [bfseries]. *)
+    [bfseries]. No catalogue loaded. *)
 
 val of_json : Yojson.Safe.t -> cfg
-(** Parse a configuration from JSON, falling back to {!default} on error. *)
+(** Parse a configuration from JSON, falling back to {!default} on error. Does
+    not load a catalogue. *)
+
+val of_catalogue : Latex_parse_lib.Macro_catalogue.catalogue -> cfg
+(** Create a configuration that delegates to the given macro catalogue. *)
+
+val with_catalogue :
+  cfg -> Latex_parse_lib.Macro_catalogue.catalogue option -> cfg
+(** Override the catalogue in an existing configuration. *)
 
 val expand_once : cfg -> string -> string
-(** Single-pass expansion: strip configured commands once. *)
+(** Single-pass expansion. In catalogue mode this is a no-op; use {!expand_fix}
+    instead. *)
 
 val expand_fix : cfg -> string -> string
-(** Fixed-point expansion: iterate {!expand_once} until stable. *)
+(** Fixed-point expansion. In catalogue mode delegates to
+    {!Latex_parse_lib.Macro_catalogue.expand}. *)
 
 val expand_and_tokenize :
   cfg -> string -> string * Latex_parse_lib.Tokenizer_lite.tok list

--- a/latex-parse/src/test_macro_catalogue.ml
+++ b/latex-parse/src/test_macro_catalogue.ml
@@ -1,0 +1,233 @@
+(** Unit tests for Macro_catalogue (L1 macro expander). *)
+
+open Latex_parse_lib
+
+let fails = ref 0
+let cases = ref 0
+
+let expect cond msg =
+  if not cond then (
+    Printf.eprintf "[macro-cat] FAIL: %s\n%!" msg;
+    incr fails)
+
+let run msg f =
+  incr cases;
+  f msg
+
+(* ── Catalogue paths (relative to project root, where dune runs) ──── *)
+
+let v25r2_path = "../data/macro_catalogue.v25r2.json"
+let argsafe_path = "../data/macro_catalogue.argsafe.v25r1.json"
+let cat = lazy (Macro_catalogue.load ~v25r2_path ~argsafe_path)
+
+let () =
+  (* 1. Load v25r2 catalogue — 383 entries *)
+  run "symbol count = 383" (fun tag ->
+      let c = Lazy.force cat in
+      let n = Macro_catalogue.symbol_count c in
+      expect (n = 383) (tag ^ Printf.sprintf ": got %d" n));
+
+  (* 2. Load argsafe catalogue — 23 entries *)
+  run "argsafe count = 23" (fun tag ->
+      let c = Lazy.force cat in
+      let n = Macro_catalogue.argsafe_count c in
+      expect (n = 23) (tag ^ Printf.sprintf ": got %d" n));
+
+  (* 3. Lookup alpha → Symbol with TText "α" *)
+  run "lookup alpha" (fun tag ->
+      let c = Lazy.force cat in
+      match Macro_catalogue.lookup c "alpha" with
+      | Some (Symbol e) -> (
+          match e.expansion with
+          | [ Macro_catalogue.TText s ] ->
+              expect (s = "\xCE\xB1") (tag ^ ": expansion = " ^ s)
+          | _ -> expect false (tag ^ ": unexpected expansion"))
+      | _ -> expect false (tag ^ ": not found"));
+
+  (* 4. Lookup textbf → Argsafe with positional=1 *)
+  run "lookup textbf" (fun tag ->
+      let c = Lazy.force cat in
+      match Macro_catalogue.lookup c "textbf" with
+      | Some (Argsafe e) -> expect (e.positional = 1) (tag ^ ": positional")
+      | _ -> expect false (tag ^ ": not found or wrong type"));
+
+  (* 5. Lookup nonexistent → None *)
+  run "lookup nonexistent" (fun tag ->
+      let c = Lazy.force cat in
+      match Macro_catalogue.lookup c "nonexistent_macro_xyz" with
+      | None -> ()
+      | Some _ -> expect false (tag ^ ": should be None"));
+
+  (* 6. Expand \alpha → α (symbol expansion) *)
+  run "expand \\alpha" (fun tag ->
+      let c = Lazy.force cat in
+      let result = Macro_catalogue.expand c "$\\alpha$" in
+      (* \alpha is math mode, so wrap in $ to enable expansion *)
+      expect (result = "$\xCE\xB1$") (tag ^ ": got " ^ String.escaped result));
+
+  (* 7. Expand \leq → ≤ (operator) *)
+  run "expand \\leq" (fun tag ->
+      let c = Lazy.force cat in
+      let result = Macro_catalogue.expand c "$\\leq$" in
+      expect (result = "$\xE2\x89\xA4$") (tag ^ ": got " ^ String.escaped result));
+
+  (* 8. Expand \langle → ⟨ (delimiter, mode=any) *)
+  run "expand \\langle" (fun tag ->
+      let c = Lazy.force cat in
+      (* mode=any should expand even in text context *)
+      let result = Macro_catalogue.expand c "\\langle" in
+      expect (result = "\xE2\x9F\xA8") (tag ^ ": got " ^ String.escaped result));
+
+  (* 9. Expand \textbf{hello} → {\bfseries hello} (argsafe inline) *)
+  run "expand \\textbf{hello}" (fun tag ->
+      let c = Lazy.force cat in
+      let result = Macro_catalogue.expand c "\\textbf{hello}" in
+      expect
+        (result = "{\\bfseries hello}")
+        (tag ^ ": got " ^ String.escaped result));
+
+  (* 10. Expand \emph{world} → {\itshape world} *)
+  run "expand \\emph{world}" (fun tag ->
+      let c = Lazy.force cat in
+      let result = Macro_catalogue.expand c "\\emph{world}" in
+      expect
+        (result = "{\\itshape world}")
+        (tag ^ ": got " ^ String.escaped result));
+
+  (* 11. Expand nested: \textbf{\emph{nested}} *)
+  run "expand nested" (fun tag ->
+      let c = Lazy.force cat in
+      let result = Macro_catalogue.expand c "\\textbf{\\emph{nested}}" in
+      expect
+        (result = "{\\bfseries {\\itshape nested}}")
+        (tag ^ ": got " ^ String.escaped result));
+
+  (* 12. Unknown macro passes through unchanged *)
+  run "unknown passthrough" (fun tag ->
+      let c = Lazy.force cat in
+      let result = Macro_catalogue.expand c "\\foobar" in
+      expect (result = "\\foobar") (tag ^ ": got " ^ String.escaped result));
+
+  (* 13. Math-only macro in text context → unchanged *)
+  run "math-only in text" (fun tag ->
+      let c = Lazy.force cat in
+      (* \alpha is mode=math; outside $ it should not expand *)
+      let result = Macro_catalogue.expand c "\\alpha in text" in
+      expect
+        (result = "\\alpha in text")
+        (tag ^ ": got " ^ String.escaped result));
+
+  (* 14. Text-only macro in math context → unchanged *)
+  run "text-only in math" (fun tag ->
+      let c = Lazy.force cat in
+      (* \texteuro is mode=text; inside $ it should not expand *)
+      let result = Macro_catalogue.expand c "$\\texteuro$" in
+      expect (result = "$\\texteuro$") (tag ^ ": got " ^ String.escaped result));
+
+  (* 15. Mode=any expands in both contexts *)
+  run "any-mode in math" (fun tag ->
+      let c = Lazy.force cat in
+      let result = Macro_catalogue.expand c "$\\langle$" in
+      expect
+        (String.length result > 0 && result <> "$\\langle$")
+        (tag ^ ": got " ^ String.escaped result));
+
+  (* 16. Empty string → empty string *)
+  run "empty input" (fun tag ->
+      let c = Lazy.force cat in
+      let result = Macro_catalogue.expand c "" in
+      expect (result = "") (tag ^ ": got " ^ String.escaped result));
+
+  (* 17. No macros → unchanged *)
+  run "no macros" (fun tag ->
+      let c = Lazy.force cat in
+      let input = "Hello, world! This has no macros." in
+      let result = Macro_catalogue.expand c input in
+      expect (result = input) (tag ^ ": got " ^ String.escaped result));
+
+  (* 18. token_to_string coverage *)
+  run "token_to_string" (fun tag ->
+      expect
+        (Macro_catalogue.token_to_string (TText "abc") = "abc")
+        (tag ^ ": TText");
+      expect (Macro_catalogue.token_to_string (TOp "+") = "+") (tag ^ ": TOp");
+      expect
+        (Macro_catalogue.token_to_string (TDelim "(") = "(")
+        (tag ^ ": TDelim"));
+
+  (* 19. Max expansion bound — doesn't hang *)
+  run "termination" (fun tag ->
+      let c = Lazy.force cat in
+      (* Feed a long string with many macros — should terminate *)
+      let buf = Buffer.create 10000 in
+      for _ = 1 to 1000 do
+        Buffer.add_string buf "$\\alpha$ "
+      done;
+      let input = Buffer.contents buf in
+      let result = Macro_catalogue.expand c input in
+      expect (String.length result > 0) (tag ^ ": non-empty result"));
+
+  (* 20. Math context: $\alpha + \beta$ *)
+  run "math context full" (fun tag ->
+      let c = Lazy.force cat in
+      let result = Macro_catalogue.expand c "$\\alpha + \\beta$" in
+      (* α = \xCE\xB1, β = \xCE\xB2 *)
+      expect
+        (result = "$\xCE\xB1 + \xCE\xB2$")
+        (tag ^ ": got " ^ String.escaped result));
+
+  (* 21. expand_and_tokenize returns tokens *)
+  run "expand_and_tokenize" (fun tag ->
+      let c = Lazy.force cat in
+      let expanded, toks =
+        Macro_catalogue.expand_and_tokenize c "\\textbf{ok}"
+      in
+      expect (expanded = "{\\bfseries ok}") (tag ^ ": expanded");
+      expect (List.length toks > 0) (tag ^ ": has tokens"));
+
+  (* 22. Display math \[...\] context *)
+  run "display math \\[...\\]" (fun tag ->
+      let c = Lazy.force cat in
+      let result = Macro_catalogue.expand c "\\[\\alpha\\]" in
+      expect (result = "\\[\xCE\xB1\\]") (tag ^ ": got " ^ String.escaped result));
+
+  (* 23. Inline math \(...\) context *)
+  run "inline math \\(...\\)" (fun tag ->
+      let c = Lazy.force cat in
+      let result = Macro_catalogue.expand c "\\(\\alpha\\)" in
+      expect (result = "\\(\xCE\xB1\\)") (tag ^ ": got " ^ String.escaped result));
+
+  (* 24. validate_epsilon on inline template *)
+  run "epsilon validation" (fun tag ->
+      let e : Macro_catalogue.argsafe_entry =
+        {
+          name = "test";
+          mode = Text;
+          category = "style";
+          positional = 1;
+          kinds = [ "text" ];
+          template = Inline "{\\bfseries $1}";
+        }
+      in
+      let ok, _ = Macro_catalogue.validate_epsilon e in
+      expect ok (tag ^ ": should pass"));
+
+  (* 25. validate_epsilon rejects bad template *)
+  run "epsilon reject" (fun tag ->
+      let e : Macro_catalogue.argsafe_entry =
+        {
+          name = "bad";
+          mode = Text;
+          category = "style";
+          positional = 1;
+          kinds = [ "text" ];
+          template = Inline "\\input{$1}";
+        }
+      in
+      let ok, _ = Macro_catalogue.validate_epsilon e in
+      expect (not ok) (tag ^ ": should fail"));
+
+  if !fails > 0 then (
+    Printf.eprintf "[macro-cat] %d failure(s)\n%!" !fails;
+    exit 1)
+  else Printf.printf "[macro-cat] PASS %d cases\n%!" !cases


### PR DESCRIPTION
## Summary

Production-grade L1 macro expander that replaces the 3-command stripper with a real catalogue-driven engine. This is the Q2 gateway deliverable per the project specs.

- **383 symbol macros** (v25r2 format): `\alpha` → `α`, `\leq` → `≤`, `\langle` → `⟨`, etc.
- **23 argumentful macros** (argsafe format): `\textbf{x}` → `{\bfseries x}`, `\emph{x}` → `{\itshape x}`, etc.
- **Mode-aware**: math-only macros expand only inside `$...$`, `$$...$$`, `\[...\]`, `\(...\)`
- **Epsilon-safe**: validates all argsafe templates at load time
- **Bounded**: max 256 expansion iterations for termination guarantee
- **Backward compatible**: falls back to legacy expander if catalogue files missing

### New files
- `macro_catalogue.ml` / `.mli` — Core expander module (loader, validator, expansion engine)
- `test_macro_catalogue.ml` — 25 unit test cases
- `data/macro_catalogue.v25r2.json` — 383 symbol macros (from specs/)
- `data/macro_catalogue.argsafe.v25r1.json` — 23 argumentful macros (from specs/)

### Modified files
- `rest_simple_expander.ml/mli` — Added catalogue mode alongside legacy mode
- `rest_api_server.ml` — Loads catalogue at startup, wires into /tokenize and /expand
- `dune` — Added macro_catalogue to library modules, yojson dependency, test stanza

## Test plan
- [x] `dune build` green
- [x] `dune build @fmt` clean
- [x] `dune runtest` — all 34 test suites pass (including new `[macro-cat] PASS 25 cases`)
- [ ] CI green