### PR TITLE
feat: L1 MATH-C Part 3 — 14 remaining rules

### DIFF
--- a/latex-parse/src/dune
+++ b/latex-parse/src/dune
@@ -296,3 +296,8 @@
  (name test_validators_math_c2)
  (modules test_validators_math_c2)
  (libraries latex_parse_lib unix))
+
+(test
+ (name test_validators_math_c3)
+ (modules test_validators_math_c3)
+ (libraries latex_parse_lib unix))

--- a/latex-parse/src/test_validators_math_c3.ml
+++ b/latex-parse/src/test_validators_math_c3.ml
@@ -1,0 +1,299 @@
+(** Unit tests for MATH-C Part 3: MATH-072..108 remaining rules. *)
+
+open Latex_parse_lib
+
+let fails = ref 0
+let cases = ref 0
+
+let expect cond msg =
+  if not cond then (
+    Printf.eprintf "[math-c3] FAIL: %s\n%!" msg;
+    incr fails)
+
+let run msg f =
+  incr cases;
+  f msg
+
+let find_result id src =
+  let results = Validators.run_all src in
+  List.find_opt (fun (r : Validators.result) -> r.id = id) results
+
+let fires id src = find_result id src <> None
+
+let fires_with_count id src expected_count =
+  match find_result id src with
+  | Some r -> r.count = expected_count
+  | None -> false
+
+let does_not_fire id src = find_result id src = None
+
+let () =
+  (* ════════════════════════════════════════════════════════════════════
+     MATH-072: \operatorname for predefined function
+     ════════════════════════════════════════════════════════════════════ *)
+  run "MATH-072 fires on operatorname{det}" (fun tag ->
+      expect (fires "MATH-072" "$\\operatorname{det}(A)$") (tag ^ ": det"));
+  run "MATH-072 fires on operatorname{sin}" (fun tag ->
+      expect (fires "MATH-072" "$\\operatorname{sin}(x)$") (tag ^ ": sin"));
+  run "MATH-072 severity=Warning" (fun tag ->
+      match find_result "MATH-072" "$\\operatorname{det}(A)$" with
+      | Some r -> expect (r.severity = Validators.Warning) (tag ^ ": Warning")
+      | None -> expect false (tag ^ ": should fire"));
+  run "MATH-072 clean custom operator" (fun tag ->
+      expect
+        (does_not_fire "MATH-072" "$\\operatorname{Tr}(A)$")
+        (tag ^ ": custom Tr ok"));
+  run "MATH-072 clean no operatorname" (fun tag ->
+      expect (does_not_fire "MATH-072" "$\\det(A)$") (tag ^ ": none"));
+
+  (* ════════════════════════════════════════════════════════════════════
+     MATH-074: TikZ \node inside math without math mode key
+     ════════════════════════════════════════════════════════════════════ *)
+  run "MATH-074 fires on node in math" (fun tag ->
+      expect (fires "MATH-074" "$\\node at (0,0) {x};$") (tag ^ ": node in math"));
+  run "MATH-074 severity=Warning" (fun tag ->
+      match find_result "MATH-074" "$\\node at (0,0) {x};$" with
+      | Some r -> expect (r.severity = Validators.Warning) (tag ^ ": Warning")
+      | None -> expect false (tag ^ ": should fire"));
+  run "MATH-074 clean with math mode" (fun tag ->
+      expect
+        (does_not_fire "MATH-074" "$\\node[math mode] at (0,0) {x};$")
+        (tag ^ ": math mode ok"));
+  run "MATH-074 clean no node" (fun tag ->
+      expect (does_not_fire "MATH-074" "$x + y$") (tag ^ ": no node"));
+
+  (* ════════════════════════════════════════════════════════════════════
+     MATH-087: Fake bold digits via \mathbf
+     ════════════════════════════════════════════════════════════════════ *)
+  run "MATH-087 fires on mathbf digits" (fun tag ->
+      expect (fires "MATH-087" "$\\mathbf{42}$") (tag ^ ": bold digits"));
+  run "MATH-087 fires on single digit" (fun tag ->
+      expect (fires "MATH-087" "$\\mathbf{0}$") (tag ^ ": single digit"));
+  run "MATH-087 severity=Info" (fun tag ->
+      match find_result "MATH-087" "$\\mathbf{42}$" with
+      | Some r -> expect (r.severity = Validators.Info) (tag ^ ": Info")
+      | None -> expect false (tag ^ ": should fire"));
+  run "MATH-087 clean mathbf letters" (fun tag ->
+      expect (does_not_fire "MATH-087" "$\\mathbf{ABC}$") (tag ^ ": letters ok"));
+  run "MATH-087 clean no mathbf" (fun tag ->
+      expect (does_not_fire "MATH-087" "$42$") (tag ^ ": no mathbf"));
+
+  (* ════════════════════════════════════════════════════════════════════
+     MATH-088: Bare \partial lacks thin space
+     ════════════════════════════════════════════════════════════════════ *)
+  run "MATH-088 fires on partial without spacing" (fun tag ->
+      expect
+        (fires "MATH-088" "$x\\partial y$")
+        (tag ^ ": no space around partial"));
+  run "MATH-088 severity=Info" (fun tag ->
+      match find_result "MATH-088" "$x\\partial y$" with
+      | Some r -> expect (r.severity = Validators.Info) (tag ^ ": Info")
+      | None -> expect false (tag ^ ": should fire"));
+  run "MATH-088 clean with spacing" (fun tag ->
+      expect (does_not_fire "MATH-088" "$\\partial{f}$") (tag ^ ": braced ok"));
+  run "MATH-088 clean no partial" (fun tag ->
+      expect (does_not_fire "MATH-088" "$x + y$") (tag ^ ": no partial"));
+
+  (* ════════════════════════════════════════════════════════════════════
+     MATH-091: \operatorname{X} when predefined \X exists
+     ════════════════════════════════════════════════════════════════════ *)
+  run "MATH-091 fires on operatorname{det}" (fun tag ->
+      expect (fires "MATH-091" "$\\operatorname{det}(A)$") (tag ^ ": det"));
+  run "MATH-091 fires on operatorname{lim}" (fun tag ->
+      expect (fires "MATH-091" "$\\operatorname{lim}_{n}$") (tag ^ ": lim"));
+  run "MATH-091 severity=Info" (fun tag ->
+      match find_result "MATH-091" "$\\operatorname{sin}(x)$" with
+      | Some r -> expect (r.severity = Validators.Info) (tag ^ ": Info")
+      | None -> expect false (tag ^ ": should fire"));
+  run "MATH-091 clean custom op" (fun tag ->
+      expect
+        (does_not_fire "MATH-091" "$\\operatorname{Tr}(A)$")
+        (tag ^ ": custom Tr"));
+  run "MATH-091 clean no operatorname" (fun tag ->
+      expect (does_not_fire "MATH-091" "$\\sin(x)$") (tag ^ ": none"));
+
+  (* ════════════════════════════════════════════════════════════════════
+     MATH-092: \sum with explicit limits in inline math
+     ════════════════════════════════════════════════════════════════════ *)
+  run "MATH-092 fires on sum with limits inline" (fun tag ->
+      expect (fires "MATH-092" "$\\sum_{i=1}^{n} x_i$") (tag ^ ": sum_ inline"));
+  run "MATH-092 severity=Info" (fun tag ->
+      match find_result "MATH-092" "$\\sum_{i}$" with
+      | Some r -> expect (r.severity = Validators.Info) (tag ^ ": Info")
+      | None -> expect false (tag ^ ": should fire"));
+  run "MATH-092 clean in display math" (fun tag ->
+      expect
+        (does_not_fire "MATH-092" "\\[\\sum_{i=1}^{n}\\]")
+        (tag ^ ": display ok"));
+  run "MATH-092 clean sum without limits" (fun tag ->
+      expect (does_not_fire "MATH-092" "$\\sum x_i$") (tag ^ ": no limits ok"));
+
+  (* ════════════════════════════════════════════════════════════════════
+     MATH-095: Log base without braces (alias of MATH-061)
+     ════════════════════════════════════════════════════════════════════ *)
+  run "MATH-095 fires on log_10x" (fun tag ->
+      expect (fires "MATH-095" "$\\log_10 x$") (tag ^ ": log_10x"));
+  run "MATH-095 severity=Warning" (fun tag ->
+      match find_result "MATH-095" "$\\log_10 x$" with
+      | Some r -> expect (r.severity = Validators.Warning) (tag ^ ": Warning")
+      | None -> expect false (tag ^ ": should fire"));
+  run "MATH-095 clean braced" (fun tag ->
+      expect (does_not_fire "MATH-095" "$\\log_{10} x$") (tag ^ ": braced ok"));
+
+  (* ════════════════════════════════════════════════════════════════════
+     MATH-096: Bold Greek via \mathbf
+     ════════════════════════════════════════════════════════════════════ *)
+  run "MATH-096 fires on mathbf{alpha}" (fun tag ->
+      expect (fires "MATH-096" "$\\mathbf{\\alpha}$") (tag ^ ": bold alpha"));
+  run "MATH-096 fires on mathbf{Gamma}" (fun tag ->
+      expect (fires "MATH-096" "$\\mathbf{\\Gamma}$") (tag ^ ": bold Gamma"));
+  run "MATH-096 severity=Info" (fun tag ->
+      match find_result "MATH-096" "$\\mathbf{\\alpha}$" with
+      | Some r -> expect (r.severity = Validators.Info) (tag ^ ": Info")
+      | None -> expect false (tag ^ ": should fire"));
+  run "MATH-096 clean boldsymbol" (fun tag ->
+      expect
+        (does_not_fire "MATH-096" "$\\boldsymbol{\\alpha}$")
+        (tag ^ ": boldsymbol ok"));
+  run "MATH-096 clean mathbf on letters" (fun tag ->
+      expect (does_not_fire "MATH-096" "$\\mathbf{x}$") (tag ^ ": non-Greek ok"));
+
+  (* ════════════════════════════════════════════════════════════════════
+     MATH-097: Arrow => instead of \implies
+     ════════════════════════════════════════════════════════════════════ *)
+  run "MATH-097 fires on =>" (fun tag ->
+      expect (fires "MATH-097" "$a => b$") (tag ^ ": => in math"));
+  run "MATH-097 severity=Info" (fun tag ->
+      match find_result "MATH-097" "$a => b$" with
+      | Some r -> expect (r.severity = Validators.Info) (tag ^ ": Info")
+      | None -> expect false (tag ^ ": should fire"));
+  run "MATH-097 clean implies" (fun tag ->
+      expect (does_not_fire "MATH-097" "$a \\implies b$") (tag ^ ": implies ok"));
+  run "MATH-097 clean >=" (fun tag ->
+      expect (does_not_fire "MATH-097" "$a >= b$") (tag ^ ": >= ok"));
+  run "MATH-097 clean outside math" (fun tag ->
+      expect (does_not_fire "MATH-097" "a => b") (tag ^ ": outside math"));
+
+  (* ════════════════════════════════════════════════════════════════════
+     MATH-099: Large operator in inline math
+     ════════════════════════════════════════════════════════════════════ *)
+  run "MATH-099 fires on bigcup inline" (fun tag ->
+      expect (fires "MATH-099" "$\\bigcup_{i} A_i$") (tag ^ ": bigcup inline"));
+  run "MATH-099 fires on bigcap inline" (fun tag ->
+      expect (fires "MATH-099" "$\\bigcap_{i} A_i$") (tag ^ ": bigcap inline"));
+  run "MATH-099 fires on bigoplus inline" (fun tag ->
+      expect
+        (fires "MATH-099" "$\\bigoplus_{i} V_i$")
+        (tag ^ ": bigoplus inline"));
+  run "MATH-099 severity=Info" (fun tag ->
+      match find_result "MATH-099" "$\\bigcup_{i} A_i$" with
+      | Some r -> expect (r.severity = Validators.Info) (tag ^ ": Info")
+      | None -> expect false (tag ^ ": should fire"));
+  run "MATH-099 clean in display math" (fun tag ->
+      expect
+        (does_not_fire "MATH-099" "\\[\\bigcup_{i} A_i\\]")
+        (tag ^ ": display ok"));
+  run "MATH-099 clean no big ops" (fun tag ->
+      expect (does_not_fire "MATH-099" "$x + y$") (tag ^ ": no ops"));
+
+  (* ════════════════════════════════════════════════════════════════════
+     MATH-101: Deprecated \over primitive
+     ════════════════════════════════════════════════════════════════════ *)
+  run "MATH-101 fires on over" (fun tag ->
+      expect (fires "MATH-101" "$a \\over b$") (tag ^ ": over"));
+  run "MATH-101 severity=Warning" (fun tag ->
+      match find_result "MATH-101" "$a \\over b$" with
+      | Some r -> expect (r.severity = Validators.Warning) (tag ^ ": Warning")
+      | None -> expect false (tag ^ ": should fire"));
+  run "MATH-101 count=2" (fun tag ->
+      expect
+        (fires_with_count "MATH-101" "$a \\over b + c \\over d$" 2)
+        (tag ^ ": count=2"));
+  run "MATH-101 clean frac" (fun tag ->
+      expect (does_not_fire "MATH-101" "$\\frac{a}{b}$") (tag ^ ": frac ok"));
+
+  (* ════════════════════════════════════════════════════════════════════
+     MATH-104: Repeated \left(\right) pairs
+     ════════════════════════════════════════════════════════════════════ *)
+  run "MATH-104 fires on 3+ left/right pairs" (fun tag ->
+      expect
+        (fires "MATH-104"
+           "$\\left(a\\right) + \\left(b\\right) + \\left(c\\right)$")
+        (tag ^ ": 3 pairs"));
+  run "MATH-104 severity=Info" (fun tag ->
+      match
+        find_result "MATH-104"
+          "$\\left(a\\right) \\left(b\\right) \\left(c\\right)$"
+      with
+      | Some r -> expect (r.severity = Validators.Info) (tag ^ ": Info")
+      | None -> expect false (tag ^ ": should fire"));
+  run "MATH-104 clean 2 pairs" (fun tag ->
+      expect
+        (does_not_fire "MATH-104" "$\\left(a\\right) + \\left(b\\right)$")
+        (tag ^ ": 2 pairs ok"));
+  run "MATH-104 clean no left" (fun tag ->
+      expect (does_not_fire "MATH-104" "$(a) + (b)$") (tag ^ ": no left"));
+
+  (* ════════════════════════════════════════════════════════════════════
+     MATH-106: \not= used — prefer \neq
+     ════════════════════════════════════════════════════════════════════ *)
+  run "MATH-106 fires on not=" (fun tag ->
+      expect (fires "MATH-106" "$a \\not= b$") (tag ^ ": not="));
+  run "MATH-106 severity=Info" (fun tag ->
+      match find_result "MATH-106" "$a \\not= b$" with
+      | Some r -> expect (r.severity = Validators.Info) (tag ^ ": Info")
+      | None -> expect false (tag ^ ": should fire"));
+  run "MATH-106 count=2" (fun tag ->
+      expect
+        (fires_with_count "MATH-106" "$a \\not= b \\not= c$" 2)
+        (tag ^ ": count=2"));
+  run "MATH-106 clean neq" (fun tag ->
+      expect (does_not_fire "MATH-106" "$a \\neq b$") (tag ^ ": neq ok"));
+
+  (* ════════════════════════════════════════════════════════════════════
+     MATH-108: Middle dot U+00B7 in math — use \cdot
+     ════════════════════════════════════════════════════════════════════ *)
+  run "MATH-108 fires on middle dot" (fun tag ->
+      expect (fires "MATH-108" "$a \xc2\xb7 b$") (tag ^ ": middle dot"));
+  run "MATH-108 severity=Info" (fun tag ->
+      match find_result "MATH-108" "$a \xc2\xb7 b$" with
+      | Some r -> expect (r.severity = Validators.Info) (tag ^ ": Info")
+      | None -> expect false (tag ^ ": should fire"));
+  run "MATH-108 clean cdot" (fun tag ->
+      expect (does_not_fire "MATH-108" "$a \\cdot b$") (tag ^ ": cdot ok"));
+  run "MATH-108 clean outside math" (fun tag ->
+      expect (does_not_fire "MATH-108" "a \xc2\xb7 b") (tag ^ ": outside math"));
+
+  (* ════════════════════════════════════════════════════════════════════ Empty
+     input
+     ════════════════════════════════════════════════════════════════════ *)
+  run "empty input fires nothing" (fun tag ->
+      let results = Validators.run_all "" in
+      let math_c3 =
+        List.filter
+          (fun (r : Validators.result) ->
+            List.mem r.id
+              [
+                "MATH-072";
+                "MATH-074";
+                "MATH-087";
+                "MATH-088";
+                "MATH-091";
+                "MATH-092";
+                "MATH-095";
+                "MATH-096";
+                "MATH-097";
+                "MATH-099";
+                "MATH-101";
+                "MATH-104";
+                "MATH-106";
+                "MATH-108";
+              ])
+          results
+      in
+      expect (math_c3 = []) (tag ^ ": no fires on empty"));
+
+  if !fails > 0 then (
+    Printf.eprintf "[math-c3] %d failure(s)\n%!" !fails;
+    exit 1)
+  else Printf.printf "[math-c3] PASS %d cases\n%!" !cases

