### PR TITLE
feat: implement 12 quick-win L0 validators (batch 3)

### DIFF
--- a/latex-parse/src/test_validators_batch2.ml
+++ b/latex-parse/src/test_validators_batch2.ml
@@ -258,6 +258,71 @@ let () =
   run "SPC-035 clean" (fun tag ->
       expect (does_not_fire "SPC-035" " text") (tag ^ ": normal space"));
 
+  (* ══════════════════════════════════════════════════════════════════════ New
+     SPC rules (batch 3)
+     ══════════════════════════════════════════════════════════════════════ *)
+
+  (* SPC-010: Two spaces after sentence-ending period *)
+  run "SPC-010 fires on two spaces" (fun tag ->
+      expect (fires "SPC-010" "End.  Next sentence.") (tag ^ ": two spaces"));
+  run "SPC-010 does not fire on single space" (fun tag ->
+      expect
+        (does_not_fire "SPC-010" "End. Next sentence.")
+        (tag ^ ": single space ok"));
+  run "SPC-010 does not fire on three spaces" (fun tag ->
+      (* Three spaces = SPC-031 territory, not SPC-010 *)
+      expect
+        (does_not_fire "SPC-010" "End.   Next sentence.")
+        (tag ^ ": three spaces is SPC-031"));
+  run "SPC-010 count=2" (fun tag ->
+      expect (fires_with_count "SPC-010" "A.  B.  C." 2) (tag ^ ": count=2"));
+  run "SPC-010 does not fire in math" (fun tag ->
+      expect (does_not_fire "SPC-010" "$a.  B$") (tag ^ ": math stripped"));
+
+  (* SPC-018: No space after sentence-ending period *)
+  run "SPC-018 fires on period-uppercase" (fun tag ->
+      expect (fires "SPC-018" "End.Next") (tag ^ ": no space"));
+  run "SPC-018 does not fire with space" (fun tag ->
+      expect (does_not_fire "SPC-018" "End. Next") (tag ^ ": space present"));
+  run "SPC-018 count=2" (fun tag ->
+      expect (fires_with_count "SPC-018" "A.B.C." 2) (tag ^ ": count=2"));
+  run "SPC-018 does not fire in math" (fun tag ->
+      expect (does_not_fire "SPC-018" "$x.Y$") (tag ^ ": math stripped"));
+  run "SPC-018 does not fire on lowercase" (fun tag ->
+      expect
+        (does_not_fire "SPC-018" "e.g. here")
+        (tag ^ ": lowercase after period ok"));
+
+  (* SPC-022: Tab after bullet in \itemize *)
+  run "SPC-022 fires on item-tab" (fun tag ->
+      expect (fires "SPC-022" "\\item\tSomething") (tag ^ ": tab after item"));
+  run "SPC-022 does not fire on item-space" (fun tag ->
+      expect (does_not_fire "SPC-022" "\\item Something") (tag ^ ": space ok"));
+  run "SPC-022 count=2" (fun tag ->
+      expect
+        (fires_with_count "SPC-022" "\\item\tA\n\\item\tB" 2)
+        (tag ^ ": count=2"));
+  run "SPC-022 clean" (fun tag ->
+      expect (does_not_fire "SPC-022" "regular text") (tag ^ ": no items"));
+
+  (* SPC-027: Trailing whitespace inside \url{} *)
+  run "SPC-027 fires on trailing space in url" (fun tag ->
+      expect (fires "SPC-027" "\\url{http://x.com }") (tag ^ ": trailing"));
+  run "SPC-027 fires on leading space in url" (fun tag ->
+      expect (fires "SPC-027" "\\url{ http://x.com}") (tag ^ ": leading"));
+  run "SPC-027 fires on tab in url" (fun tag ->
+      expect (fires "SPC-027" "\\url{http://x.com\t}") (tag ^ ": trailing tab"));
+  run "SPC-027 does not fire on clean url" (fun tag ->
+      expect
+        (does_not_fire "SPC-027" "\\url{http://x.com}")
+        (tag ^ ": clean url"));
+  run "SPC-027 count=2" (fun tag ->
+      expect
+        (fires_with_count "SPC-027" "\\url{ a.com} and \\url{b.org }" 2)
+        (tag ^ ": count=2"));
+  run "SPC-027 clean" (fun tag ->
+      expect (does_not_fire "SPC-027" "no urls here") (tag ^ ": no urls"));
+
   (* ══════════════════════════════════════════════════════════════════════
      Math-mode edge cases for rules using strip_math_segments
      ══════════════════════════════════════════════════════════════════════ *)

