### PR TITLE
feat: L1 REF + CHEM validators (17 rules, 135 tests)

### DIFF
--- a/latex-parse/src/dune
+++ b/latex-parse/src/dune
@@ -266,3 +266,13 @@
  (name test_validators_math_l1b)
  (modules test_validators_math_l1b)
  (libraries latex_parse_lib unix))
+
+(test
+ (name test_validators_ref)
+ (modules test_validators_ref)
+ (libraries latex_parse_lib unix))
+
+(test
+ (name test_validators_chem)
+ (modules test_validators_chem)
+ (libraries latex_parse_lib unix))

--- a/latex-parse/src/test_validators_chem.ml
+++ b/latex-parse/src/test_validators_chem.ml
@@ -1,0 +1,289 @@
+(** Unit tests for CHEM validator rules (L1 chemistry notation). CHEM-001
+    through CHEM-009. *)
+
+open Latex_parse_lib
+
+let fails = ref 0
+let cases = ref 0
+
+let expect cond msg =
+  incr cases;
+  if not cond then (
+    Printf.eprintf "FAIL: %s\n%!" msg;
+    incr fails)
+
+let run msg f =
+  let tag = Printf.sprintf "case %d: %s" (!cases + 1) msg in
+  f tag
+
+let find_result id results =
+  List.find_opt (fun (r : Validators.result) -> r.id = id) results
+
+let fires id src =
+  let results = Validators.run_all src in
+  match find_result id results with Some _ -> true | None -> false
+
+let does_not_fire id src =
+  let results = Validators.run_all src in
+  match find_result id results with Some _ -> false | None -> true
+
+let fires_with_count id src expected_count =
+  let results = Validators.run_all src in
+  match find_result id results with
+  | Some r -> r.count = expected_count
+  | None -> false
+
+let () =
+  (* ══════════════════════════════════════════════════════════════════════
+     CHEM-001: Missing \ce{} wrapper for chemical formula
+     ══════════════════════════════════════════════════════════════════════ *)
+  run "CHEM-001 fires on H_2O in math" (fun tag ->
+      expect (fires "CHEM-001" "$H_2O$") (tag ^ ": H_2O"));
+  run "CHEM-001 fires on CO_2" (fun tag ->
+      expect (fires "CHEM-001" "$CO_2$") (tag ^ ": CO_2"));
+  run "CHEM-001 fires on Na_2 (multi-digit)" (fun tag ->
+      expect (fires "CHEM-001" "$Na_{23}$") (tag ^ ": Na_{23}"));
+  run "CHEM-001 clean: inside \\ce{}" (fun tag ->
+      expect (does_not_fire "CHEM-001" "$\\ce{H_2O}$") (tag ^ ": in ce"));
+  run "CHEM-001 clean: not in math" (fun tag ->
+      expect (does_not_fire "CHEM-001" "H_2O is water") (tag ^ ": not in math"));
+  run "CHEM-001 clean: no chemistry" (fun tag ->
+      expect (does_not_fire "CHEM-001" "$x + y = 0$") (tag ^ ": pure math"));
+
+  (* ══════════════════════════════════════════════════════════════════════
+     CHEM-002: Oxidation-state superscript missing braces
+     ══════════════════════════════════════════════════════════════════════ *)
+  run "CHEM-002 fires on Fe^2+" (fun tag ->
+      expect (fires "CHEM-002" "$Fe^2+$") (tag ^ ": Fe^2+"));
+  run "CHEM-002 fires on Cu^3+" (fun tag ->
+      expect (fires "CHEM-002" "$Cu^3+$") (tag ^ ": Cu^3+"));
+  run "CHEM-002 fires on O^2-" (fun tag ->
+      expect (fires "CHEM-002" "$O^2-$") (tag ^ ": O^2-"));
+  run "CHEM-002 clean: Fe^{2+}" (fun tag ->
+      expect (does_not_fire "CHEM-002" "$Fe^{2+}$") (tag ^ ": braced"));
+  run "CHEM-002 clean: not in math" (fun tag ->
+      expect (does_not_fire "CHEM-002" "Fe^2+ outside math") (tag ^ ": text"));
+  run "CHEM-002 fires on Na^1+ (single-letter element)" (fun tag ->
+      expect (fires "CHEM-002" "$N^1+$") (tag ^ ": N^1+"));
+
+  (* ══════════════════════════════════════════════════════════════════════
+     CHEM-003: Isotope mass number subscripted not superscripted
+     ══════════════════════════════════════════════════════════════════════ *)
+  run "CHEM-003 fires on _14C" (fun tag ->
+      expect (fires "CHEM-003" "$_14C$") (tag ^ ": _14C"));
+  run "CHEM-003 fires on _{14}C" (fun tag ->
+      expect (fires "CHEM-003" "$_{14}C$") (tag ^ ": _{14}C"));
+  run "CHEM-003 fires on _6C" (fun tag ->
+      expect (fires "CHEM-003" "$_6C$") (tag ^ ": _6C"));
+  run "CHEM-003 clean: ^{14}C" (fun tag ->
+      expect (does_not_fire "CHEM-003" "$^{14}C$") (tag ^ ": superscripted"));
+  run "CHEM-003 clean: normal subscript" (fun tag ->
+      expect (does_not_fire "CHEM-003" "$x_i$") (tag ^ ": variable subscript"));
+
+  (* ══════════════════════════════════════════════════════════════════════
+     CHEM-004: Charge written ^- instead of ^{-}
+     ══════════════════════════════════════════════════════════════════════ *)
+  run "CHEM-004 fires on Cl^-x" (fun tag ->
+      expect (fires "CHEM-004" "$Cl^-x$") (tag ^ ": Cl^-x"));
+  run "CHEM-004 fires on Na^+O" (fun tag ->
+      expect (fires "CHEM-004" "$Na^+O$") (tag ^ ": Na^+O"));
+  run "CHEM-004 clean: Cl^{-}" (fun tag ->
+      expect (does_not_fire "CHEM-004" "$Cl^{-}$") (tag ^ ": braced"));
+  run "CHEM-004 clean: Na^{+}" (fun tag ->
+      expect (does_not_fire "CHEM-004" "$Na^{+}$") (tag ^ ": braced +"));
+  run "CHEM-004 clean: not in math" (fun tag ->
+      expect (does_not_fire "CHEM-004" "Cl^-x outside") (tag ^ ": text"));
+
+  (* ══════════════════════════════════════════════════════════════════════
+     CHEM-005: Chemical arrow typed '->' not \rightarrow
+     ══════════════════════════════════════════════════════════════════════ *)
+  run "CHEM-005 fires on -> in math" (fun tag ->
+      expect (fires "CHEM-005" "$A -> B$") (tag ^ ": bare ->"));
+  run "CHEM-005 fires count=2" (fun tag ->
+      expect (fires_with_count "CHEM-005" "$A -> B -> C$" 2) (tag ^ ": count=2"));
+  run "CHEM-005 clean: \\rightarrow" (fun tag ->
+      expect
+        (does_not_fire "CHEM-005" "$A \\rightarrow B$")
+        (tag ^ ": rightarrow"));
+  run "CHEM-005 clean: \\longrightarrow" (fun tag ->
+      expect
+        (does_not_fire "CHEM-005" "$A \\longrightarrow B$")
+        (tag ^ ": longrightarrow"));
+  run "CHEM-005 clean: not in math" (fun tag ->
+      expect (does_not_fire "CHEM-005" "A -> B outside math") (tag ^ ": text"));
+
+  (* ══════════════════════════════════════════════════════════════════════
+     CHEM-006: Stoichiometry coefficient inside \ce missing
+     ══════════════════════════════════════════════════════════════════════ *)
+  run "CHEM-006 fires on \\ce{H2 + O2}" (fun tag ->
+      expect (fires "CHEM-006" "\\ce{H2 + O2}") (tag ^ ": missing coefficients"));
+  run "CHEM-006 fires on \\ce{Na + Cl2}" (fun tag ->
+      expect
+        (fires "CHEM-006" "\\ce{Na + Cl2}")
+        (tag ^ ": Na and Cl2 lack coefficients"));
+  run "CHEM-006 clean: \\ce{2H2 + O2}" (fun tag ->
+      expect
+        (does_not_fire "CHEM-006" "\\ce{2H2 + 1O2}")
+        (tag ^ ": has coefficients"));
+  run "CHEM-006 clean: \\ce{H2O} (no reaction)" (fun tag ->
+      expect (does_not_fire "CHEM-006" "\\ce{H2O}") (tag ^ ": no + sign"));
+  run "CHEM-006 clean: no \\ce at all" (fun tag ->
+      expect (does_not_fire "CHEM-006" "$H_2O$") (tag ^ ": no ce"));
+  run "CHEM-006 in math context" (fun tag ->
+      expect
+        (does_not_fire "CHEM-006" "$\\ce{H2O}$")
+        (tag ^ ": ce in math, no reaction"));
+
+  (* ══════════════════════════════════════════════════════════════════════
+     CHEM-007: Reaction conditions not in \text above arrow
+     ══════════════════════════════════════════════════════════════════════ *)
+  run "CHEM-007 fires on ->[heat]" (fun tag ->
+      expect (fires "CHEM-007" "$A ->[heat] B$") (tag ^ ": ->[heat]"));
+  run "CHEM-007 fires on ->[cat]" (fun tag ->
+      expect (fires "CHEM-007" "$X ->[cat] Y$") (tag ^ ": ->[cat]"));
+  run "CHEM-007 clean: ->[\\text{heat}]" (fun tag ->
+      expect
+        (does_not_fire "CHEM-007" "$A ->[\\text{heat}] B$")
+        (tag ^ ": text wrapped"));
+  run "CHEM-007 clean: no arrow conditions" (fun tag ->
+      expect (does_not_fire "CHEM-007" "$A -> B$") (tag ^ ": no brackets"));
+  run "CHEM-007 clean: empty brackets" (fun tag ->
+      expect (does_not_fire "CHEM-007" "$A ->[] B$") (tag ^ ": empty brackets"));
+
+  (* ══════════════════════════════════════════════════════════════════════
+     CHEM-008: State symbols (aq)/(s)/(l)/(g) not wrapped in \text
+     ══════════════════════════════════════════════════════════════════════ *)
+  run "CHEM-008 fires on bare (aq)" (fun tag ->
+      expect (fires "CHEM-008" "$NaCl(aq)$") (tag ^ ": bare (aq)"));
+  run "CHEM-008 fires on bare (s)" (fun tag ->
+      expect (fires "CHEM-008" "$NaCl(s)$") (tag ^ ": bare (s)"));
+  run "CHEM-008 fires on bare (l)" (fun tag ->
+      expect (fires "CHEM-008" "$H_2O(l)$") (tag ^ ": bare (l)"));
+  run "CHEM-008 fires on bare (g)" (fun tag ->
+      expect (fires "CHEM-008" "$CO_2(g)$") (tag ^ ": bare (g)"));
+  run "CHEM-008 clean: \\text{(aq)}" (fun tag ->
+      expect
+        (does_not_fire "CHEM-008" "$NaCl\\text{(aq)}$")
+        (tag ^ ": text wrapped"));
+  run "CHEM-008 clean: no state symbols" (fun tag ->
+      expect (does_not_fire "CHEM-008" "$x + y$") (tag ^ ": no states"));
+  run "CHEM-008 clean: not in math" (fun tag ->
+      expect
+        (does_not_fire "CHEM-008" "NaCl(aq) is dissolved in water")
+        (tag ^ ": text mode"));
+
+  (* ══════════════════════════════════════════════════════════════════════
+     CHEM-009: Equilibrium arrow typed as <> or <->
+     ══════════════════════════════════════════════════════════════════════ *)
+  run "CHEM-009 fires on <->" (fun tag ->
+      expect (fires "CHEM-009" "$A <-> B$") (tag ^ ": <->"));
+  run "CHEM-009 fires on <=>" (fun tag ->
+      expect (fires "CHEM-009" "$A <=> B$") (tag ^ ": <=>"));
+  run "CHEM-009 fires count=2" (fun tag ->
+      expect
+        (fires_with_count "CHEM-009" "$A <-> B <=> C$" 2)
+        (tag ^ ": count=2"));
+  run "CHEM-009 clean: \\rightleftharpoons" (fun tag ->
+      expect
+        (does_not_fire "CHEM-009" "$A \\rightleftharpoons B$")
+        (tag ^ ": proper symbol"));
+  run "CHEM-009 clean: not in math" (fun tag ->
+      expect (does_not_fire "CHEM-009" "A <-> B outside") (tag ^ ": text"));
+
+  (* ══════════════════════════════════════════════════════════════════════
+     Cross-cutting edge cases
+     ══════════════════════════════════════════════════════════════════════ *)
+  run "empty input: no CHEM rules fire" (fun tag ->
+      let results = Validators.run_all "" in
+      let chem_fires =
+        List.filter
+          (fun (r : Validators.result) ->
+            String.length r.id >= 5 && String.sub r.id 0 5 = "CHEM-")
+          results
+      in
+      expect (chem_fires = []) (tag ^ ": no CHEM on empty"));
+
+  run "clean math: no CHEM rules fire" (fun tag ->
+      let results = Validators.run_all "$x^{2} + y_{1} = 0$" in
+      let chem_fires =
+        List.filter
+          (fun (r : Validators.result) ->
+            String.length r.id >= 5 && String.sub r.id 0 5 = "CHEM-")
+          results
+      in
+      expect (chem_fires = []) (tag ^ ": no CHEM on clean math"));
+
+  (* Registration: verify each CHEM rule fires on known-bad input *)
+  run "registration: CHEM-001" (fun tag ->
+      expect (fires "CHEM-001" "$H_2O$") (tag ^ ": registered"));
+  run "registration: CHEM-002" (fun tag ->
+      expect (fires "CHEM-002" "$Fe^2+$") (tag ^ ": registered"));
+  run "registration: CHEM-003" (fun tag ->
+      expect (fires "CHEM-003" "$_{14}C$") (tag ^ ": registered"));
+  run "registration: CHEM-004" (fun tag ->
+      expect (fires "CHEM-004" "$Cl^-x$") (tag ^ ": registered"));
+  run "registration: CHEM-005" (fun tag ->
+      expect (fires "CHEM-005" "$A -> B$") (tag ^ ": registered"));
+  run "registration: CHEM-006" (fun tag ->
+      expect (fires "CHEM-006" "\\ce{Na + Cl}") (tag ^ ": registered"));
+  run "registration: CHEM-007" (fun tag ->
+      expect (fires "CHEM-007" "$->[heat]$") (tag ^ ": registered"));
+  run "registration: CHEM-008" (fun tag ->
+      expect (fires "CHEM-008" "$NaCl(aq)$") (tag ^ ": registered"));
+  run "registration: CHEM-009" (fun tag ->
+      expect (fires "CHEM-009" "$A <-> B$") (tag ^ ": registered"));
+
+  (* Precondition check *)
+  run "precondition: CHEM- maps to L1" (fun tag ->
+      expect
+        (Validators.precondition_of_rule_id "CHEM-001" = L1)
+        (tag ^ ": L1 layer"));
+
+  (* Severity checks *)
+  run "severity: CHEM-001 is Warning" (fun tag ->
+      let results = Validators.run_all "$H_2O$" in
+      match find_result "CHEM-001" results with
+      | Some r -> expect (r.severity = Warning) (tag ^ ": Warning")
+      | None -> expect false (tag ^ ": should fire"));
+  run "severity: CHEM-004 is Info" (fun tag ->
+      let results = Validators.run_all "$Cl^-x$" in
+      match find_result "CHEM-004" results with
+      | Some r -> expect (r.severity = Info) (tag ^ ": Info")
+      | None -> expect false (tag ^ ": should fire"));
+  run "severity: CHEM-009 is Warning" (fun tag ->
+      let results = Validators.run_all "$A <-> B$" in
+      match find_result "CHEM-009" results with
+      | Some r -> expect (r.severity = Warning) (tag ^ ": Warning")
+      | None -> expect false (tag ^ ": should fire"));
+
+  (* Combined multi-rule test *)
+  run "combined: chemistry document fires multiple rules" (fun tag ->
+      let src = "$Fe^2+ + H_2O -> Fe^{2+}(aq)$" in
+      expect (fires "CHEM-002" src) (tag ^ ": CHEM-002 (Fe^2+)");
+      expect (fires "CHEM-005" src) (tag ^ ": CHEM-005 (->)");
+      expect (fires "CHEM-008" src) (tag ^ ": CHEM-008 ((aq))"));
+
+  (* \ce{} context: rules that operate inside \ce should work *)
+  run "CHEM-006 with nested braces in \\ce" (fun tag ->
+      expect
+        (does_not_fire "CHEM-006" "\\ce{2H2O}")
+        (tag ^ ": single compound ok"));
+
+  (* Stress test: repeated calls don't accumulate state *)
+  run "stress: 50 repeated calls" (fun tag ->
+      let ok = ref true in
+      for _ = 1 to 50 do
+        let results = Validators.run_all "$Fe^2+$" in
+        match find_result "CHEM-002" results with
+        | Some r -> if r.count <> 1 then ok := false
+        | None -> ok := false
+      done;
+      expect !ok (tag ^ ": stable across 50 calls"));
+
+  (* Summary *)
+  Printf.printf "[chem] %s %d cases\n"
+    (if !fails = 0 then "PASS" else "FAIL")
+    !cases;
+  if !fails > 0 then (
+    Printf.eprintf "[chem] %d / %d failures\n" !fails !cases;
+    exit 1)

--- a/latex-parse/src/test_validators_ref.ml
+++ b/latex-parse/src/test_validators_ref.ml
@@ -1,0 +1,287 @@
+(** Unit tests for REF validator rules (L1 cross-referencing / label hygiene).
+    REF-001 through REF-009, excluding REF-008 (L3_Semantics). *)
+
+open Latex_parse_lib
+
+let fails = ref 0
+let cases = ref 0
+
+let expect cond msg =
+  incr cases;
+  if not cond then (
+    Printf.eprintf "FAIL: %s\n%!" msg;
+    incr fails)
+
+let run msg f =
+  let tag = Printf.sprintf "case %d: %s" (!cases + 1) msg in
+  f tag
+
+let find_result id results =
+  List.find_opt (fun (r : Validators.result) -> r.id = id) results
+
+let fires id src =
+  let results = Validators.run_all src in
+  match find_result id results with Some _ -> true | None -> false
+
+let does_not_fire id src =
+  let results = Validators.run_all src in
+  match find_result id results with Some _ -> false | None -> true
+
+let fires_with_count id src expected_count =
+  let results = Validators.run_all src in
+  match find_result id results with
+  | Some r -> r.count = expected_count
+  | None -> false
+
+let () =
+  (* ══════════════════════════════════════════════════════════════════════
+     REF-001: Undefined \ref/\eqref label after expansion
+     ══════════════════════════════════════════════════════════════════════ *)
+  run "REF-001 fires on undefined ref" (fun tag ->
+      expect
+        (fires "REF-001" "See \\ref{eq:missing} for details.")
+        (tag ^ ": undefined ref"));
+  run "REF-001 fires on undefined eqref" (fun tag ->
+      expect
+        (fires "REF-001" "See \\eqref{eq:missing} for details.")
+        (tag ^ ": undefined eqref"));
+  run "REF-001 fires count=2" (fun tag ->
+      expect
+        (fires_with_count "REF-001" "See \\ref{eq:a} and \\ref{eq:b}." 2)
+        (tag ^ ": count=2"));
+  run "REF-001 clean: ref has matching label" (fun tag ->
+      expect
+        (does_not_fire "REF-001" "\\label{eq:main} See \\ref{eq:main}.")
+        (tag ^ ": matching label"));
+  run "REF-001 clean: eqref has matching label" (fun tag ->
+      expect
+        (does_not_fire "REF-001" "\\label{eq:main} See \\eqref{eq:main}.")
+        (tag ^ ": matching eqref"));
+  run "REF-001 clean: no refs at all" (fun tag ->
+      expect (does_not_fire "REF-001" "No references here.") (tag ^ ": no refs"));
+  run "REF-001 partial: one matching, one undefined" (fun tag ->
+      expect
+        (fires_with_count "REF-001"
+           "\\label{eq:ok} See \\ref{eq:ok} and \\ref{eq:bad}." 1)
+        (tag ^ ": one undefined"));
+
+  (* ══════════════════════════════════════════════════════════════════════
+     REF-002: Duplicate label name
+     ══════════════════════════════════════════════════════════════════════ *)
+  run "REF-002 fires on duplicate labels" (fun tag ->
+      expect
+        (fires "REF-002" "\\label{eq:main} some text \\label{eq:main}")
+        (tag ^ ": duplicate"));
+  run "REF-002 fires count=1 (two copies = one dup)" (fun tag ->
+      expect
+        (fires_with_count "REF-002" "\\label{eq:main} x \\label{eq:main}" 1)
+        (tag ^ ": count=1"));
+  run "REF-002 fires count=2 (three copies)" (fun tag ->
+      expect
+        (fires_with_count "REF-002" "\\label{eq:x} \\label{eq:x} \\label{eq:x}"
+           2)
+        (tag ^ ": count=2 for three copies"));
+  run "REF-002 clean: distinct labels" (fun tag ->
+      expect
+        (does_not_fire "REF-002" "\\label{eq:a} \\label{eq:b} \\label{eq:c}")
+        (tag ^ ": distinct labels"));
+  run "REF-002 clean: no labels" (fun tag ->
+      expect (does_not_fire "REF-002" "No labels here.") (tag ^ ": no labels"));
+
+  (* ══════════════════════════════════════════════════════════════════════
+     REF-003: Label contains spaces
+     ══════════════════════════════════════════════════════════════════════ *)
+  run "REF-003 fires on label with space" (fun tag ->
+      expect (fires "REF-003" "\\label{eq main}") (tag ^ ": space in label"));
+  run "REF-003 fires count=2" (fun tag ->
+      expect
+        (fires_with_count "REF-003" "\\label{eq main} \\label{fig diagram}" 2)
+        (tag ^ ": count=2"));
+  run "REF-003 clean: no spaces" (fun tag ->
+      expect (does_not_fire "REF-003" "\\label{eq:main}") (tag ^ ": no space"));
+  run "REF-003 clean: no labels" (fun tag ->
+      expect (does_not_fire "REF-003" "Just text.") (tag ^ ": no labels"));
+
+  (* ══════════════════════════════════════════════════════════════════════
+     REF-004: Label contains uppercase letters
+     ══════════════════════════════════════════════════════════════════════ *)
+  run "REF-004 fires on uppercase label" (fun tag ->
+      expect (fires "REF-004" "\\label{eq:Main}") (tag ^ ": uppercase"));
+  run "REF-004 fires on ALL CAPS" (fun tag ->
+      expect (fires "REF-004" "\\label{FIG:DIAGRAM}") (tag ^ ": all caps"));
+  run "REF-004 fires count=2" (fun tag ->
+      expect
+        (fires_with_count "REF-004" "\\label{eq:Main} \\label{sec:Intro}" 2)
+        (tag ^ ": count=2"));
+  run "REF-004 clean: all lowercase" (fun tag ->
+      expect (does_not_fire "REF-004" "\\label{eq:main}") (tag ^ ": lowercase"));
+  run "REF-004 clean: digits and colons" (fun tag ->
+      expect
+        (does_not_fire "REF-004" "\\label{eq:123-test}")
+        (tag ^ ": no uppercase"));
+
+  (* ══════════════════════════════════════════════════════════════════════
+     REF-005: Label not prefixed fig:/tab:/eq:/sec: etc.
+     ══════════════════════════════════════════════════════════════════════ *)
+  run "REF-005 fires on unprefixed label" (fun tag ->
+      expect (fires "REF-005" "\\label{main}") (tag ^ ": no prefix"));
+  run "REF-005 fires on numeric label" (fun tag ->
+      expect (fires "REF-005" "\\label{1234}") (tag ^ ": numeric"));
+  run "REF-005 clean: fig: prefix" (fun tag ->
+      expect (does_not_fire "REF-005" "\\label{fig:diagram}") (tag ^ ": fig:"));
+  run "REF-005 clean: tab: prefix" (fun tag ->
+      expect (does_not_fire "REF-005" "\\label{tab:results}") (tag ^ ": tab:"));
+  run "REF-005 clean: eq: prefix" (fun tag ->
+      expect (does_not_fire "REF-005" "\\label{eq:main}") (tag ^ ": eq:"));
+  run "REF-005 clean: sec: prefix" (fun tag ->
+      expect (does_not_fire "REF-005" "\\label{sec:intro}") (tag ^ ": sec:"));
+  run "REF-005 clean: thm: prefix" (fun tag ->
+      expect (does_not_fire "REF-005" "\\label{thm:main}") (tag ^ ": thm:"));
+  run "REF-005 clean: alg: prefix" (fun tag ->
+      expect (does_not_fire "REF-005" "\\label{alg:sort}") (tag ^ ": alg:"));
+
+  (* ══════════════════════════════════════════════════════════════════════
+     REF-006: Page reference uses \ref not \pageref
+     ══════════════════════════════════════════════════════════════════════ *)
+  run "REF-006 fires on page \\ref" (fun tag ->
+      expect (fires "REF-006" "page \\ref{eq:main}") (tag ^ ": page ref"));
+  run "REF-006 fires on Page \\ref" (fun tag ->
+      expect (fires "REF-006" "Page \\ref{sec:intro}") (tag ^ ": Page ref"));
+  run "REF-006 fires with tilde" (fun tag ->
+      expect (fires "REF-006" "page~\\ref{eq:main}") (tag ^ ": tilde"));
+  run "REF-006 clean: \\pageref" (fun tag ->
+      expect
+        (does_not_fire "REF-006" "page \\pageref{eq:main}")
+        (tag ^ ": pageref"));
+  run "REF-006 clean: regular \\ref" (fun tag ->
+      expect (does_not_fire "REF-006" "See \\ref{eq:main}.") (tag ^ ": not page"));
+
+  (* ══════════════════════════════════════════════════════════════════════
+     REF-007: Cite key contains whitespace
+     ══════════════════════════════════════════════════════════════════════ *)
+  run "REF-007 fires on cite with space" (fun tag ->
+      expect (fires "REF-007" "\\cite{jones 2020}") (tag ^ ": space in cite"));
+  run "REF-007 fires on cite with tab" (fun tag ->
+      expect (fires "REF-007" "\\cite{jones\t2020}") (tag ^ ": tab in cite"));
+  run "REF-007 clean: no whitespace" (fun tag ->
+      expect (does_not_fire "REF-007" "\\cite{jones2020}") (tag ^ ": clean cite"));
+  run "REF-007 clean: no cite" (fun tag ->
+      expect (does_not_fire "REF-007" "No citations here.") (tag ^ ": no cite"));
+
+  (* ══════════════════════════════════════════════════════════════════════
+     REF-009: Reference appears before label definition (forward ref)
+     ══════════════════════════════════════════════════════════════════════ *)
+  run "REF-009 fires on forward ref" (fun tag ->
+      expect
+        (fires "REF-009" "See \\ref{eq:main}. \\label{eq:main}")
+        (tag ^ ": forward ref"));
+  run "REF-009 fires on forward eqref" (fun tag ->
+      expect
+        (fires "REF-009" "See \\eqref{eq:main}. \\label{eq:main}")
+        (tag ^ ": forward eqref"));
+  run "REF-009 clean: label before ref" (fun tag ->
+      expect
+        (does_not_fire "REF-009" "\\label{eq:main} See \\ref{eq:main}.")
+        (tag ^ ": backward ref ok"));
+  run "REF-009 clean: no refs" (fun tag ->
+      expect (does_not_fire "REF-009" "No references.") (tag ^ ": no refs"));
+
+  (* ══════════════════════════════════════════════════════════════════════
+     Cross-cutting edge cases
+     ══════════════════════════════════════════════════════════════════════ *)
+  run "empty input: no REF rules fire" (fun tag ->
+      let results = Validators.run_all "" in
+      let ref_fires =
+        List.filter
+          (fun (r : Validators.result) ->
+            String.length r.id >= 4 && String.sub r.id 0 4 = "REF-")
+          results
+      in
+      expect (ref_fires = []) (tag ^ ": no REF on empty input"));
+
+  run "no label/ref content: no REF fires" (fun tag ->
+      let results = Validators.run_all "Plain text with $x + y = 0$." in
+      let ref_fires =
+        List.filter
+          (fun (r : Validators.result) ->
+            String.length r.id >= 4 && String.sub r.id 0 4 = "REF-")
+          results
+      in
+      expect (ref_fires = []) (tag ^ ": no REF on plain text"));
+
+  (* Registration: verify each REF rule fires on known-bad input *)
+  run "registration: REF-001 registered" (fun tag ->
+      expect (fires "REF-001" "See \\ref{eq:missing}.") (tag ^ ": registered"));
+  run "registration: REF-002 registered" (fun tag ->
+      expect
+        (fires "REF-002" "\\label{eq:x} \\label{eq:x}")
+        (tag ^ ": registered"));
+  run "registration: REF-003 registered" (fun tag ->
+      expect (fires "REF-003" "\\label{eq main}") (tag ^ ": registered"));
+  run "registration: REF-004 registered" (fun tag ->
+      expect (fires "REF-004" "\\label{eq:Main}") (tag ^ ": registered"));
+  run "registration: REF-005 registered" (fun tag ->
+      expect (fires "REF-005" "\\label{main}") (tag ^ ": registered"));
+  run "registration: REF-006 registered" (fun tag ->
+      expect (fires "REF-006" "page \\ref{eq:x}") (tag ^ ": registered"));
+  run "registration: REF-007 registered" (fun tag ->
+      expect (fires "REF-007" "\\cite{a b}") (tag ^ ": registered"));
+  run "registration: REF-009 registered" (fun tag ->
+      expect (fires "REF-009" "\\ref{eq:x} \\label{eq:x}") (tag ^ ": registered"));
+
+  (* Precondition check *)
+  run "precondition: REF- maps to L1" (fun tag ->
+      expect
+        (Validators.precondition_of_rule_id "REF-001" = L1)
+        (tag ^ ": L1 layer"));
+
+  (* Severity checks *)
+  run "severity: REF-001 is Error" (fun tag ->
+      let results = Validators.run_all "\\ref{missing}" in
+      match find_result "REF-001" results with
+      | Some r -> expect (r.severity = Error) (tag ^ ": Error severity")
+      | None -> expect false (tag ^ ": should fire"));
+  run "severity: REF-003 is Warning" (fun tag ->
+      let results = Validators.run_all "\\label{eq main}" in
+      match find_result "REF-003" results with
+      | Some r -> expect (r.severity = Warning) (tag ^ ": Warning severity")
+      | None -> expect false (tag ^ ": should fire"));
+  run "severity: REF-004 is Info" (fun tag ->
+      let results = Validators.run_all "\\label{eq:Main}" in
+      match find_result "REF-004" results with
+      | Some r -> expect (r.severity = Info) (tag ^ ": Info severity")
+      | None -> expect false (tag ^ ": should fire"));
+
+  (* Combined multi-rule test *)
+  run "combined: multiple REF rules fire" (fun tag ->
+      let src =
+        "\\label{eq Main} \\label{eq Main} See page \\ref{eq:missing}."
+      in
+      expect (fires "REF-001" src) (tag ^ ": REF-001 fires");
+      expect (fires "REF-002" src) (tag ^ ": REF-002 fires");
+      expect (fires "REF-003" src) (tag ^ ": REF-003 fires");
+      expect (fires "REF-004" src) (tag ^ ": REF-004 fires");
+      expect (fires "REF-005" src) (tag ^ ": REF-005 fires");
+      expect (fires "REF-006" src) (tag ^ ": REF-006 fires"));
+
+  (* Real-document test: proper LaTeX with labels and refs *)
+  run "real document: clean labels and refs" (fun tag ->
+      let src =
+        "\\section{Introduction}\\label{sec:intro}\n\
+         As shown in Figure~\\ref{fig:diagram}, the result follows.\n\
+         \\begin{figure}\\label{fig:diagram}\n\
+         \\end{figure}\n\
+         See Equation~\\eqref{eq:main}.\n\
+         \\label{eq:main} $E = mc^2$"
+      in
+      expect (does_not_fire "REF-001" src) (tag ^ ": no undefined refs");
+      expect (does_not_fire "REF-002" src) (tag ^ ": no duplicate labels");
+      expect (does_not_fire "REF-003" src) (tag ^ ": no spaces in labels"));
+
+  (* Summary *)
+  Printf.printf "[ref] %s %d cases\n"
+    (if !fails = 0 then "PASS" else "FAIL")
+    !cases;
+  if !fails > 0 then (
+    Printf.eprintf "[ref] %d / %d failures\n" !fails !cases;
+    exit 1)


### PR DESCRIPTION
## Summary
- **8 REF validators** (REF-001..009, excluding REF-008/L3_Semantics): cross-referencing and label hygiene
  - REF-001: Undefined \ref/\eqref label
  - REF-002: Duplicate label name
  - REF-003: Label contains spaces
  - REF-004: Label contains uppercase letters
  - REF-005: Label not prefixed (fig:/tab:/eq:/sec: etc.)
  - REF-006: Page reference uses \ref not \pageref
  - REF-007: Cite key contains whitespace
  - REF-009: Forward reference (ref before label)

- **9 CHEM validators** (CHEM-001..009): chemistry notation
  - CHEM-001: Missing \ce{} wrapper for chemical formula
  - CHEM-002: Oxidation-state superscript missing braces
  - CHEM-003: Isotope mass number subscripted not superscripted
  - CHEM-004: Charge written ^- instead of ^{-}
  - CHEM-005: Chemical arrow typed -> not \rightarrow
  - CHEM-006: Stoichiometry coefficient inside \ce missing
  - CHEM-007: Reaction conditions not in \text above arrow
  - CHEM-008: State symbols (aq)/(s)/(l)/(g) not in \text
  - CHEM-009: Equilibrium arrow typed as <->/<=>

- **135 new tests** (65 REF + 70 CHEM) covering fires/clean/count/registration/severity/cross-cutting/combined/stress
- Precondition routing updated for REF- and CHEM- prefixes → L1
- CHEM-006 uses manual substring scanning to avoid Str global state corruption
- REF-007 uses regular string for tab character in character class

## Test plan
- [x] `dune build` clean — no warnings
- [x] `dune runtest` — all 14 suites pass (1,334 total cases)
  - strip-math: 8, strip-prop: 1000, enc-char-spc: 152, batch2: 122, typo: 196
  - verb-cjk-cmd: 53, batch5: 75, l1: 78, delim: 49, script: 96
  - math-l1: 67, math-l1b: 145, **ref: 65**, **chem: 70**
- [x] No regressions in existing test suites