--- a/latex-parse/src/validators.ml
+++ b/latex-parse/src/validators.ml
@@ -9563,6 +9563,435 @@ let l1_math_098_rule : rule =
   in
   { id = "MATH-098"; run }
 
+(* MATH-072: Unknown math operator name — \operatorname{X} where X is a
+   predefined LaTeX function like \det, \lim, \sin etc. *)
+let l1_math_072_rule : rule =
+  let known_ops =
+    [
+      "det";
+      "lim";
+      "sin";
+      "cos";
+      "tan";
+      "log";
+      "ln";
+      "exp";
+      "sup";
+      "inf";
+      "max";
+      "min";
+      "gcd";
+      "deg";
+      "dim";
+      "hom";
+      "ker";
+      "arg";
+      "Pr";
+      "sec";
+      "csc";
+      "cot";
+      "arcsin";
+      "arccos";
+      "arctan";
+      "sinh";
+      "cosh";
+      "tanh";
+      "limsup";
+      "liminf";
+      "projlim";
+      "injlim";
+      "varlimsup";
+      "varliminf";
+    ]
+  in
+  let re = Str.regexp {|\\operatorname{[^}]*}|} in
+  let run s =
+    let math_segs = extract_math_segments s in
+    let cnt = ref 0 in
+    List.iter
+      (fun seg ->
+        let i = ref 0 in
+        try
+          while true do
+            let _ = Str.search_forward re seg !i in
+            let m = Str.matched_string seg in
+            (* Extract the name between { and } *)
+            let brace_start =
+              (try String.index_from m 0 '{' with Not_found -> -1) + 1
+            in
+            let brace_end =
+              try String.index_from m brace_start '}'
+              with Not_found -> String.length m
+            in
+            let name = String.sub m brace_start (brace_end - brace_start) in
+            if List.mem name known_ops then incr cnt;
+            i := Str.match_end ()
+          done
+        with Not_found -> ())
+      math_segs;
+    if !cnt > 0 then
+      Some
+        {
+          id = "MATH-072";
+          severity = Warning;
+          message =
+            "\\operatorname used for predefined function — use built-in command";
+          count = !cnt;
+        }
+    else None
+  in
+  { id = "MATH-072"; run }
+
+(* MATH-074: TikZ \node inside math without math mode key *)
+let l1_math_074_rule : rule =
+  let run s =
+    let math_segs = extract_math_segments s in
+    let cnt = ref 0 in
+    List.iter
+      (fun seg ->
+        if
+          count_substring seg "\\node" > 0
+          && count_substring seg "math mode" = 0
+        then cnt := !cnt + count_substring seg "\\node")
+      math_segs;
+    if !cnt > 0 then
+      Some
+        {
+          id = "MATH-074";
+          severity = Warning;
+          message = "TikZ \\node inside math without math mode key";
+          count = !cnt;
+        }
+    else None
+  in
+  { id = "MATH-074"; run }
+
+(* MATH-087: Fake bold digits via \mathbf{0}...\mathbf{9} *)
+let l1_math_087_rule : rule =
+  let re = Str.regexp {|\\mathbf{[0-9]+}|} in
+  let run s =
+    let math_segs = extract_math_segments s in
+    let cnt = ref 0 in
+    List.iter (fun seg -> cnt := !cnt + count_re_matches re seg) math_segs;
+    if !cnt > 0 then
+      Some
+        {
+          id = "MATH-087";
+          severity = Info;
+          message = "Fake bold digits via \\mathbf — consider bm package";
+          count = !cnt;
+        }
+    else None
+  in
+  { id = "MATH-087"; run }
+
+(* MATH-088: Bare \partial lacks thin space *)
+let l1_math_088_rule : rule =
+  let re = Str.regexp {|[^ \t,\\]\\partial\|\\partial[^ \t{\\]|} in
+  let run s =
+    let math_segs = extract_math_segments s in
+    let cnt = ref 0 in
+    List.iter (fun seg -> cnt := !cnt + count_re_matches re seg) math_segs;
+    if !cnt > 0 then
+      Some
+        {
+          id = "MATH-088";
+          severity = Info;
+          message = "Bare \\partial lacks thin space";
+          count = !cnt;
+        }
+    else None
+  in
+  { id = "MATH-088"; run }
+
+(* MATH-091: \operatorname{X} used when predefined \X exists *)
+let l1_math_091_rule : rule =
+  (* This is the same detection as MATH-072 but with a different message. We
+     alias it via the same logic registered under a separate ID. *)
+  let known_ops =
+    [
+      "det";
+      "lim";
+      "sin";
+      "cos";
+      "tan";
+      "log";
+      "ln";
+      "exp";
+      "sup";
+      "inf";
+      "max";
+      "min";
+      "gcd";
+      "deg";
+      "dim";
+      "hom";
+      "ker";
+      "arg";
+      "Pr";
+    ]
+  in
+  let re = Str.regexp {|\\operatorname{[^}]*}|} in
+  let run s =
+    let math_segs = extract_math_segments s in
+    let cnt = ref 0 in
+    List.iter
+      (fun seg ->
+        let i = ref 0 in
+        try
+          while true do
+            let _ = Str.search_forward re seg !i in
+            let m = Str.matched_string seg in
+            let brace_start =
+              (try String.index_from m 0 '{' with Not_found -> -1) + 1
+            in
+            let brace_end =
+              try String.index_from m brace_start '}'
+              with Not_found -> String.length m
+            in
+            let name = String.sub m brace_start (brace_end - brace_start) in
+            if List.mem name known_ops then incr cnt;
+            i := Str.match_end ()
+          done
+        with Not_found -> ())
+      math_segs;
+    if !cnt > 0 then
+      Some
+        {
+          id = "MATH-091";
+          severity = Info;
+          message = "\\operatorname{X} used — predefined \\X exists";
+          count = !cnt;
+        }
+    else None
+  in
+  { id = "MATH-091"; run }
+
+(* MATH-092: \sum with explicit limits in inline math *)
+let l1_math_092_rule : rule =
+  let re = Str.regexp {|\\sum[ \t]*_|} in
+  let run s =
+    let inline_segs = extract_inline_math_segments s in
+    let cnt = ref 0 in
+    List.iter (fun seg -> cnt := !cnt + count_re_matches re seg) inline_segs;
+    if !cnt > 0 then
+      Some
+        {
+          id = "MATH-092";
+          severity = Info;
+          message = "\\sum with explicit limits in inline math";
+          count = !cnt;
+        }
+    else None
+  in
+  { id = "MATH-092"; run }
+
+(* MATH-095: Log base without braces — alias of MATH-061 logic *)
+let l1_math_095_rule : rule =
+  let re = Str.regexp {|\\log_[0-9][0-9a-zA-Z]|} in
+  let run s =
+    let math_segs = extract_math_segments s in
+    let cnt = ref 0 in
+    List.iter (fun seg -> cnt := !cnt + count_re_matches re seg) math_segs;
+    if !cnt > 0 then
+      Some
+        {
+          id = "MATH-095";
+          severity = Warning;
+          message = "Log base typeset without braces — use \\log_{10}";
+          count = !cnt;
+        }
+    else None
+  in
+  { id = "MATH-095"; run }
+
+(* MATH-096: Bold Greek via \mathbf — use \boldsymbol *)
+let l1_math_096_rule : rule =
+  let greek_letters =
+    [
+      "\\alpha";
+      "\\beta";
+      "\\gamma";
+      "\\delta";
+      "\\epsilon";
+      "\\zeta";
+      "\\eta";
+      "\\theta";
+      "\\iota";
+      "\\kappa";
+      "\\lambda";
+      "\\mu";
+      "\\nu";
+      "\\xi";
+      "\\pi";
+      "\\rho";
+      "\\sigma";
+      "\\tau";
+      "\\upsilon";
+      "\\phi";
+      "\\chi";
+      "\\psi";
+      "\\omega";
+      "\\Gamma";
+      "\\Delta";
+      "\\Theta";
+      "\\Lambda";
+      "\\Xi";
+      "\\Pi";
+      "\\Sigma";
+      "\\Phi";
+      "\\Psi";
+      "\\Omega";
+    ]
+  in
+  let run s =
+    let math_segs = extract_math_segments s in
+    let cnt = ref 0 in
+    List.iter
+      (fun seg ->
+        List.iter
+          (fun gl -> cnt := !cnt + count_substring seg ("\\mathbf{" ^ gl ^ "}"))
+          greek_letters)
+      math_segs;
+    if !cnt > 0 then
+      Some
+        {
+          id = "MATH-096";
+          severity = Info;
+          message = "Bold Greek via \\mathbf — use \\boldsymbol";
+          count = !cnt;
+        }
+    else None
+  in
+  { id = "MATH-096"; run }
+
+(* MATH-097: Arrow => typed instead of \implies *)
+let l1_math_097_rule : rule =
+  let re = Str.regexp {|[^=!<>\\]=>|} in
+  let run s =
+    let math_segs = extract_math_segments s in
+    let cnt = ref 0 in
+    List.iter
+      (fun seg ->
+        let padded = " " ^ seg in
+        cnt := !cnt + count_re_matches re padded)
+      math_segs;
+    if !cnt > 0 then
+      Some
+        {
+          id = "MATH-097";
+          severity = Info;
+          message = "Arrow => typed — use \\implies";
+          count = !cnt;
+        }
+    else None
+  in
+  { id = "MATH-097"; run }
+
+(* MATH-099: Large operator (\bigcup/\bigcap/\bigoplus) in inline math *)
+let l1_math_099_rule : rule =
+  let big_ops =
+    [ "\\bigcup"; "\\bigcap"; "\\bigoplus"; "\\bigotimes"; "\\bigsqcup" ]
+  in
+  let run s =
+    let inline_segs = extract_inline_math_segments s in
+    let cnt = ref 0 in
+    List.iter
+      (fun seg ->
+        List.iter (fun op -> cnt := !cnt + count_substring seg op) big_ops)
+      inline_segs;
+    if !cnt > 0 then
+      Some
+        {
+          id = "MATH-099";
+          severity = Info;
+          message = "Large operator used in inline math";
+          count = !cnt;
+        }
+    else None
+  in
+  { id = "MATH-099"; run }
+
+(* MATH-101: Deprecated \over primitive used *)
+let l1_math_101_rule : rule =
+  let run s =
+    let math_segs = extract_math_segments s in
+    let cnt = ref 0 in
+    List.iter (fun seg -> cnt := !cnt + count_substring seg "\\over") math_segs;
+    if !cnt > 0 then
+      Some
+        {
+          id = "MATH-101";
+          severity = Warning;
+          message = "Deprecated \\over primitive — use \\frac";
+          count = !cnt;
+        }
+    else None
+  in
+  { id = "MATH-101"; run }
+
+(* MATH-104: Repeated \left(...\right) pairs without \DeclarePairedDelimiter *)
+let l1_math_104_rule : rule =
+  let run s =
+    let math_segs = extract_math_segments s in
+    let cnt = ref 0 in
+    List.iter
+      (fun seg ->
+        let pairs = count_substring seg "\\left(" in
+        if pairs > 2 && count_substring seg "\\DeclarePairedDelimiter" = 0 then
+          cnt := !cnt + 1)
+      math_segs;
+    if !cnt > 0 then
+      Some
+        {
+          id = "MATH-104";
+          severity = Info;
+          message =
+            "Repeated \\left(\\right) pairs — consider \\DeclarePairedDelimiter";
+          count = !cnt;
+        }
+    else None
+  in
+  { id = "MATH-104"; run }
+
+(* MATH-106: Misuse of \not= — prefer \neq *)
+let l1_math_106_rule : rule =
+  let run s =
+    let math_segs = extract_math_segments s in
+    let cnt = ref 0 in
+    List.iter (fun seg -> cnt := !cnt + count_substring seg "\\not=") math_segs;
+    if !cnt > 0 then
+      Some
+        {
+          id = "MATH-106";
+          severity = Info;
+          message = "\\not= used — prefer \\neq";
+          count = !cnt;
+        }
+    else None
+  in
+  { id = "MATH-106"; run }
+
+(* MATH-108: Middle dot U+00B7 in math — use \cdot *)
+let l1_math_108_rule : rule =
+  let run s =
+    let math_segs = extract_math_segments s in
+    let cnt = ref 0 in
+    List.iter
+      (fun seg -> cnt := !cnt + count_substring seg "\xc2\xb7")
+      math_segs;
+    if !cnt > 0 then
+      Some
+        {
+          id = "MATH-108";
+          severity = Info;
+          message = "Middle dot (\xc2\xb7) in math — use \\cdot";
+          count = !cnt;
+        }
+    else None
+  in
+  { id = "MATH-108"; run }
+
 (* ═══════════════════════════════════════════════════════════════════════ REF
    validators: cross-referencing and label hygiene
    ═══════════════════════════════════════════════════════════════════════ *)
