### PR TITLE
feat: L0 ENC/CHAR/SPC validators (25 rules) + TYPO-062 bugfix

### DIFF
--- a/latex-parse/src/dune
+++ b/latex-parse/src/dune
@@ -216,3 +216,8 @@
  (deps
   ../data/macro_catalogue.v25r2.json
   ../data/macro_catalogue.argsafe.v25r1.json))
+
+(test
+ (name test_validators_enc_char_spc)
+ (modules test_validators_enc_char_spc)
+ (libraries latex_parse_lib unix))

--- a/latex-parse/src/test_validators_enc_char_spc.ml
+++ b/latex-parse/src/test_validators_enc_char_spc.ml
@@ -1,0 +1,348 @@
+(** Unit tests for ENC, CHAR, SPC, and TYPO-062 validator rules. *)
+
+open Latex_parse_lib
+
+let fails = ref 0
+let cases = ref 0
+
+let expect cond msg =
+  if not cond then (
+    Printf.eprintf "[enc-char-spc] FAIL: %s\n%!" msg;
+    incr fails)
+
+let run msg f =
+  incr cases;
+  f msg
+
+(* Helper: run all validators and find result for a specific rule ID *)
+let find_result id src =
+  let results = Validators.run_all src in
+  List.find_opt (fun (r : Validators.result) -> r.id = id) results
+
+let fires id src = find_result id src <> None
+
+let fires_with_count id src expected_count =
+  match find_result id src with
+  | Some r -> r.count = expected_count
+  | None -> false
+
+let does_not_fire id src = find_result id src = None
+
+let () =
+  (* ══════════════════════════════════════════════════════════════════════ ENC
+     rules
+     ══════════════════════════════════════════════════════════════════════ *)
+
+  (* ENC-007: Zero-width space U+200B *)
+  run "ENC-007 fires on ZWS" (fun tag ->
+      expect (fires "ENC-007" "hello\xe2\x80\x8bworld") (tag ^ ": should fire"));
+  run "ENC-007 count=2" (fun tag ->
+      expect
+        (fires_with_count "ENC-007" "a\xe2\x80\x8bb\xe2\x80\x8bc" 2)
+        (tag ^ ": count"));
+  run "ENC-007 clean" (fun tag ->
+      expect (does_not_fire "ENC-007" "hello world") (tag ^ ": clean"));
+
+  (* ENC-012: C1 control characters U+0080-009F *)
+  run "ENC-012 fires on C1" (fun tag ->
+      (* U+0085 = NEXT LINE = \xC2\x85 *)
+      expect (fires "ENC-012" "text\xc2\x85here") (tag ^ ": should fire"));
+  run "ENC-012 fires U+0080" (fun tag ->
+      expect (fires "ENC-012" "\xc2\x80") (tag ^ ": U+0080"));
+  run "ENC-012 fires U+009F" (fun tag ->
+      expect (fires "ENC-012" "\xc2\x9f") (tag ^ ": U+009F"));
+  run "ENC-012 does not fire on U+00A0" (fun tag ->
+      (* U+00A0 = NBSP = \xC2\xA0, outside the C1 range *)
+      expect (does_not_fire "ENC-012" "text\xc2\xa0here") (tag ^ ": U+00A0"));
+  run "ENC-012 clean" (fun tag ->
+      expect (does_not_fire "ENC-012" "normal ascii text") (tag ^ ": clean"));
+
+  (* ENC-017: Soft hyphen U+00AD *)
+  run "ENC-017 fires" (fun tag ->
+      expect (fires "ENC-017" "hyphen\xc2\xadated") (tag ^ ": should fire"));
+  run "ENC-017 clean" (fun tag ->
+      expect (does_not_fire "ENC-017" "no soft hyphens") (tag ^ ": clean"));
+
+  (* ENC-020: Invisible formatting marks LRM/RLM *)
+  run "ENC-020 fires on LRM" (fun tag ->
+      (* U+200E = LRM = \xe2\x80\x8e *)
+      expect (fires "ENC-020" "a\xe2\x80\x8eb") (tag ^ ": LRM"));
+  run "ENC-020 fires on RLM" (fun tag ->
+      (* U+200F = RLM = \xe2\x80\x8f *)
+      expect (fires "ENC-020" "a\xe2\x80\x8fb") (tag ^ ": RLM"));
+  run "ENC-020 clean" (fun tag ->
+      expect (does_not_fire "ENC-020" "normal text") (tag ^ ": clean"));
+
+  (* ENC-021: Word joiner U+2060 *)
+  run "ENC-021 fires" (fun tag ->
+      expect (fires "ENC-021" "join\xe2\x81\xa0ed") (tag ^ ": should fire"));
+  run "ENC-021 clean" (fun tag ->
+      expect (does_not_fire "ENC-021" "no word joiner") (tag ^ ": clean"));
+
+  (* ENC-022: Interlinear annotation U+FFF9-FFFB *)
+  run "ENC-022 fires on FFF9" (fun tag ->
+      expect (fires "ENC-022" "x\xef\xbf\xb9y") (tag ^ ": U+FFF9"));
+  run "ENC-022 fires on FFFA" (fun tag ->
+      expect (fires "ENC-022" "x\xef\xbf\xbay") (tag ^ ": U+FFFA"));
+  run "ENC-022 fires on FFFB" (fun tag ->
+      expect (fires "ENC-022" "x\xef\xbf\xbby") (tag ^ ": U+FFFB"));
+  run "ENC-022 clean" (fun tag ->
+      expect (does_not_fire "ENC-022" "normal") (tag ^ ": clean"));
+
+  (* ENC-023: Narrow no-break space U+202F *)
+  run "ENC-023 fires" (fun tag ->
+      expect (fires "ENC-023" "a\xe2\x80\xafb") (tag ^ ": should fire"));
+  run "ENC-023 clean" (fun tag ->
+      expect (does_not_fire "ENC-023" "plain text") (tag ^ ": clean"));
+
+  (* ENC-024: Bidirectional embeddings U+202A-202E *)
+  run "ENC-024 fires on LRE U+202A" (fun tag ->
+      expect (fires "ENC-024" "\xe2\x80\xaa") (tag ^ ": U+202A"));
+  run "ENC-024 fires on RLE U+202B" (fun tag ->
+      expect (fires "ENC-024" "\xe2\x80\xab") (tag ^ ": U+202B"));
+  run "ENC-024 fires on PDF U+202C" (fun tag ->
+      expect (fires "ENC-024" "\xe2\x80\xac") (tag ^ ": U+202C"));
+  run "ENC-024 fires on LRO U+202D" (fun tag ->
+      expect (fires "ENC-024" "\xe2\x80\xad") (tag ^ ": U+202D"));
+  run "ENC-024 fires on RLO U+202E" (fun tag ->
+      expect (fires "ENC-024" "\xe2\x80\xae") (tag ^ ": U+202E"));
+  run "ENC-024 count=2" (fun tag ->
+      expect
+        (fires_with_count "ENC-024" "a\xe2\x80\xaab\xe2\x80\xaec" 2)
+        (tag ^ ": count"));
+  run "ENC-024 clean" (fun tag ->
+      expect (does_not_fire "ENC-024" "normal text") (tag ^ ": clean"));
+
+  (* ══════════════════════════════════════════════════════════════════════ CHAR
+     rules
+     ══════════════════════════════════════════════════════════════════════ *)
+
+  (* CHAR-006: Backspace U+0008 *)
+  run "CHAR-006 fires" (fun tag ->
+      expect (fires "CHAR-006" "ab\x08c") (tag ^ ": should fire"));
+  run "CHAR-006 count=3" (fun tag ->
+      expect (fires_with_count "CHAR-006" "\x08\x08\x08" 3) (tag ^ ": count"));
+  run "CHAR-006 clean" (fun tag ->
+      expect (does_not_fire "CHAR-006" "no backspace") (tag ^ ": clean"));
+
+  (* CHAR-007: Bell/alert U+0007 *)
+  run "CHAR-007 fires" (fun tag ->
+      expect (fires "CHAR-007" "bell\x07here") (tag ^ ": should fire"));
+  run "CHAR-007 clean" (fun tag ->
+      expect (does_not_fire "CHAR-007" "silence") (tag ^ ": clean"));
+
+  (* CHAR-008: Form feed U+000C *)
+  run "CHAR-008 fires" (fun tag ->
+      expect (fires "CHAR-008" "page\x0cbreak") (tag ^ ": should fire"));
+  run "CHAR-008 clean" (fun tag ->
+      expect (does_not_fire "CHAR-008" "no form feed") (tag ^ ": clean"));
+
+  (* CHAR-009: Delete U+007F *)
+  run "CHAR-009 fires" (fun tag ->
+      expect (fires "CHAR-009" "del\x7fete") (tag ^ ": should fire"));
+  run "CHAR-009 clean" (fun tag ->
+      expect (does_not_fire "CHAR-009" "normal text") (tag ^ ": clean"));
+
+  (* CHAR-013: Bidirectional isolate chars U+2066-2069 *)
+  run "CHAR-013 fires on LRI U+2066" (fun tag ->
+      expect (fires "CHAR-013" "\xe2\x81\xa6") (tag ^ ": U+2066"));
+  run "CHAR-013 fires on RLI U+2067" (fun tag ->
+      expect (fires "CHAR-013" "\xe2\x81\xa7") (tag ^ ": U+2067"));
+  run "CHAR-013 fires on FSI U+2068" (fun tag ->
+      expect (fires "CHAR-013" "\xe2\x81\xa8") (tag ^ ": U+2068"));
+  run "CHAR-013 fires on PDI U+2069" (fun tag ->
+      expect (fires "CHAR-013" "\xe2\x81\xa9") (tag ^ ": U+2069"));
+  run "CHAR-013 clean" (fun tag ->
+      expect (does_not_fire "CHAR-013" "normal text") (tag ^ ": clean"));
+
+  (* CHAR-014: Unicode replacement character U+FFFD *)
+  run "CHAR-014 fires" (fun tag ->
+      expect (fires "CHAR-014" "bad\xef\xbf\xbdbyte") (tag ^ ": should fire"));
+  run "CHAR-014 count=2" (fun tag ->
+      expect
+        (fires_with_count "CHAR-014" "\xef\xbf\xbd\xef\xbf\xbd" 2)
+        (tag ^ ": count"));
+  run "CHAR-014 clean" (fun tag ->
+      expect (does_not_fire "CHAR-014" "normal text") (tag ^ ": clean"));
+
+  (* CHAR-021: Stray BOM U+FEFF inside paragraph *)
+  run "CHAR-021 fires on interior BOM" (fun tag ->
+      expect (fires "CHAR-021" "text\xef\xbb\xbfmore") (tag ^ ": should fire"));
+  run "CHAR-021 allows BOM at start" (fun tag ->
+      (* A single BOM at the very start is legitimate *)
+      expect
+        (does_not_fire "CHAR-021" "\xef\xbb\xbflegitimate start")
+        (tag ^ ": start BOM ok"));
+  run "CHAR-021 fires on second BOM even with start BOM" (fun tag ->
+      expect
+        (fires "CHAR-021" "\xef\xbb\xbfstart\xef\xbb\xbfmiddle")
+        (tag ^ ": second BOM fires"));
+  run "CHAR-021 clean" (fun tag ->
+      expect (does_not_fire "CHAR-021" "no BOM at all") (tag ^ ": clean"));
+
+  (* ══════════════════════════════════════════════════════════════════════ SPC
+     rules
+     ══════════════════════════════════════════════════════════════════════ *)
+
+  (* SPC-001: Line longer than 120 characters *)
+  run "SPC-001 fires on long line" (fun tag ->
+      let long = String.make 121 'x' in
+      expect (fires "SPC-001" long) (tag ^ ": 121 chars"));
+  run "SPC-001 ok at 120" (fun tag ->
+      let exact = String.make 120 'x' in
+      expect (does_not_fire "SPC-001" exact) (tag ^ ": 120 ok"));
+  run "SPC-001 multiline counts" (fun tag ->
+      let input =
+        "short\n" ^ String.make 130 'a' ^ "\nshort\n" ^ String.make 200 'b'
+      in
+      expect (fires_with_count "SPC-001" input 2) (tag ^ ": 2 long lines"));
+
+  (* SPC-002: Whitespace-only line *)
+  run "SPC-002 fires on space line" (fun tag ->
+      expect (fires "SPC-002" "text\n   \nmore") (tag ^ ": spaces"));
+  run "SPC-002 fires on tab line" (fun tag ->
+      expect (fires "SPC-002" "text\n\t\nmore") (tag ^ ": tab"));
+  run "SPC-002 does not fire on empty line" (fun tag ->
+      expect (does_not_fire "SPC-002" "text\n\nmore") (tag ^ ": empty line ok"));
+  run "SPC-002 clean" (fun tag ->
+      expect (does_not_fire "SPC-002" "all content\nhere") (tag ^ ": clean"));
+
+  (* SPC-003: Mixed tab/space indent *)
+  run "SPC-003 fires" (fun tag ->
+      expect (fires "SPC-003" "\t code") (tag ^ ": tab then space"));
+  run "SPC-003 fires reverse" (fun tag ->
+      expect (fires "SPC-003" " \tcode") (tag ^ ": space then tab"));
+  run "SPC-003 clean tabs only" (fun tag ->
+      expect (does_not_fire "SPC-003" "\t\tcode") (tag ^ ": tabs only"));
+  run "SPC-003 clean spaces only" (fun tag ->
+      expect (does_not_fire "SPC-003" "    code") (tag ^ ": spaces only"));
+
+  (* SPC-004: Bare CR without LF *)
+  run "SPC-004 fires on bare CR" (fun tag ->
+      expect (fires "SPC-004" "line1\rline2") (tag ^ ": bare CR"));
+  run "SPC-004 ok with CRLF" (fun tag ->
+      expect (does_not_fire "SPC-004" "line1\r\nline2") (tag ^ ": CRLF ok"));
+  run "SPC-004 clean" (fun tag ->
+      expect (does_not_fire "SPC-004" "line1\nline2") (tag ^ ": LF only"));
+
+  (* SPC-005: Trailing tab at end of line *)
+  run "SPC-005 fires" (fun tag ->
+      expect (fires "SPC-005" "text\t\nmore") (tag ^ ": trailing tab"));
+  run "SPC-005 fires at EOF" (fun tag ->
+      expect (fires "SPC-005" "text\t") (tag ^ ": trailing tab at EOF"));
+  run "SPC-005 clean" (fun tag ->
+      expect (does_not_fire "SPC-005" "text\nmore") (tag ^ ": clean"));
+
+  (* SPC-006: Indentation mixes spaces and tabs (specifically tab then space) *)
+  run "SPC-006 fires on tab-then-space" (fun tag ->
+      expect (fires "SPC-006" "\t code") (tag ^ ": tab then space"));
+  run "SPC-006 clean on space-then-tab" (fun tag ->
+      (* SPC-006 specifically detects space AFTER tab, not space BEFORE tab *)
+      expect
+        (does_not_fire "SPC-006" "  \tcode")
+        (tag ^ ": space-tab ok for 006"));
+
+  (* SPC-012: BOM not at file start *)
+  run "SPC-012 fires on interior BOM" (fun tag ->
+      expect (fires "SPC-012" "text\xef\xbb\xbfmore") (tag ^ ": interior BOM"));
+  run "SPC-012 ok at start" (fun tag ->
+      expect
+        (does_not_fire "SPC-012" "\xef\xbb\xbffile start")
+        (tag ^ ": start BOM ok"));
+  run "SPC-012 fires on extra BOM after start" (fun tag ->
+      expect
+        (fires "SPC-012" "\xef\xbb\xbfstart\xef\xbb\xbfextra")
+        (tag ^ ": extra fires"));
+
+  (* SPC-024: Leading spaces on blank line *)
+  run "SPC-024 fires" (fun tag ->
+      expect (fires "SPC-024" "text\n   \nmore") (tag ^ ": spaces on blank"));
+  run "SPC-024 clean" (fun tag ->
+      expect (does_not_fire "SPC-024" "text\n\nmore") (tag ^ ": empty line ok"));
+
+  (* SPC-028: Multiple consecutive ~~ (non-breaking spaces) *)
+  run "SPC-028 fires" (fun tag ->
+      expect (fires "SPC-028" "use~~here") (tag ^ ": double tilde"));
+  run "SPC-028 fires triple" (fun tag ->
+      expect (fires "SPC-028" "use~~~here") (tag ^ ": triple tilde"));
+  run "SPC-028 clean single" (fun tag ->
+      expect (does_not_fire "SPC-028" "use~single") (tag ^ ": single ok"));
+
+  (* ══════════════════════════════════════════════════════════════════════
+     TYPO-062: Literal backslash in text
+     ══════════════════════════════════════════════════════════════════════ *)
+  run "TYPO-062 fires on \\\\ in text" (fun tag ->
+      expect (fires "TYPO-062" "text \\\\ more") (tag ^ ": should fire"));
+  run "TYPO-062 does not fire on \\\\[ at line start" (fun tag ->
+      (* \\[2pt] is a linebreak with optional arg; the \\ before [ should not
+         fire. However, strip_math_segments sees \[ as display math. So we test
+         the pattern in isolation: backslash-backslash-bracket at end. *)
+      expect
+        (does_not_fire "TYPO-062" "end of line\\\\[2pt]")
+        (tag ^ ": \\\\[ ok"));
+  run "TYPO-062 does not fire on \\\\*" (fun tag ->
+      expect (does_not_fire "TYPO-062" "end of line\\\\*") (tag ^ ": \\\\* ok"));
+  run "TYPO-062 does not fire in math" (fun tag ->
+      expect
+        (does_not_fire "TYPO-062" "$a \\\\ b$")
+        (tag ^ ": math mode excluded"));
+  run "TYPO-062 clean" (fun tag ->
+      expect (does_not_fire "TYPO-062" "no backslashes here") (tag ^ ": clean"));
+
+  (* ══════════════════════════════════════════════════════════════════════ Edge
+     cases
+     ══════════════════════════════════════════════════════════════════════ *)
+
+  (* Empty input triggers nothing *)
+  run "empty input" (fun tag ->
+      let results = Validators.run_all "" in
+      let enc_char_spc =
+        List.filter
+          (fun (r : Validators.result) ->
+            let id = r.id in
+            (String.length id >= 4 && String.sub id 0 4 = "ENC-")
+            || (String.length id >= 5 && String.sub id 0 5 = "CHAR-")
+            || (String.length id >= 4 && String.sub id 0 4 = "SPC-")
+            || id = "TYPO-062")
+          results
+      in
+      expect (enc_char_spc = []) (tag ^ ": no ENC/CHAR/SPC on empty"));
+
+  (* Clean LaTeX triggers no ENC/CHAR/SPC rules *)
+  run "clean LaTeX" (fun tag ->
+      let src =
+        "\\documentclass{article}\n\
+         \\begin{document}\n\
+         Hello, world!\n\
+         \\end{document}\n"
+      in
+      let results = Validators.run_all src in
+      let enc_char_spc =
+        List.filter
+          (fun (r : Validators.result) ->
+            let id = r.id in
+            (String.length id >= 4 && String.sub id 0 4 = "ENC-")
+            || (String.length id >= 5 && String.sub id 0 5 = "CHAR-")
+            || (String.length id >= 4 && String.sub id 0 4 = "SPC-"))
+          results
+      in
+      expect (enc_char_spc = []) (tag ^ ": clean LaTeX"));
+
+  (* precondition_of_rule_id dispatches correctly *)
+  run "layer dispatch ENC" (fun tag ->
+      expect
+        (Validators.precondition_of_rule_id "ENC-007" = L0)
+        (tag ^ ": ENC -> L0"));
+  run "layer dispatch CHAR" (fun tag ->
+      expect
+        (Validators.precondition_of_rule_id "CHAR-006" = L0)
+        (tag ^ ": CHAR -> L0"));
+  run "layer dispatch SPC" (fun tag ->
+      expect
+        (Validators.precondition_of_rule_id "SPC-001" = L0)
+        (tag ^ ": SPC -> L0"));
+
+  if !fails > 0 then (
+    Printf.eprintf "[enc-char-spc] %d failure(s)\n%!" !fails;
+    exit 1)
+  else Printf.printf "[enc-char-spc] PASS %d cases\n%!" !cases

--- a/latex-parse/src/validators.ml
+++ b/latex-parse/src/validators.ml
@@ -2078,6 +2078,559 @@ let rules_vpd_gen : rule list =
 
 (* END VPD-generated validators *)
 
+(* ── ENC rules: encoding / Unicode character detection ─────────────── *)
+
+(* ENC-007: Zero-width space U+200B *)
+let r_enc_007 : rule =
+  let run s =
+    let cnt = count_substring s "\xe2\x80\x8b" in
+    if cnt > 0 then
+      Some
+        {
+          id = "ENC-007";
+          severity = Warning;
+          message = "Zero-width space U+200B present";
+          count = cnt;
+        }
+    else None
+  in
+  { id = "ENC-007"; run }
+
+(* ENC-012: C1 control characters U+0080-009F *)
+let r_enc_012 : rule =
+  let run s =
+    let n = String.length s in
+    let cnt = ref 0 in
+    let i = ref 0 in
+    while !i < n - 1 do
+      if
+        Char.code s.[!i] = 0xC2
+        && Char.code s.[!i + 1] >= 0x80
+        && Char.code s.[!i + 1] <= 0x9F
+      then (
+        incr cnt;
+        i := !i + 2)
+      else incr i
+    done;
+    if !cnt > 0 then
+      Some
+        {
+          id = "ENC-012";
+          severity = Error;
+          message = "C1 control characters U+0080-009F present";
+          count = !cnt;
+        }
+    else None
+  in
+  { id = "ENC-012"; run }
+
+(* ENC-017: Soft hyphen U+00AD *)
+let r_enc_017 : rule =
+  let run s =
+    let cnt = count_substring s "\xc2\xad" in
+    if cnt > 0 then
+      Some
+        {
+          id = "ENC-017";
+          severity = Warning;
+          message = "Soft hyphen U+00AD found in source";
+          count = cnt;
+        }
+    else None
+  in
+  { id = "ENC-017"; run }
+
+(* ENC-020: Invisible formatting marks U+200E (LRM) / U+200F (RLM) *)
+let r_enc_020 : rule =
+  let run s =
+    let cnt =
+      count_substring s "\xe2\x80\x8e" + count_substring s "\xe2\x80\x8f"
+    in
+    if cnt > 0 then
+      Some
+        {
+          id = "ENC-020";
+          severity = Warning;
+          message = "Invisible formatting mark U+200E/U+200F present";
+          count = cnt;
+        }
+    else None
+  in
+  { id = "ENC-020"; run }
+
+(* ENC-021: Word joiner U+2060 *)
+let r_enc_021 : rule =
+  let run s =
+    let cnt = count_substring s "\xe2\x81\xa0" in
+    if cnt > 0 then
+      Some
+        {
+          id = "ENC-021";
+          severity = Warning;
+          message = "Word joiner U+2060 present";
+          count = cnt;
+        }
+    else None
+  in
+  { id = "ENC-021"; run }
+
+(* ENC-022: Interlinear annotation chars U+FFF9-FFFB *)
+let r_enc_022 : rule =
+  let run s =
+    let cnt =
+      count_substring s "\xef\xbf\xb9"
+      + count_substring s "\xef\xbf\xba"
+      + count_substring s "\xef\xbf\xbb"
+    in
+    if cnt > 0 then
+      Some
+        {
+          id = "ENC-022";
+          severity = Warning;
+          message = "Interlinear annotation chars U+FFF9-FFFB detected";
+          count = cnt;
+        }
+    else None
+  in
+  { id = "ENC-022"; run }
+
+(* ENC-023: Narrow no-break space U+202F *)
+let r_enc_023 : rule =
+  let run s =
+    let cnt = count_substring s "\xe2\x80\xaf" in
+    if cnt > 0 then
+      Some
+        {
+          id = "ENC-023";
+          severity = Warning;
+          message = "Narrow no-break space U+202F present";
+          count = cnt;
+        }
+    else None
+  in
+  { id = "ENC-023"; run }
+
+(* ENC-024: Bidirectional embeddings U+202A-U+202E *)
+let r_enc_024 : rule =
+  let run s =
+    let cnt =
+      count_substring s "\xe2\x80\xaa"
+      + count_substring s "\xe2\x80\xab"
+      + count_substring s "\xe2\x80\xac"
+      + count_substring s "\xe2\x80\xad"
+      + count_substring s "\xe2\x80\xae"
+    in
+    if cnt > 0 then
+      Some
+        {
+          id = "ENC-024";
+          severity = Warning;
+          message = "Bidirectional embedding chars U+202A-U+202E present";
+          count = cnt;
+        }
+    else None
+  in
+  { id = "ENC-024"; run }
+
+let rules_enc : rule list =
+  [
+    r_enc_007;
+    r_enc_012;
+    r_enc_017;
+    r_enc_020;
+    r_enc_021;
+    r_enc_022;
+    r_enc_023;
+    r_enc_024;
+  ]
+
+(* ── CHAR rules: control character detection ───────────────────────── *)
+
+(* CHAR-006: Backspace U+0008 *)
+let r_char_006 : rule =
+  let run s =
+    let cnt = count_char s '\x08' in
+    if cnt > 0 then
+      Some
+        {
+          id = "CHAR-006";
+          severity = Error;
+          message = "Backspace U+0008 present";
+          count = cnt;
+        }
+    else None
+  in
+  { id = "CHAR-006"; run }
+
+(* CHAR-007: Bell/alert U+0007 *)
+let r_char_007 : rule =
+  let run s =
+    let cnt = count_char s '\x07' in
+    if cnt > 0 then
+      Some
+        {
+          id = "CHAR-007";
+          severity = Error;
+          message = "Bell/alert U+0007 present";
+          count = cnt;
+        }
+    else None
+  in
+  { id = "CHAR-007"; run }
+
+(* CHAR-008: Form feed U+000C *)
+let r_char_008 : rule =
+  let run s =
+    let cnt = count_char s '\x0c' in
+    if cnt > 0 then
+      Some
+        {
+          id = "CHAR-008";
+          severity = Warning;
+          message = "Form feed U+000C present";
+          count = cnt;
+        }
+    else None
+  in
+  { id = "CHAR-008"; run }
+
+(* CHAR-009: Delete U+007F *)
+let r_char_009 : rule =
+  let run s =
+    let cnt = count_char s '\x7f' in
+    if cnt > 0 then
+      Some
+        {
+          id = "CHAR-009";
+          severity = Warning;
+          message = "Delete U+007F present";
+          count = cnt;
+        }
+    else None
+  in
+  { id = "CHAR-009"; run }
+
+(* CHAR-013: Bidirectional isolate chars U+2066-U+2069 *)
+let r_char_013 : rule =
+  let run s =
+    let cnt =
+      count_substring s "\xe2\x81\xa6"
+      + count_substring s "\xe2\x81\xa7"
+      + count_substring s "\xe2\x81\xa8"
+      + count_substring s "\xe2\x81\xa9"
+    in
+    if cnt > 0 then
+      Some
+        {
+          id = "CHAR-013";
+          severity = Warning;
+          message = "Bidirectional isolate chars U+2066-U+2069 present";
+          count = cnt;
+        }
+    else None
+  in
+  { id = "CHAR-013"; run }
+
+(* CHAR-014: Unicode replacement character U+FFFD *)
+let r_char_014 : rule =
+  let run s =
+    let cnt = count_substring s "\xef\xbf\xbd" in
+    if cnt > 0 then
+      Some
+        {
+          id = "CHAR-014";
+          severity = Warning;
+          message = "Unicode replacement character U+FFFD found; decoding error";
+          count = cnt;
+        }
+    else None
+  in
+  { id = "CHAR-014"; run }
+
+(* CHAR-021: Zero-width no-break space U+FEFF inside paragraph (BOM) *)
+let r_char_021 : rule =
+  let run s =
+    (* Count U+FEFF occurrences, skip the one at file start (legitimate BOM) *)
+    let bom = "\xef\xbb\xbf" in
+    let total = count_substring s bom in
+    let starts_with_bom = String.length s >= 3 && String.sub s 0 3 = bom in
+    let cnt = if starts_with_bom then total - 1 else total in
+    if cnt > 0 then
+      Some
+        {
+          id = "CHAR-021";
+          severity = Error;
+          message =
+            "Zero-width no-break space U+FEFF inside paragraph (stray BOM)";
+          count = cnt;
+        }
+    else None
+  in
+  { id = "CHAR-021"; run }
+
+let rules_char : rule list =
+  [
+    r_char_006;
+    r_char_007;
+    r_char_008;
+    r_char_009;
+    r_char_013;
+    r_char_014;
+    r_char_021;
+  ]
+
+(* ── SPC rules: spacing and whitespace ─────────────────────────────── *)
+
+(* SPC-001: Line longer than 120 characters *)
+let r_spc_001 : rule =
+  let run s =
+    let _, matched = any_line_pred s (fun line -> String.length line > 120) in
+    if matched > 0 then
+      Some
+        {
+          id = "SPC-001";
+          severity = Info;
+          message = "Line longer than 120 characters";
+          count = matched;
+        }
+    else None
+  in
+  { id = "SPC-001"; run }
+
+(* SPC-002: Line containing only whitespace *)
+let r_spc_002 : rule =
+  let run s =
+    let is_ws_only line =
+      let len = String.length line in
+      len > 0
+      &&
+      let ok = ref true in
+      for i = 0 to len - 1 do
+        let c = line.[i] in
+        if c <> ' ' && c <> '\t' && c <> '\r' then ok := false
+      done;
+      !ok
+    in
+    let _, matched = any_line_pred s is_ws_only in
+    if matched > 0 then
+      Some
+        {
+          id = "SPC-002";
+          severity = Info;
+          message = "Line containing only whitespace";
+          count = matched;
+        }
+    else None
+  in
+  { id = "SPC-002"; run }
+
+(* SPC-003: Hard tab precedes non-tab text (mixed indent) *)
+let r_spc_003 : rule =
+  let run s =
+    let is_mixed_indent line =
+      let len = String.length line in
+      let i = ref 0 in
+      let has_tab = ref false in
+      let has_space = ref false in
+      while !i < len && (line.[!i] = ' ' || line.[!i] = '\t') do
+        if line.[!i] = '\t' then has_tab := true else has_space := true;
+        incr i
+      done;
+      !has_tab && !has_space && !i < len
+    in
+    let _, matched = any_line_pred s is_mixed_indent in
+    if matched > 0 then
+      Some
+        {
+          id = "SPC-003";
+          severity = Warning;
+          message = "Hard tab mixed with spaces in indentation";
+          count = matched;
+        }
+    else None
+  in
+  { id = "SPC-003"; run }
+
+(* SPC-004: Carriage return U+000D without LF *)
+let r_spc_004 : rule =
+  let run s =
+    let n = String.length s in
+    let cnt = ref 0 in
+    for i = 0 to n - 1 do
+      if s.[i] = '\r' then
+        if i + 1 < n && s.[i + 1] = '\n' then () else incr cnt
+    done;
+    if !cnt > 0 then
+      Some
+        {
+          id = "SPC-004";
+          severity = Warning;
+          message = "Bare carriage return U+000D without LF";
+          count = !cnt;
+        }
+    else None
+  in
+  { id = "SPC-004"; run }
+
+(* SPC-005: Trailing tab at end of line *)
+let r_spc_005 : rule =
+  let run s =
+    let ends_with_tab line =
+      let len = String.length line in
+      len > 0 && line.[len - 1] = '\t'
+    in
+    let _, matched = any_line_pred s ends_with_tab in
+    if matched > 0 then
+      Some
+        {
+          id = "SPC-005";
+          severity = Info;
+          message = "Trailing tab at end of line";
+          count = matched;
+        }
+    else None
+  in
+  { id = "SPC-005"; run }
+
+(* SPC-006: Indentation mixes spaces and tabs *)
+let r_spc_006 : rule =
+  let run s =
+    let has_mixed_indent line =
+      let len = String.length line in
+      if len = 0 then false
+      else
+        let seen_tab = ref false in
+        let seen_space_after_tab = ref false in
+        let i = ref 0 in
+        while !i < len && (line.[!i] = ' ' || line.[!i] = '\t') do
+          if line.[!i] = '\t' then seen_tab := true
+          else if !seen_tab then seen_space_after_tab := true;
+          incr i
+        done;
+        !seen_space_after_tab
+    in
+    let _, matched = any_line_pred s has_mixed_indent in
+    if matched > 0 then
+      Some
+        {
+          id = "SPC-006";
+          severity = Info;
+          message = "Indentation mixes spaces and tabs";
+          count = matched;
+        }
+    else None
+  in
+  { id = "SPC-006"; run }
+
+(* SPC-012: BOM not at file start *)
+let r_spc_012 : rule =
+  let run s =
+    let bom = "\xef\xbb\xbf" in
+    let total = count_substring s bom in
+    let at_start = String.length s >= 3 && String.sub s 0 3 = bom in
+    let interior = if at_start then total - 1 else total in
+    if interior > 0 then
+      Some
+        {
+          id = "SPC-012";
+          severity = Error;
+          message = "BOM U+FEFF not at file start";
+          count = interior;
+        }
+    else None
+  in
+  { id = "SPC-012"; run }
+
+(* SPC-024: Leading spaces on blank line *)
+let r_spc_024 : rule =
+  let run s =
+    let is_spaces_only_blank line =
+      let len = String.length line in
+      len > 0
+      &&
+      let all_space = ref true in
+      for i = 0 to len - 1 do
+        if line.[i] <> ' ' && line.[i] <> '\t' then all_space := false
+      done;
+      !all_space
+    in
+    let _, matched = any_line_pred s is_spaces_only_blank in
+    if matched > 0 then
+      Some
+        {
+          id = "SPC-024";
+          severity = Info;
+          message = "Leading spaces on blank line";
+          count = matched;
+        }
+    else None
+  in
+  { id = "SPC-024"; run }
+
+(* SPC-028: Multiple consecutive ~ (non-breaking spaces) *)
+let r_spc_028 : rule =
+  let run s =
+    let cnt = count_substring s "~~" in
+    if cnt > 0 then
+      Some
+        {
+          id = "SPC-028";
+          severity = Warning;
+          message = "Multiple consecutive non-breaking spaces (~~)";
+          count = cnt;
+        }
+    else None
+  in
+  { id = "SPC-028"; run }
+
+let rules_spc : rule list =
+  [
+    r_spc_001;
+    r_spc_002;
+    r_spc_003;
+    r_spc_004;
+    r_spc_005;
+    r_spc_006;
+    r_spc_012;
+    r_spc_024;
+    r_spc_028;
+  ]
+
+(* ── TYPO-062: Literal backslash in text ───────────────────────────── *)
+let r_typo_062 : rule =
+  let run s =
+    (* Count \textbackslash suggestions -- look for \\ not followed by a letter
+       (i.e. bare backslash, not a command) outside math *)
+    let s = strip_math_segments s in
+    let n = String.length s in
+    let cnt = ref 0 in
+    let i = ref 0 in
+    while !i < n - 1 do
+      if s.[!i] = '\\' && s.[!i + 1] = '\\' then (
+        (* Check it's not a linebreak command like \\[2pt] or \\* *)
+        if !i + 2 < n then (
+          let c = s.[!i + 2] in
+          if c <> '[' && c <> '*' then incr cnt)
+        else incr cnt;
+        i := !i + 2)
+      else incr i
+    done;
+    if !cnt > 0 then
+      Some
+        {
+          id = "TYPO-062";
+          severity = Warning;
+          message = "Literal backslash in text; use \\textbackslash";
+          count = !cnt;
+        }
+    else None
+  in
+  { id = "TYPO-062"; run }
+
+(* Combined ENC + CHAR + SPC + new TYPO rules *)
+let rules_enc_char_spc : rule list =
+  rules_enc @ rules_char @ rules_spc @ [ r_typo_062 ]
+
 (* L1 modernization and expansion checks (using post-commands heuristics) *)
 let l1_mod_001_rule : rule =
   let run s =
@@ -2469,8 +3022,8 @@ let rules_l1 : rule list =
 let get_rules () : rule list =
   match Sys.getenv_opt "L0_VALIDATORS" with
   | Some ("1" | "true" | "pilot" | "PILOT") ->
-      rules_pilot @ rules_vpd_gen @ rules_l1
-  | _ -> rules_basic @ rules_l1
+      rules_pilot @ rules_vpd_gen @ rules_enc_char_spc @ rules_l1
+  | _ -> rules_basic @ rules_enc_char_spc @ rules_l1
 
 let run_all (src : string) : result list =
   let rec go acc = function
@@ -2525,6 +3078,9 @@ type layer = L0 | L1 | L2 | L3 | L4
 let precondition_of_rule_id (id : string) : layer =
   match id with
   | _ when String.length id >= 5 && String.sub id 0 5 = "TYPO-" -> L0
+  | _ when String.length id >= 4 && String.sub id 0 4 = "ENC-" -> L0
+  | _ when String.length id >= 5 && String.sub id 0 5 = "CHAR-" -> L0
+  | _ when String.length id >= 4 && String.sub id 0 4 = "SPC-" -> L0
   | _ when String.length id >= 4 && String.sub id 0 4 = "CMD-" -> L1
   | _ when String.length id >= 4 && String.sub id 0 4 = "MOD-" -> L1
   | _ when String.length id >= 4 && String.sub id 0 4 = "EXP-" -> L1

--- a/latex-parse/src/validators.mli
+++ b/latex-parse/src/validators.mli
@@ -26,3 +26,6 @@ val run_all_with_timings : string -> result list * float * (string * float) list
 val run_all_with_timings_for_layer :
   string -> layer -> result list * float * (string * float) list
 (** Like {!run_all_with_timings} but restricted to rules for the given layer. *)
+
+val precondition_of_rule_id : string -> layer
+(** Map a rule ID to the layer it belongs to based on its prefix. *)


### PR DESCRIPTION
## Summary

- Add **25 new L0 validator rules** covering three previously unimplemented rule families:
  - **8 ENC rules** (encoding/Unicode byte scans): ENC-007 (zero-width space), ENC-012 (C1 controls U+0080–009F), ENC-017 (soft hyphen), ENC-020 (LRM/RLM marks), ENC-021 (word joiner), ENC-022 (interlinear annotation), ENC-023 (narrow NBSP), ENC-024 (bidi embeddings)
  - **7 CHAR rules** (control character detection): CHAR-006 (backspace), CHAR-007 (bell), CHAR-008 (form feed), CHAR-009 (delete), CHAR-013 (bidi isolates), CHAR-014 (replacement char U+FFFD), CHAR-021 (stray BOM inside paragraph)
  - **9 SPC rules** (spacing/whitespace): SPC-001 (line >120 chars), SPC-002 (whitespace-only line), SPC-003 (mixed tab/space indent), SPC-004 (bare CR), SPC-005 (trailing tab), SPC-006 (tab-then-space indent), SPC-012 (interior BOM), SPC-024 (spaces on blank line), SPC-028 (consecutive ~~)
  - **1 TYPO rule**: TYPO-062 (literal backslash in text)
- **Fix TYPO-062 parsing bug**: OCaml's `let`-binding scope caused the `else incr cnt` to bind to the inner `if` rather than the outer `if`, making the rule always fire regardless of the `[`/`*` character check. Fixed with explicit parenthesization.
- Add explicit `ENC-`/`CHAR-`/`SPC-` prefix dispatch in `precondition_of_rule_id`
- Expose `precondition_of_rule_id` in `validators.mli`
- **86 unit tests** in `test_validators_enc_char_spc.ml` covering all 25 rules (positive, negative, count, and edge cases)

This brings implemented L0 rule count from ~55 to ~80, covering ~43% of the 184 active L0_Lexer rules.

## Test plan

- [x] `dune build` — clean
- [x] `dune fmt` — clean
- [x] `dune runtest` — all tests pass (86 new + all existing)
- [x] All 25 rules tested with positive triggers, clean inputs, count assertions
- [x] Edge cases: empty input, clean LaTeX, layer dispatch verification