--- a/latex-parse/src/test_validators_typo.ml
+++ b/latex-parse/src/test_validators_typo.ml
@@ -667,6 +667,36 @@ let () =
         (tag ^ ": standard hyphen ok"));
 
   (* ══════════════════════════════════════════════════════════════════════
+     TYPO-060: Smart quotes inside lstlisting/verbatim
+     ══════════════════════════════════════════════════════════════════════ *)
+  run "TYPO-060 fires on curly quote in lstlisting" (fun tag ->
+      expect
+        (fires "TYPO-060"
+           "\\begin{lstlisting}\n\
+            print(\xe2\x80\x9chi\xe2\x80\x9d)\n\
+            \\end{lstlisting}")
+        (tag ^ ": curly in lstlisting"));
+  run "TYPO-060 fires on curly quote in verbatim" (fun tag ->
+      expect
+        (fires "TYPO-060"
+           "\\begin{verbatim}\n\xe2\x80\x98text\xe2\x80\x99\n\\end{verbatim}")
+        (tag ^ ": curly in verbatim"));
+  run "TYPO-060 count=2 for two curly quotes in lstlisting" (fun tag ->
+      expect
+        (fires_with_count "TYPO-060"
+           "\\begin{lstlisting}\n\xe2\x80\x9c\xe2\x80\x9d\n\\end{lstlisting}" 2)
+        (tag ^ ": count=2"));
+  run "TYPO-060 does not fire outside lstlisting" (fun tag ->
+      expect
+        (does_not_fire "TYPO-060" "Normal \xe2\x80\x9ctext\xe2\x80\x9d here")
+        (tag ^ ": outside verbatim ok"));
+  run "TYPO-060 clean" (fun tag ->
+      expect
+        (does_not_fire "TYPO-060"
+           "\\begin{lstlisting}\nprint(\"hi\")\n\\end{lstlisting}")
+        (tag ^ ": ASCII quotes in lstlisting ok"));
+
+  (* ══════════════════════════════════════════════════════════════════════
      Math-mode edge cases for rules using strip_math_segments
      ══════════════════════════════════════════════════════════════════════ *)
 


### PR DESCRIPTION
## Summary

- Implements 12 new L0 validator rules identified as quick-wins from the remaining unimplemented rule audit
- Brings L0 rule implementation from 122/142 (85.9%) to **134/142 (94.4%)**
- Adds 55 new test cases across 3 test files (429 total across all suites)

## New Rules

### Encoding (3 rules)
| Rule | Description | Severity |
|------|-------------|----------|
| ENC-008 | Private-use codepoint U+E000–F8FF | Warning |
| ENC-009 | Unpaired surrogate code unit U+D800–DFFF | Error |
| ENC-016 | Fullwidth digits U+FF10–FF19 | Warning |

### Character (4 rules)
| Rule | Description | Severity |
|------|-------------|----------|
| CHAR-005 | Control chars U+0000–001F (excl TAB/LF/CR/bell/BS/FF) | Error |
| CHAR-016 | Double-width CJK punctuation (，。；：！？) | Info |
| CHAR-019 | Unicode minus U+2212 in text mode (math-aware via `strip_math_segments`) | Warning |
| CHAR-020 | Sharp S (ß) in uppercase context | Warning |

### Typography (1 rule)
| Rule | Description | Severity |
|------|-------------|----------|
| TYPO-060 | Smart/curly quotes inside lstlisting/verbatim environments | Warning |

### Spacing (4 rules)
| Rule | Description | Severity |
|------|-------------|----------|
| SPC-010 | Two spaces after sentence-ending period | Info |
| SPC-018 | No space after sentence-ending period (before uppercase) | Warning |
| SPC-022 | Tab character after \item bullet | Info |
| SPC-027 | Trailing whitespace inside \url{} | Warning |

## Test Results

```
[enc-char-spc] PASS 116 cases
[batch2]       PASS 93 cases
[strip-math]   PASS 8 cases
[strip-prop]   PASS 1000 trials (seed=12345)
[typo]         PASS 158 cases
[l1]           PASS 62 cases
```

All `dune build`, `dune fmt`, `dune runtest` green.

## Implementation Notes

- CHAR-005 excludes characters already covered by dedicated rules (CHAR-006/bell, CHAR-007/BS, CHAR-008/FF)
- CHAR-019 uses `strip_math_segments` to avoid false positives on U+2212 in math mode
- SPC-010 avoids overlap with SPC-031 (3+ spaces) by checking for exactly 2 spaces
- TYPO-060 scans for curly quote byte sequences specifically within lstlisting/verbatim blocks
- ENC-009 detects UTF-8 encoded surrogate sequences (ED A0-BF xx) which are invalid per RFC 3629

## Test plan
- [x] `dune build` — clean
- [x] `dune fmt` — clean (exit 0)
- [x] `dune runtest` — all 429 cases pass
- [x] No regressions in existing test suites