@@ -10521,6 +10950,20 @@ let rules_l1 : rule list =
     l1_math_090_rule;
     l1_math_093_rule;
     l1_math_098_rule;
+    l1_math_072_rule;
+    l1_math_074_rule;
+    l1_math_087_rule;
+    l1_math_088_rule;
+    l1_math_091_rule;
+    l1_math_092_rule;
+    l1_math_095_rule;
+    l1_math_096_rule;
+    l1_math_097_rule;
+    l1_math_099_rule;
+    l1_math_101_rule;
+    l1_math_104_rule;
+    l1_math_106_rule;
+    l1_math_108_rule;
     l1_ref_001_rule;
     l1_ref_002_rule;
     l1_ref_003_rule;


### PR DESCRIPTION
## Summary

- Implement **14 L1 MATH-C** remaining rules with **63 tests**
- Completes the MATH-C implementation: all 42 L1 MATH-C rules (MATH-055..108) now implemented
- Rules: MATH-072, 074, 087, 088, 091, 092, 095, 096, 097, 099, 101, 104, 106, 108

| Rule | Description | Severity |
|------|-------------|----------|
| MATH-072 | `\operatorname` for predefined function | Warning |
| MATH-074 | TikZ `\node` in math without math mode | Warning |
| MATH-087 | Fake bold digits via `\mathbf` | Info |
| MATH-088 | `\partial` without thin space | Info |
| MATH-091 | `\operatorname{X}` when `\X` exists | Info |
| MATH-092 | `\sum` with limits in inline math | Info |
| MATH-095 | Log base without braces (alias MATH-061) | Warning |
| MATH-096 | Bold Greek via `\mathbf` | Info |
| MATH-097 | `=>` instead of `\implies` | Info |
| MATH-099 | Large operator in inline math | Info |
| MATH-101 | Deprecated `\over` primitive | Warning |
| MATH-104 | Repeated `\left`/`\right` pairs | Info |
| MATH-106 | `\not=` instead of `\neq` | Info |
| MATH-108 | Middle dot instead of `\cdot` | Info |

## Test plan

- [x] `dune build` clean
- [x] `dune runtest` — all 19 suites green
- [x] `dune fmt` — no diffs
- [x] 63 new test cases covering fires/clean/count/severity