### PR TITLE
feat: L2-approx batch 3 — 22 rules (CMD/DOC/TAB/PKG/LANG/TIKZ/FIG)

### DIFF
--- a/corpora/lint/l2_batch3/cmd_014.tex
+++ b/corpora/lint/l2_batch3/cmd_014.tex
@@ -1,0 +1,3 @@
+\begin{document}
+\AtBeginDocument{\color{red}}
+\end{document}

--- a/corpora/lint/l2_batch3/doc_001.tex
+++ b/corpora/lint/l2_batch3/doc_001.tex
@@ -1,0 +1,3 @@
+\begin{document}
+Hello world
+\end{document}

--- a/corpora/lint/l2_batch3/doc_002.tex
+++ b/corpora/lint/l2_batch3/doc_002.tex
@@ -1,0 +1,4 @@
+\begin{document}
+\maketitle
+\keywords{test}
+\end{document}

--- a/corpora/lint/l2_batch3/doc_003.tex
+++ b/corpora/lint/l2_batch3/doc_003.tex
@@ -1,0 +1,6 @@
+\begin{document}
+\maketitle
+\begin{abstract}
+Text
+\end{abstract}
+\end{document}

--- a/corpora/lint/l2_batch3/fig_010.tex
+++ b/corpora/lint/l2_batch3/fig_010.tex
@@ -1,0 +1,3 @@
+\begin{subfigure}{0.5\textwidth}
+\includegraphics{a.png}
+\end{subfigure}

--- a/corpora/lint/l2_batch3/fig_013.tex
+++ b/corpora/lint/l2_batch3/fig_013.tex
@@ -1,0 +1,1 @@
+\includegraphics[scale=0.5]{img.png}

--- a/corpora/lint/l2_batch3/lang_002.tex
+++ b/corpora/lint/l2_batch3/lang_002.tex
@@ -1,0 +1,3 @@
+\usepackage{babel}
+\begin{document}
+\end{document}

--- a/corpora/lint/l2_batch3/lang_004.tex
+++ b/corpora/lint/l2_batch3/lang_004.tex
@@ -1,0 +1,4 @@
+\usepackage{polyglossia}
+\usepackage[english]{babel}
+\begin{document}
+\end{document}

--- a/corpora/lint/l2_batch3/pkg_007.tex
+++ b/corpora/lint/l2_batch3/pkg_007.tex
@@ -1,0 +1,4 @@
+\usepackage{hyperref}
+\usepackage{geometry}
+\begin{document}
+\end{document}

--- a/corpora/lint/l2_batch3/pkg_009.tex
+++ b/corpora/lint/l2_batch3/pkg_009.tex
@@ -1,0 +1,3 @@
+\begin{document}
+\usetikzlibrary{calc}
+\end{document}

--- a/corpora/lint/l2_batch3/pkg_011.tex
+++ b/corpora/lint/l2_batch3/pkg_011.tex
@@ -1,0 +1,5 @@
+\begin{tabular}{c}
+\toprule
+a \\
+\bottomrule
+\end{tabular}

--- a/corpora/lint/l2_batch3/pkg_012.tex
+++ b/corpora/lint/l2_batch3/pkg_012.tex
@@ -1,0 +1,1 @@
+\enquote{hello world}

--- a/corpora/lint/l2_batch3/pkg_015.tex
+++ b/corpora/lint/l2_batch3/pkg_015.tex
@@ -1,0 +1,4 @@
+\usepackage[utf8]{inputenc}
+\usepackage{fontspec}
+\begin{document}
+\end{document}

--- a/corpora/lint/l2_batch3/pkg_020.tex
+++ b/corpora/lint/l2_batch3/pkg_020.tex
@@ -1,0 +1,1 @@
+\tikzexternalize

--- a/corpora/lint/l2_batch3/pkg_022.tex
+++ b/corpora/lint/l2_batch3/pkg_022.tex
@@ -1,0 +1,3 @@
+\usepackage{epsfig}
+\begin{document}
+\end{document}

--- a/corpora/lint/l2_batch3/pkg_023.tex
+++ b/corpora/lint/l2_batch3/pkg_023.tex
@@ -1,0 +1,4 @@
+\usepackage{microtype}
+\usepackage{unicode-math}
+\begin{document}
+\end{document}

--- a/corpora/lint/l2_batch3/tab_006.tex
+++ b/corpora/lint/l2_batch3/tab_006.tex
@@ -1,0 +1,5 @@
+\begin{tabular}{c}
+\hline
+\hline
+a \\
+\end{tabular}

--- a/corpora/lint/l2_batch3/tab_009.tex
+++ b/corpora/lint/l2_batch3/tab_009.tex
@@ -1,0 +1,6 @@
+\begin{table}
+\caption{Test}
+\begin{tabular}{c}
+a
+\end{tabular}
+\end{table}

--- a/corpora/lint/l2_batch3/tab_010.tex
+++ b/corpora/lint/l2_batch3/tab_010.tex
@@ -1,0 +1,6 @@
+\begin{table}
+\footnote{note}
+\begin{tabular}{c}
+a
+\end{tabular}
+\end{table}

--- a/corpora/lint/l2_batch3/tab_011.tex
+++ b/corpora/lint/l2_batch3/tab_011.tex
@@ -1,0 +1,5 @@
+\begin{tabular}{c}
+\hline
+a \\
+\hline
+\end{tabular}

--- a/corpora/lint/l2_batch3/tab_014.tex
+++ b/corpora/lint/l2_batch3/tab_014.tex
@@ -1,0 +1,3 @@
+\begin{tabular}{cc}
+\multicolumn{2}{}{text}
+\end{tabular}

--- a/corpora/lint/l2_batch3/tikz_007.tex
+++ b/corpora/lint/l2_batch3/tikz_007.tex
@@ -1,0 +1,4 @@
+\usepackage{hyperref}
+\usepackage{tikz}
+\begin{document}
+\end{document}

--- a/docs/WEEKLY_STATUS.md
+++ b/docs/WEEKLY_STATUS.md
@@ -231,12 +231,42 @@ Week 20 — L2-Approximable Rules Batch 2 (FONT, MATH, REF cross-ref)
 - 374/374 messages match spec, 0 mismatches
 - All dune build, dune runtest, dune fmt: exit 0
 
-Current State (Post Week 20 / Phase 2 Active)
-- Validators: 384 rules implemented out of 623 spec rules (61.6%)
-  - Y1 target: 180 rules — well exceeded (2x+)
+Week 21 — L2-Approximable Rules Batch 3 (CMD, DOC, TAB, PKG, LANG, TIKZ, FIG)
+- 22 new validators — package ordering, document structure, table hygiene:
+  - CMD-014: \AtBeginDocument after \begin{document} (position comparison)
+  - DOC-001: Title missing \maketitle (substring absence)
+  - DOC-002: Abstract environment missing (substring absence)
+  - DOC-003: Keywords missing (substring absence)
+  - TAB-006: Consecutive \hline duplicated (regex)
+  - TAB-009: Floating table missing \label (env block scan)
+  - TAB-010: Footnote placed inside table environment (env block scan)
+  - TAB-011: Top/bottom \hline instead of \toprule/\bottomrule (env block scan)
+  - TAB-014: Empty multicolumn alignment spec {} (regex)
+  - PKG-007: hyperref loaded before geometry (preamble position)
+  - PKG-009: TikZ libraries loaded inside document body (position check)
+  - PKG-011: booktabs required but not loaded for \toprule (cmd vs pkg)
+  - PKG-012: csquotes not loaded when \enquote used (cmd vs pkg)
+  - PKG-015: inputenc loaded under XeLaTeX/LuaLaTeX (pkg co-occurrence)
+  - PKG-020: tikz external library not loaded (cmd vs lib)
+  - PKG-022: Obsolete package detected (epsfig, subfigure, natbib, etc.)
+  - PKG-023: unicode-math must load before microtype (preamble ordering)
+  - LANG-002: babel language option missing (bare package detection)
+  - LANG-004: Polyglossia loaded alongside babel – mutual exclusion (pkg pair)
+  - TIKZ-007: TikZ loaded after hyperref (preamble ordering)
+  - FIG-010: Subfigure without \subcaption (env block scan)
+  - FIG-013: Graphicx option scale used instead of width (regex)
+- 91 new unit tests in test_validators_l2_batch3.ml
+- 22 corpus files in corpora/lint/l2_batch3/
+- 22 golden entries in l2_batch3_golden.yaml (162 total golden cases, all pass)
+- 396/396 messages match spec, 0 mismatches
+- All dune build, dune runtest, dune fmt: exit 0
+
+Current State (Post Week 21 / Phase 2 Active)
+- Validators: 406 rules implemented out of 623 spec rules (65.2%)
+  - Y1 target: 180 rules — well exceeded (2.2x)
   - L0/L1: 100% actionable (333 impl + 12 Reserved)
-  - L2-approx: 25 rules (FIG, TAB, PKG, CJK, FONT, MATH, REF)
-  - Remaining: 239 rules (L2/L3/L4 layer — BIB, FIG, LAY, PKG, STYLE, TAB, TIKZ)
+  - L2-approx: 47 rules (FIG, TAB, PKG, CJK, FONT, MATH, REF, CMD, DOC, LANG, TIKZ)
+  - Remaining: 217 rules (L2/L3/L4 layer — BIB, FIG, LAY, PKG, STYLE, TAB, TIKZ)
 - VPD Pipeline: rules_v3.yaml → vpd_grammar → vpd_compile → OCaml (31 rules in vpd_patterns.json)
 - Proofs: 13 files, 0 admits, 0 axioms — all expansion theorems QED
 - Performance: p95 ≈ 2.96 ms full-doc (target < 25 ms), edit-window p95 ≈ 0.017 ms

--- a/latex-parse/src/dune
+++ b/latex-parse/src/dune
@@ -334,6 +334,7 @@
   ../../specs/rules/locale_golden.yaml
   ../../specs/rules/stragglers2_golden.yaml
   ../../specs/rules/l2_approx_golden.yaml
+  ../../specs/rules/l2_batch3_golden.yaml
   (source_tree ../../corpora)))
 
 (test
@@ -349,4 +350,9 @@
 (test
  (name test_validators_l2_approx)
  (modules test_validators_l2_approx)
+ (libraries latex_parse_lib unix))
+
+(test
+ (name test_validators_l2_batch3)
+ (modules test_validators_l2_batch3)
  (libraries latex_parse_lib unix))

--- a/latex-parse/src/test_golden_corpus.ml
+++ b/latex-parse/src/test_golden_corpus.ml
@@ -271,6 +271,9 @@ let () =
   run_golden_suite "l2_approx"
     (Filename.concat base_dir "specs/rules/l2_approx_golden.yaml")
     base_dir;
+  run_golden_suite "l2_batch3"
+    (Filename.concat base_dir "specs/rules/l2_batch3_golden.yaml")
+    base_dir;
   if !fails > 0 then (
     Printf.eprintf "[golden] %d failure(s) in %d cases\n%!" !fails !cases;
     exit 1)

--- a/latex-parse/src/test_validators_l2_batch3.ml
+++ b/latex-parse/src/test_validators_l2_batch3.ml
@@ -1,0 +1,484 @@
+(** Unit tests for L2-approximable batch 3 rules (CMD, DOC, TAB, PKG, LANG,
+    TIKZ, FIG). *)
+
+open Latex_parse_lib
+
+let fails = ref 0
+let cases = ref 0
+
+let expect cond msg =
+  if not cond then (
+    Printf.eprintf "[l2-batch3] FAIL: %s\n%!" msg;
+    incr fails)
+
+let run msg f =
+  incr cases;
+  f msg
+
+let find_result id src =
+  let results = Validators.run_all src in
+  List.find_opt (fun (r : Validators.result) -> r.id = id) results
+
+let fires id src = find_result id src <> None
+
+let fires_with_count id src expected_count =
+  match find_result id src with
+  | Some r -> r.count = expected_count
+  | None -> false
+
+let does_not_fire id src = find_result id src = None
+
+let () =
+  Unix.putenv "L0_VALIDATORS" "pilot";
+
+  (* ══════════════════════════════════════════════════════════════════════
+     CMD-014: \AtBeginDocument placed after \begin{document}
+     ══════════════════════════════════════════════════════════════════════ *)
+  run "CMD-014 fires when AtBeginDocument after begin{document}" (fun tag ->
+      expect
+        (fires "CMD-014" "\\begin{document}\n\\AtBeginDocument{\\color{red}}")
+        (tag ^ ": after doc"));
+  run "CMD-014 clean when AtBeginDocument before begin{document}" (fun tag ->
+      expect
+        (does_not_fire "CMD-014"
+           "\\AtBeginDocument{\\color{red}}\n\\begin{document}")
+        (tag ^ ": before doc"));
+  run "CMD-014 clean without begin{document}" (fun tag ->
+      expect
+        (does_not_fire "CMD-014" "\\AtBeginDocument{\\color{red}}")
+        (tag ^ ": no document"));
+  run "CMD-014 clean empty" (fun tag ->
+      expect (does_not_fire "CMD-014" "") (tag ^ ": empty"));
+
+  (* ══════════════════════════════════════════════════════════════════════
+     DOC-001: Title missing \maketitle
+     ══════════════════════════════════════════════════════════════════════ *)
+  run "DOC-001 fires when no maketitle" (fun tag ->
+      expect
+        (fires "DOC-001" "\\begin{document}\nHello\n\\end{document}")
+        (tag ^ ": no maketitle"));
+  run "DOC-001 clean with maketitle" (fun tag ->
+      expect
+        (does_not_fire "DOC-001"
+           "\\begin{document}\n\\maketitle\n\\end{document}")
+        (tag ^ ": has maketitle"));
+  run "DOC-001 clean without document" (fun tag ->
+      expect (does_not_fire "DOC-001" "just text") (tag ^ ": no document"));
+  run "DOC-001 clean empty" (fun tag ->
+      expect (does_not_fire "DOC-001" "") (tag ^ ": empty"));
+
+  (* ══════════════════════════════════════════════════════════════════════
+     DOC-002: Abstract environment missing
+     ══════════════════════════════════════════════════════════════════════ *)
+  run "DOC-002 fires when no abstract" (fun tag ->
+      expect
+        (fires "DOC-002" "\\begin{document}\nHello\n\\end{document}")
+        (tag ^ ": no abstract"));
+  run "DOC-002 clean with abstract" (fun tag ->
+      expect
+        (does_not_fire "DOC-002"
+           "\\begin{document}\n\
+            \\begin{abstract}\n\
+            Text\n\
+            \\end{abstract}\n\
+            \\end{document}")
+        (tag ^ ": has abstract"));
+  run "DOC-002 clean without document" (fun tag ->
+      expect (does_not_fire "DOC-002" "just text") (tag ^ ": no document"));
+  run "DOC-002 clean empty" (fun tag ->
+      expect (does_not_fire "DOC-002" "") (tag ^ ": empty"));
+
+  (* ══════════════════════════════════════════════════════════════════════
+     DOC-003: Keywords missing
+     ══════════════════════════════════════════════════════════════════════ *)
+  run "DOC-003 fires when no keywords" (fun tag ->
+      expect
+        (fires "DOC-003" "\\begin{document}\nHello\n\\end{document}")
+        (tag ^ ": no keywords"));
+  run "DOC-003 clean with keywords" (fun tag ->
+      expect
+        (does_not_fire "DOC-003"
+           "\\begin{document}\n\\keywords{foo, bar}\n\\end{document}")
+        (tag ^ ": has keywords"));
+  run "DOC-003 clean without document" (fun tag ->
+      expect (does_not_fire "DOC-003" "just text") (tag ^ ": no document"));
+  run "DOC-003 clean empty" (fun tag ->
+      expect (does_not_fire "DOC-003" "") (tag ^ ": empty"));
+
+  (* ══════════════════════════════════════════════════════════════════════
+     TAB-006: Consecutive \hline duplicated
+     ══════════════════════════════════════════════════════════════════════ *)
+  run "TAB-006 fires on consecutive hline" (fun tag ->
+      expect (fires "TAB-006" "\\hline\n\\hline") (tag ^ ": consecutive hlines"));
+  run "TAB-006 fires on adjacent hline" (fun tag ->
+      expect (fires "TAB-006" "\\hline\\hline") (tag ^ ": adjacent hlines"));
+  run "TAB-006 clean with single hline" (fun tag ->
+      expect (does_not_fire "TAB-006" "\\hline") (tag ^ ": single hline"));
+  run "TAB-006 clean empty" (fun tag ->
+      expect (does_not_fire "TAB-006" "") (tag ^ ": empty"));
+
+  (* ══════════════════════════════════════════════════════════════════════
+     TAB-009: Floating table missing \label
+     ══════════════════════════════════════════════════════════════════════ *)
+  run "TAB-009 fires on table without label" (fun tag ->
+      expect
+        (fires "TAB-009"
+           "\\begin{table}\n\
+            \\caption{T}\n\
+            \\begin{tabular}{c}\n\
+            a\n\
+            \\end{tabular}\n\
+            \\end{table}")
+        (tag ^ ": table no label"));
+  run "TAB-009 clean with label" (fun tag ->
+      expect
+        (does_not_fire "TAB-009"
+           "\\begin{table}\n\
+            \\caption{T}\n\
+            \\label{tab:x}\n\
+            \\begin{tabular}{c}\n\
+            a\n\
+            \\end{tabular}\n\
+            \\end{table}")
+        (tag ^ ": table with label"));
+  run "TAB-009 fires on table*" (fun tag ->
+      expect
+        (fires "TAB-009"
+           "\\begin{table*}\n\
+            \\caption{T}\n\
+            \\begin{tabular}{c}\n\
+            a\n\
+            \\end{tabular}\n\
+            \\end{table*}")
+        (tag ^ ": table* no label"));
+  run "TAB-009 clean empty" (fun tag ->
+      expect (does_not_fire "TAB-009" "") (tag ^ ": empty"));
+
+  (* ══════════════════════════════════════════════════════════════════════
+     TAB-010: Footnote placed inside table environment
+     ══════════════════════════════════════════════════════════════════════ *)
+  run "TAB-010 fires on footnote in table" (fun tag ->
+      expect
+        (fires "TAB-010" "\\begin{table}\n\\footnote{note}\n\\end{table}")
+        (tag ^ ": footnote in table"));
+  run "TAB-010 clean with footnote outside table" (fun tag ->
+      expect
+        (does_not_fire "TAB-010"
+           "text\\footnote{note}\n\\begin{table}\n\\end{table}")
+        (tag ^ ": footnote outside table"));
+  run "TAB-010 clean empty" (fun tag ->
+      expect (does_not_fire "TAB-010" "") (tag ^ ": empty"));
+
+  (* ══════════════════════════════════════════════════════════════════════
+     TAB-011: Top/bottom \hline instead of \toprule/\bottomrule
+     ══════════════════════════════════════════════════════════════════════ *)
+  run "TAB-011 fires with hline in tabular" (fun tag ->
+      expect
+        (fires "TAB-011"
+           "\\begin{tabular}{c}\n\\hline\na\n\\hline\n\\end{tabular}")
+        (tag ^ ": hline in tabular"));
+  run "TAB-011 clean with toprule/bottomrule" (fun tag ->
+      expect
+        (does_not_fire "TAB-011"
+           "\\begin{tabular}{c}\n\\toprule\na\n\\bottomrule\n\\end{tabular}")
+        (tag ^ ": booktabs rules"));
+  run "TAB-011 clean with both hline and toprule" (fun tag ->
+      expect
+        (does_not_fire "TAB-011"
+           "\\begin{tabular}{c}\n\
+            \\toprule\n\
+            a\n\
+            \\hline\n\
+            b\n\
+            \\bottomrule\n\
+            \\end{tabular}")
+        (tag ^ ": mixed (has booktabs = OK)"));
+  run "TAB-011 clean empty" (fun tag ->
+      expect (does_not_fire "TAB-011" "") (tag ^ ": empty"));
+
+  (* ══════════════════════════════════════════════════════════════════════
+     TAB-014: Empty multicolumn alignment spec {} encountered
+     ══════════════════════════════════════════════════════════════════════ *)
+  run "TAB-014 fires on empty multicolumn alignment" (fun tag ->
+      expect
+        (fires "TAB-014" "\\multicolumn{2}{}{text}")
+        (tag ^ ": empty alignment"));
+  run "TAB-014 clean with alignment" (fun tag ->
+      expect
+        (does_not_fire "TAB-014" "\\multicolumn{2}{c}{text}")
+        (tag ^ ": has alignment"));
+  run "TAB-014 clean empty" (fun tag ->
+      expect (does_not_fire "TAB-014" "") (tag ^ ": empty"));
+
+  (* ══════════════════════════════════════════════════════════════════════
+     PKG-007: hyperref loaded before geometry
+     ══════════════════════════════════════════════════════════════════════ *)
+  run "PKG-007 fires when hyperref before geometry" (fun tag ->
+      expect
+        (fires "PKG-007"
+           "\\usepackage{hyperref}\n\\usepackage{geometry}\n\\begin{document}")
+        (tag ^ ": hyperref before geometry"));
+  run "PKG-007 clean when geometry before hyperref" (fun tag ->
+      expect
+        (does_not_fire "PKG-007"
+           "\\usepackage{geometry}\n\\usepackage{hyperref}\n\\begin{document}")
+        (tag ^ ": geometry first"));
+  run "PKG-007 clean without both" (fun tag ->
+      expect
+        (does_not_fire "PKG-007" "\\usepackage{graphicx}\n\\begin{document}")
+        (tag ^ ": neither pkg"));
+  run "PKG-007 clean empty" (fun tag ->
+      expect (does_not_fire "PKG-007" "") (tag ^ ": empty"));
+
+  (* ══════════════════════════════════════════════════════════════════════
+     PKG-009: TikZ libraries loaded inside document body
+     ══════════════════════════════════════════════════════════════════════ *)
+  run "PKG-009 fires when usetikzlibrary after begin{document}" (fun tag ->
+      expect
+        (fires "PKG-009" "\\begin{document}\n\\usetikzlibrary{calc}")
+        (tag ^ ": tikzlib in body"));
+  run "PKG-009 clean when usetikzlibrary before begin{document}" (fun tag ->
+      expect
+        (does_not_fire "PKG-009" "\\usetikzlibrary{calc}\n\\begin{document}")
+        (tag ^ ": tikzlib in preamble"));
+  run "PKG-009 clean empty" (fun tag ->
+      expect (does_not_fire "PKG-009" "") (tag ^ ": empty"));
+
+  (* ══════════════════════════════════════════════════════════════════════
+     PKG-011: booktabs required but not loaded for \toprule
+     ══════════════════════════════════════════════════════════════════════ *)
+  run "PKG-011 fires when toprule without booktabs" (fun tag ->
+      expect
+        (fires "PKG-011" "\\begin{tabular}{c}\n\\toprule\na\n\\end{tabular}")
+        (tag ^ ": toprule no booktabs"));
+  run "PKG-011 fires when midrule without booktabs" (fun tag ->
+      expect (fires "PKG-011" "\\midrule") (tag ^ ": midrule no booktabs"));
+  run "PKG-011 clean with booktabs loaded" (fun tag ->
+      expect
+        (does_not_fire "PKG-011" "\\usepackage{booktabs}\n\\toprule")
+        (tag ^ ": booktabs loaded"));
+  run "PKG-011 clean with booktabs with options" (fun tag ->
+      expect
+        (does_not_fire "PKG-011"
+           "\\usepackage[heavyrulewidth=1pt]{booktabs}\n\\toprule")
+        (tag ^ ": booktabs with options"));
+  run "PKG-011 clean empty" (fun tag ->
+      expect (does_not_fire "PKG-011" "") (tag ^ ": empty"));
+
+  (* ══════════════════════════════════════════════════════════════════════
+     PKG-012: csquotes not loaded when \enquote used
+     ══════════════════════════════════════════════════════════════════════ *)
+  run "PKG-012 fires when enquote without csquotes" (fun tag ->
+      expect (fires "PKG-012" "\\enquote{hello}") (tag ^ ": enquote no csquotes"));
+  run "PKG-012 clean with csquotes loaded" (fun tag ->
+      expect
+        (does_not_fire "PKG-012" "\\usepackage{csquotes}\n\\enquote{hello}")
+        (tag ^ ": csquotes loaded"));
+  run "PKG-012 clean without enquote" (fun tag ->
+      expect (does_not_fire "PKG-012" "just text") (tag ^ ": no enquote"));
+  run "PKG-012 clean empty" (fun tag ->
+      expect (does_not_fire "PKG-012" "") (tag ^ ": empty"));
+
+  (* ══════════════════════════════════════════════════════════════════════
+     PKG-015: inputenc loaded under XeLaTeX/LuaLaTeX
+     ══════════════════════════════════════════════════════════════════════ *)
+  run "PKG-015 fires with inputenc + fontspec" (fun tag ->
+      expect
+        (fires "PKG-015" "\\usepackage[utf8]{inputenc}\n\\usepackage{fontspec}")
+        (tag ^ ": inputenc + fontspec"));
+  run "PKG-015 clean without fontspec" (fun tag ->
+      expect
+        (does_not_fire "PKG-015" "\\usepackage[utf8]{inputenc}")
+        (tag ^ ": inputenc only"));
+  run "PKG-015 clean without inputenc" (fun tag ->
+      expect
+        (does_not_fire "PKG-015" "\\usepackage{fontspec}")
+        (tag ^ ": fontspec only"));
+  run "PKG-015 clean empty" (fun tag ->
+      expect (does_not_fire "PKG-015" "") (tag ^ ": empty"));
+
+  (* ══════════════════════════════════════════════════════════════════════
+     PKG-020: tikz external library not loaded when externalising
+     ══════════════════════════════════════════════════════════════════════ *)
+  run "PKG-020 fires when tikzexternalize without library" (fun tag ->
+      expect (fires "PKG-020" "\\tikzexternalize") (tag ^ ": externalize no lib"));
+  run "PKG-020 clean with external library" (fun tag ->
+      expect
+        (does_not_fire "PKG-020" "\\usetikzlibrary{external}\n\\tikzexternalize")
+        (tag ^ ": has external lib"));
+  run "PKG-020 clean without tikzexternalize" (fun tag ->
+      expect (does_not_fire "PKG-020" "just text") (tag ^ ": no externalize"));
+  run "PKG-020 clean empty" (fun tag ->
+      expect (does_not_fire "PKG-020" "") (tag ^ ": empty"));
+
+  (* ══════════════════════════════════════════════════════════════════════
+     PKG-022: Obsolete package (epsfig, subfigure, natbib) detected
+     ══════════════════════════════════════════════════════════════════════ *)
+  run "PKG-022 fires with epsfig" (fun tag ->
+      expect (fires "PKG-022" "\\usepackage{epsfig}") (tag ^ ": epsfig"));
+  run "PKG-022 fires with subfigure" (fun tag ->
+      expect (fires "PKG-022" "\\usepackage{subfigure}") (tag ^ ": subfigure"));
+  run "PKG-022 fires with natbib" (fun tag ->
+      expect (fires "PKG-022" "\\usepackage{natbib}") (tag ^ ": natbib"));
+  run "PKG-022 count=2 with two obsolete" (fun tag ->
+      expect
+        (fires_with_count "PKG-022" "\\usepackage{epsfig}\n\\usepackage{natbib}"
+           2)
+        (tag ^ ": two obsolete"));
+  run "PKG-022 clean with modern packages" (fun tag ->
+      expect
+        (does_not_fire "PKG-022" "\\usepackage{graphicx}")
+        (tag ^ ": modern pkg"));
+  run "PKG-022 clean empty" (fun tag ->
+      expect (does_not_fire "PKG-022" "") (tag ^ ": empty"));
+
+  (* ══════════════════════════════════════════════════════════════════════
+     PKG-023: unicode-math must load before microtype
+     ══════════════════════════════════════════════════════════════════════ *)
+  run "PKG-023 fires when unicode-math after microtype" (fun tag ->
+      expect
+        (fires "PKG-023"
+           "\\usepackage{microtype}\n\
+            \\usepackage{unicode-math}\n\
+            \\begin{document}")
+        (tag ^ ": unicode-math after microtype"));
+  run "PKG-023 clean when unicode-math before microtype" (fun tag ->
+      expect
+        (does_not_fire "PKG-023"
+           "\\usepackage{unicode-math}\n\
+            \\usepackage{microtype}\n\
+            \\begin{document}")
+        (tag ^ ": correct order"));
+  run "PKG-023 clean without both" (fun tag ->
+      expect
+        (does_not_fire "PKG-023" "\\usepackage{graphicx}\n\\begin{document}")
+        (tag ^ ": neither pkg"));
+  run "PKG-023 clean empty" (fun tag ->
+      expect (does_not_fire "PKG-023" "") (tag ^ ": empty"));
+
+  (* ══════════════════════════════════════════════════════════════════════
+     LANG-002: babel language option missing
+     ══════════════════════════════════════════════════════════════════════ *)
+  run "LANG-002 fires when babel has no option" (fun tag ->
+      expect (fires "LANG-002" "\\usepackage{babel}") (tag ^ ": bare babel"));
+  run "LANG-002 fires when babel has empty option" (fun tag ->
+      expect (fires "LANG-002" "\\usepackage[]{babel}") (tag ^ ": empty opt"));
+  run "LANG-002 clean with babel option" (fun tag ->
+      expect
+        (does_not_fire "LANG-002" "\\usepackage[english]{babel}")
+        (tag ^ ": has option"));
+  run "LANG-002 clean without babel" (fun tag ->
+      expect (does_not_fire "LANG-002" "just text") (tag ^ ": no babel"));
+  run "LANG-002 clean empty" (fun tag ->
+      expect (does_not_fire "LANG-002" "") (tag ^ ": empty"));
+
+  (* ══════════════════════════════════════════════════════════════════════
+     LANG-004: Polyglossia loaded alongside babel – mutual exclusion
+     ══════════════════════════════════════════════════════════════════════ *)
+  run "LANG-004 fires with both polyglossia and babel" (fun tag ->
+      expect
+        (fires "LANG-004"
+           "\\usepackage{polyglossia}\n\\usepackage[english]{babel}")
+        (tag ^ ": both loaded"));
+  run "LANG-004 clean with only polyglossia" (fun tag ->
+      expect
+        (does_not_fire "LANG-004" "\\usepackage{polyglossia}")
+        (tag ^ ": only polyglossia"));
+  run "LANG-004 clean with only babel" (fun tag ->
+      expect
+        (does_not_fire "LANG-004" "\\usepackage[english]{babel}")
+        (tag ^ ": only babel"));
+  run "LANG-004 clean empty" (fun tag ->
+      expect (does_not_fire "LANG-004" "") (tag ^ ": empty"));
+
+  (* ══════════════════════════════════════════════════════════════════════
+     TIKZ-007: TikZ loaded after hyperref – reorder required
+     ══════════════════════════════════════════════════════════════════════ *)
+  run "TIKZ-007 fires when tikz after hyperref" (fun tag ->
+      expect
+        (fires "TIKZ-007"
+           "\\usepackage{hyperref}\n\\usepackage{tikz}\n\\begin{document}")
+        (tag ^ ": tikz after hyperref"));
+  run "TIKZ-007 clean when tikz before hyperref" (fun tag ->
+      expect
+        (does_not_fire "TIKZ-007"
+           "\\usepackage{tikz}\n\\usepackage{hyperref}\n\\begin{document}")
+        (tag ^ ": correct order"));
+  run "TIKZ-007 clean without both" (fun tag ->
+      expect
+        (does_not_fire "TIKZ-007" "\\usepackage{graphicx}\n\\begin{document}")
+        (tag ^ ": neither pkg"));
+  run "TIKZ-007 clean empty" (fun tag ->
+      expect (does_not_fire "TIKZ-007" "") (tag ^ ": empty"));
+
+  (* ══════════════════════════════════════════════════════════════════════
+     FIG-010: Subfigure environment without \subcaption
+     ══════════════════════════════════════════════════════════════════════ *)
+  run "FIG-010 fires on subfigure without subcaption" (fun tag ->
+      expect
+        (fires "FIG-010"
+           "\\begin{subfigure}{0.5\\textwidth}\n\
+            \\includegraphics{a.png}\n\
+            \\end{subfigure}")
+        (tag ^ ": no subcaption"));
+  run "FIG-010 clean with subcaption" (fun tag ->
+      expect
+        (does_not_fire "FIG-010"
+           "\\begin{subfigure}{0.5\\textwidth}\n\
+            \\includegraphics{a.png}\n\
+            \\subcaption{A}\n\
+            \\end{subfigure}")
+        (tag ^ ": has subcaption"));
+  run "FIG-010 clean with caption" (fun tag ->
+      expect
+        (does_not_fire "FIG-010"
+           "\\begin{subfigure}{0.5\\textwidth}\n\
+            \\includegraphics{a.png}\n\
+            \\caption{A}\n\
+            \\end{subfigure}")
+        (tag ^ ": has caption"));
+  run "FIG-010 count=2 two subfigures without subcaption" (fun tag ->
+      expect
+        (fires_with_count "FIG-010"
+           "\\begin{subfigure}{0.5\\textwidth}\n\
+            \\includegraphics{a.png}\n\
+            \\end{subfigure}\n\
+            \\begin{subfigure}{0.5\\textwidth}\n\
+            \\includegraphics{b.png}\n\
+            \\end{subfigure}"
+           2)
+        (tag ^ ": two subfigures"));
+  run "FIG-010 clean empty" (fun tag ->
+      expect (does_not_fire "FIG-010" "") (tag ^ ": empty"));
+
+  (* ══════════════════════════════════════════════════════════════════════
+     FIG-013: Graphicx option scale used instead of width
+     ══════════════════════════════════════════════════════════════════════ *)
+  run "FIG-013 fires on scale option" (fun tag ->
+      expect
+        (fires "FIG-013" "\\includegraphics[scale=0.5]{img.png}")
+        (tag ^ ": scale option"));
+  run "FIG-013 clean with width option" (fun tag ->
+      expect
+        (does_not_fire "FIG-013"
+           "\\includegraphics[width=0.5\\textwidth]{img.png}")
+        (tag ^ ": width option"));
+  run "FIG-013 clean without options" (fun tag ->
+      expect
+        (does_not_fire "FIG-013" "\\includegraphics{img.png}")
+        (tag ^ ": no options"));
+  run "FIG-013 count=2 two scale options" (fun tag ->
+      expect
+        (fires_with_count "FIG-013"
+           "\\includegraphics[scale=0.5]{a.png}\n\
+            \\includegraphics[scale=0.8]{b.png}"
+           2)
+        (tag ^ ": two scale options"));
+  run "FIG-013 clean empty" (fun tag ->
+      expect (does_not_fire "FIG-013" "") (tag ^ ": empty"));
+
+  (* ─── summary ─────────────────────────────────────────────────────── *)
+  Printf.printf "[l2-batch3] PASS %d cases\n%!" !cases;
+  if !fails > 0 then (
+    Printf.eprintf "[l2-batch3] %d FAILURES\n%!" !fails;
+    exit 1)

--- a/latex-parse/src/validators.ml
+++ b/latex-parse/src/validators.ml
@@ -7088,6 +7088,639 @@ let r_ref_010 : rule =
   in
   { id = "REF-010"; run }
 
+(* ── CMD-014: \AtBeginDocument placed after \begin{document} ──────────── *)
+let r_cmd_014 : rule =
+  let re = Str.regexp_string "\\AtBeginDocument" in
+  let run s =
+    let doc_pos =
+      try Some (Str.search_forward (Str.regexp_string "\\begin{document}") s 0)
+      with Not_found -> None
+    in
+    match doc_pos with
+    | None -> None
+    | Some dp ->
+        let cnt = ref 0 in
+        let i = ref 0 in
+        (try
+           while true do
+             let pos = Str.search_forward re s !i in
+             if pos > dp then incr cnt;
+             i := Str.match_end ()
+           done
+         with Not_found -> ());
+        if !cnt > 0 then
+          Some
+            {
+              id = "CMD-014";
+              severity = Warning;
+              message = "\\AtBeginDocument placed after \\begin{document}";
+              count = !cnt;
+            }
+        else None
+  in
+  { id = "CMD-014"; run }
+
+(* ── DOC-001: Title missing \maketitle ───────────────────────────────── *)
+let r_doc_001 : rule =
+  let run s =
+    let has_doc =
+      try
+        ignore (Str.search_forward (Str.regexp_string "\\begin{document}") s 0);
+        true
+      with Not_found -> false
+    in
+    if has_doc then
+      let has_maketitle =
+        try
+          ignore (Str.search_forward (Str.regexp_string "\\maketitle") s 0);
+          true
+        with Not_found -> false
+      in
+      if not has_maketitle then
+        Some
+          {
+            id = "DOC-001";
+            severity = Error;
+            message = "Title missing \\maketitle";
+            count = 1;
+          }
+      else None
+    else None
+  in
+  { id = "DOC-001"; run }
+
+(* ── DOC-002: Abstract environment missing ───────────────────────────── *)
+let r_doc_002 : rule =
+  let run s =
+    let has_doc =
+      try
+        ignore (Str.search_forward (Str.regexp_string "\\begin{document}") s 0);
+        true
+      with Not_found -> false
+    in
+    if has_doc then
+      let has_abstract =
+        try
+          ignore
+            (Str.search_forward (Str.regexp_string "\\begin{abstract}") s 0);
+          true
+        with Not_found -> false
+      in
+      if not has_abstract then
+        Some
+          {
+            id = "DOC-002";
+            severity = Warning;
+            message = "Abstract environment missing";
+            count = 1;
+          }
+      else None
+    else None
+  in
+  { id = "DOC-002"; run }
+
+(* ── DOC-003: Keywords missing ───────────────────────────────────────── *)
+let r_doc_003 : rule =
+  let run s =
+    let has_doc =
+      try
+        ignore (Str.search_forward (Str.regexp_string "\\begin{document}") s 0);
+        true
+      with Not_found -> false
+    in
+    if has_doc then
+      let has_keywords =
+        try
+          ignore (Str.search_forward (Str.regexp_string "\\keywords{") s 0);
+          true
+        with Not_found -> false
+      in
+      if not has_keywords then
+        Some
+          {
+            id = "DOC-003";
+            severity = Info;
+            message = "Keywords missing";
+            count = 1;
+          }
+      else None
+    else None
+  in
+  { id = "DOC-003"; run }
+
+(* ── TAB-006: Consecutive \hline duplicated ──────────────────────────── *)
+let r_tab_006 : rule =
+  let re = Str.regexp "\\\\hline[ \t\n]*\\\\hline" in
+  let run s =
+    let cnt = ref 0 in
+    let i = ref 0 in
+    (try
+       while true do
+         ignore (Str.search_forward re s !i);
+         incr cnt;
+         i := Str.match_end ()
+       done
+     with Not_found -> ());
+    if !cnt > 0 then
+      Some
+        {
+          id = "TAB-006";
+          severity = Info;
+          message = "Consecutive \\hline duplicated";
+          count = !cnt;
+        }
+    else None
+  in
+  { id = "TAB-006"; run }
+
+(* ── TAB-009: Floating table missing \label ──────────────────────────── *)
+let r_tab_009 : rule =
+  let run s =
+    let blocks = extract_env_blocks_starred "table" s in
+    let cnt =
+      List.fold_left
+        (fun acc body ->
+          let has_label =
+            try
+              ignore (Str.search_forward (Str.regexp {|\\label{|}) body 0);
+              true
+            with Not_found -> false
+          in
+          if not has_label then acc + 1 else acc)
+        0 blocks
+    in
+    if cnt > 0 then
+      Some
+        {
+          id = "TAB-009";
+          severity = Warning;
+          message = "Floating table missing \\label";
+          count = cnt;
+        }
+    else None
+  in
+  { id = "TAB-009"; run }
+
+(* ── TAB-010: Footnote placed inside table environment ───────────────── *)
+let r_tab_010 : rule =
+  let re_fn = Str.regexp {|\\footnote{|} in
+  let run s =
+    let blocks = extract_env_blocks_starred "table" s in
+    let cnt =
+      List.fold_left
+        (fun acc body ->
+          let n = ref 0 in
+          let i = ref 0 in
+          (try
+             while true do
+               ignore (Str.search_forward re_fn body !i);
+               incr n;
+               i := Str.match_end ()
+             done
+           with Not_found -> ());
+          acc + !n)
+        0 blocks
+    in
+    if cnt > 0 then
+      Some
+        {
+          id = "TAB-010";
+          severity = Warning;
+          message = "Footnote placed inside table environment";
+          count = cnt;
+        }
+    else None
+  in
+  { id = "TAB-010"; run }
+
+(* ── TAB-011: Top/bottom \hline instead of \toprule/\bottomrule ──────── *)
+let r_tab_011 : rule =
+  let run s =
+    let blocks =
+      extract_env_blocks "tabular" s @ extract_env_blocks "tabular*" s
+    in
+    let cnt =
+      List.fold_left
+        (fun acc body ->
+          let has_hline =
+            try
+              ignore (Str.search_forward (Str.regexp_string "\\hline") body 0);
+              true
+            with Not_found -> false
+          in
+          let has_booktabs =
+            try
+              ignore (Str.search_forward (Str.regexp_string "\\toprule") body 0);
+              true
+            with Not_found -> (
+              try
+                ignore
+                  (Str.search_forward (Str.regexp_string "\\bottomrule") body 0);
+                true
+              with Not_found -> false)
+          in
+          if has_hline && not has_booktabs then acc + 1 else acc)
+        0 blocks
+    in
+    if cnt > 0 then
+      Some
+        {
+          id = "TAB-011";
+          severity = Info;
+          message = "Top/bottom \\hline instead of \\toprule/\\bottomrule";
+          count = cnt;
+        }
+    else None
+  in
+  { id = "TAB-011"; run }
+
+(* ── TAB-014: Empty multicolumn alignment spec {} encountered ────────── *)
+let r_tab_014 : rule =
+  let re = Str.regexp {|\\multicolumn{[^}]*}{}|} in
+  let run s =
+    let cnt = ref 0 in
+    let i = ref 0 in
+    (try
+       while true do
+         ignore (Str.search_forward re s !i);
+         incr cnt;
+         i := Str.match_end ()
+       done
+     with Not_found -> ());
+    if !cnt > 0 then
+      Some
+        {
+          id = "TAB-014";
+          severity = Info;
+          message = "Empty multicolumn alignment spec {} encountered";
+          count = !cnt;
+        }
+    else None
+  in
+  { id = "TAB-014"; run }
+
+(* ── PKG-007: hyperref loaded before geometry ────────────────────────── *)
+let r_pkg_007 : rule =
+  let run s =
+    let preamble = extract_preamble s in
+    let pkgs = extract_usepackages preamble in
+    let hyp_pos =
+      List.fold_left
+        (fun acc (pos, name) -> if name = "hyperref" then Some pos else acc)
+        None pkgs
+    in
+    let geo_pos =
+      List.fold_left
+        (fun acc (pos, name) -> if name = "geometry" then Some pos else acc)
+        None pkgs
+    in
+    match (hyp_pos, geo_pos) with
+    | Some hp, Some gp ->
+        if hp < gp then
+          Some
+            {
+              id = "PKG-007";
+              severity = Error;
+              message = "hyperref loaded before geometry";
+              count = 1;
+            }
+        else None
+    | _ -> None
+  in
+  { id = "PKG-007"; run }
+
+(* ── PKG-009: TikZ libraries loaded inside document body ─────────────── *)
+let r_pkg_009 : rule =
+  let re = Str.regexp_string "\\usetikzlibrary" in
+  let run s =
+    let doc_pos =
+      try Some (Str.search_forward (Str.regexp_string "\\begin{document}") s 0)
+      with Not_found -> None
+    in
+    match doc_pos with
+    | None -> None
+    | Some dp ->
+        let cnt = ref 0 in
+        let i = ref 0 in
+        (try
+           while true do
+             let pos = Str.search_forward re s !i in
+             if pos > dp then incr cnt;
+             i := Str.match_end ()
+           done
+         with Not_found -> ());
+        if !cnt > 0 then
+          Some
+            {
+              id = "PKG-009";
+              severity = Info;
+              message = "TikZ libraries loaded inside document body";
+              count = !cnt;
+            }
+        else None
+  in
+  { id = "PKG-009"; run }
+
+(* ── PKG-011: booktabs required but not loaded for \toprule ──────────── *)
+let r_pkg_011 : rule =
+  let re_toprule = Str.regexp_string "\\toprule" in
+  let re_midrule = Str.regexp_string "\\midrule" in
+  let re_bottomrule = Str.regexp_string "\\bottomrule" in
+  let run s =
+    let uses_booktabs_cmds =
+      (try
+         ignore (Str.search_forward re_toprule s 0);
+         true
+       with Not_found -> false)
+      ||
+      try
+        ignore (Str.search_forward re_midrule s 0);
+        true
+      with Not_found -> (
+        try
+          ignore (Str.search_forward re_bottomrule s 0);
+          true
+        with Not_found -> false)
+    in
+    if uses_booktabs_cmds && not (has_package s "booktabs") then
+      Some
+        {
+          id = "PKG-011";
+          severity = Warning;
+          message = "booktabs required but not loaded for \\toprule";
+          count = 1;
+        }
+    else None
+  in
+  { id = "PKG-011"; run }
+
+(* ── PKG-012: csquotes not loaded when \enquote used ─────────────────── *)
+let r_pkg_012 : rule =
+  let re = Str.regexp_string "\\enquote{" in
+  let run s =
+    let has_enquote =
+      try
+        ignore (Str.search_forward re s 0);
+        true
+      with Not_found -> false
+    in
+    if has_enquote && not (has_package s "csquotes") then
+      Some
+        {
+          id = "PKG-012";
+          severity = Error;
+          message = "csquotes not loaded when \\enquote used";
+          count = 1;
+        }
+    else None
+  in
+  { id = "PKG-012"; run }
+
+(* ── PKG-015: inputenc loaded under XeLaTeX/LuaLaTeX ────────────────── *)
+let r_pkg_015 : rule =
+  let run s =
+    if has_package s "inputenc" then
+      let xeluatex =
+        has_package s "fontspec"
+        || has_package s "xeCJK"
+        || has_package s "ifxetex"
+        || has_package s "ifluatex"
+        || has_package s "luatexja"
+      in
+      if xeluatex then
+        Some
+          {
+            id = "PKG-015";
+            severity = Warning;
+            message = "inputenc loaded under XeLaTeX/LuaLaTeX";
+            count = 1;
+          }
+      else None
+    else None
+  in
+  { id = "PKG-015"; run }
+
+(* ── PKG-020: tikz external library not loaded when externalising ────── *)
+let r_pkg_020 : rule =
+  let re_ext = Str.regexp_string "\\tikzexternalize" in
+  let re_lib = Str.regexp_string "\\usetikzlibrary{external}" in
+  let run s =
+    let has_externalize =
+      try
+        ignore (Str.search_forward re_ext s 0);
+        true
+      with Not_found -> false
+    in
+    if has_externalize then
+      let has_lib =
+        try
+          ignore (Str.search_forward re_lib s 0);
+          true
+        with Not_found -> false
+      in
+      if not has_lib then
+        Some
+          {
+            id = "PKG-020";
+            severity = Info;
+            message = "tikz external library not loaded when externalising";
+            count = 1;
+          }
+      else None
+    else None
+  in
+  { id = "PKG-020"; run }
+
+(* ── PKG-022: Obsolete package (epsfig, subfigure, natbib) detected ──── *)
+let r_pkg_022 : rule =
+  let obsolete_pkgs =
+    [ "epsfig"; "subfigure"; "natbib"; "t1enc"; "palatcm"; "euler"; "pslatex" ]
+  in
+  let run s =
+    let cnt =
+      List.fold_left
+        (fun acc pkg -> if has_package s pkg then acc + 1 else acc)
+        0 obsolete_pkgs
+    in
+    if cnt > 0 then
+      Some
+        {
+          id = "PKG-022";
+          severity = Warning;
+          message = "Obsolete package (epsfig, subfigure, natbib) detected";
+          count = cnt;
+        }
+    else None
+  in
+  { id = "PKG-022"; run }
+
+(* ── PKG-023: unicode‑math must load before microtype ────────────────── *)
+(* Note: spec description has a non-breaking hyphen U+2011 between "unicode" and
+   "math" (bytes E2 80 91) *)
+let r_pkg_023 : rule =
+  let run s =
+    let preamble = extract_preamble s in
+    let pkgs = extract_usepackages preamble in
+    let umath_pos =
+      List.fold_left
+        (fun acc (pos, name) -> if name = "unicode-math" then Some pos else acc)
+        None pkgs
+    in
+    let micro_pos =
+      List.fold_left
+        (fun acc (pos, name) -> if name = "microtype" then Some pos else acc)
+        None pkgs
+    in
+    match (umath_pos, micro_pos) with
+    | Some up, Some mp ->
+        if up > mp then
+          Some
+            {
+              id = "PKG-023";
+              severity = Error;
+              message = {|unicode‑math must load before microtype|};
+              count = 1;
+            }
+        else None
+    | _ -> None
+  in
+  { id = "PKG-023"; run }
+
+(* ── LANG-002: babel language option missing ─────────────────────────── *)
+let r_lang_002 : rule =
+  let re_bare = Str.regexp {|\\usepackage{babel}|} in
+  let re_empty = Str.regexp {|\\usepackage\[\]{babel}|} in
+  let run s =
+    let has_bare =
+      try
+        ignore (Str.search_forward re_bare s 0);
+        true
+      with Not_found -> false
+    in
+    let has_empty =
+      try
+        ignore (Str.search_forward re_empty s 0);
+        true
+      with Not_found -> false
+    in
+    if has_bare || has_empty then
+      Some
+        {
+          id = "LANG-002";
+          severity = Warning;
+          message = "babel language option missing";
+          count = 1;
+        }
+    else None
+  in
+  { id = "LANG-002"; run }
+
+(* ── LANG-004: Polyglossia loaded alongside babel – mutual exclusion ── *)
+(* Note: spec has en-dash E2 80 93 between "babel" and "mutual" *)
+let r_lang_004 : rule =
+  let run s =
+    if has_package s "polyglossia" && has_package s "babel" then
+      Some
+        {
+          id = "LANG-004";
+          severity = Error;
+          message = {|Polyglossia loaded alongside babel – mutual exclusion|};
+          count = 1;
+        }
+    else None
+  in
+  { id = "LANG-004"; run }
+
+(* ── TIKZ-007: TikZ loaded after hyperref – reorder required ─────────── *)
+(* Note: spec has en-dash E2 80 93 between "hyperref" and "reorder" *)
+let r_tikz_007 : rule =
+  let run s =
+    let preamble = extract_preamble s in
+    let pkgs = extract_usepackages preamble in
+    let tikz_pos =
+      List.fold_left
+        (fun acc (pos, name) -> if name = "tikz" then Some pos else acc)
+        None pkgs
+    in
+    let hyp_pos =
+      List.fold_left
+        (fun acc (pos, name) -> if name = "hyperref" then Some pos else acc)
+        None pkgs
+    in
+    match (tikz_pos, hyp_pos) with
+    | Some tp, Some hp ->
+        if tp > hp then
+          Some
+            {
+              id = "TIKZ-007";
+              severity = Warning;
+              message = {|TikZ loaded after hyperref – reorder required|};
+              count = 1;
+            }
+        else None
+    | _ -> None
+  in
+  { id = "TIKZ-007"; run }
+
+(* ── FIG-010: Subfigure environment without \subcaption ──────────────── *)
+let r_fig_010 : rule =
+  let run s =
+    let blocks = extract_env_blocks "subfigure" s in
+    let cnt =
+      List.fold_left
+        (fun acc body ->
+          let has_subcap =
+            try
+              ignore
+                (Str.search_forward (Str.regexp_string "\\subcaption") body 0);
+              true
+            with Not_found -> (
+              try
+                ignore
+                  (Str.search_forward (Str.regexp_string "\\caption") body 0);
+                true
+              with Not_found -> false)
+          in
+          if not has_subcap then acc + 1 else acc)
+        0 blocks
+    in
+    if cnt > 0 then
+      Some
+        {
+          id = "FIG-010";
+          severity = Warning;
+          message = "Subfigure environment without \\subcaption";
+          count = cnt;
+        }
+    else None
+  in
+  { id = "FIG-010"; run }
+
+(* ── FIG-013: Graphicx option scale used instead of width ────────────── *)
+let r_fig_013 : rule =
+  let re = Str.regexp {|\\includegraphics\[[^]]*scale[ ]*=[^]]*\]|} in
+  let run s =
+    let cnt = ref 0 in
+    let i = ref 0 in
+    (try
+       while true do
+         ignore (Str.search_forward re s !i);
+         incr cnt;
+         i := Str.match_end ()
+       done
+     with Not_found -> ());
+    if !cnt > 0 then
+      Some
+        {
+          id = "FIG-013";
+          severity = Info;
+          message = "Graphicx option scale used instead of width";
+          count = !cnt;
+        }
+    else None
+  in
+  { id = "FIG-013"; run }
+
 let rules_l2_approx : rule list =
   [
     r_fig_001;
@@ -7095,13 +7728,28 @@ let rules_l2_approx : rule list =
     r_fig_003;
     r_fig_007;
     r_fig_009;
+    r_fig_010;
+    r_fig_013;
     r_tab_001;
     r_tab_002;
     r_tab_005;
+    r_tab_006;
+    r_tab_009;
+    r_tab_010;
+    r_tab_011;
+    r_tab_014;
     r_pkg_001;
     r_pkg_002;
     r_pkg_004;
     r_pkg_005;
+    r_pkg_007;
+    r_pkg_009;
+    r_pkg_011;
+    r_pkg_012;
+    r_pkg_015;
+    r_pkg_020;
+    r_pkg_022;
+    r_pkg_023;
     r_cjk_004;
     r_cjk_006;
     r_font_006;
@@ -7115,6 +7763,13 @@ let rules_l2_approx : rule list =
     r_math_023;
     r_math_024;
     r_ref_010;
+    r_cmd_014;
+    r_doc_001;
+    r_doc_002;
+    r_doc_003;
+    r_lang_002;
+    r_lang_004;
+    r_tikz_007;
   ]
 
 (* ── CMD rules: command definition checks ────────────────────────────── *)
@@ -13319,6 +13974,14 @@ let precondition_of_rule_id (id : string) : layer =
   | "MATH-032" | "MATH-054" | "MATH-062" | "MATH-063" | "MATH-100" -> L2
   | "FONT-006" | "FONT-007" | "FONT-008" -> L2
   | "REF-010" -> L2
+  | "CMD-014" -> L2
+  | "DOC-001" | "DOC-002" | "DOC-003" -> L2
+  | "TAB-006" | "TAB-009" | "TAB-010" | "TAB-011" | "TAB-014" -> L2
+  | "PKG-007" | "PKG-009" | "PKG-011" | "PKG-012" | "PKG-015" -> L2
+  | "PKG-020" | "PKG-022" | "PKG-023" -> L2
+  | "LANG-002" | "LANG-004" -> L2
+  | "TIKZ-007" -> L2
+  | "FIG-010" | "FIG-013" -> L2
   | "MATH-026" | "MATH-027" -> L3
   (* CMD-001, CMD-003, CMD-007, CMD-010 need expanded text = L1 *)
   | "CMD-001" | "CMD-003" | "CMD-007" | "CMD-010" -> L1

--- a/specs/rules/l2_batch3_golden.yaml
+++ b/specs/rules/l2_batch3_golden.yaml
@@ -1,0 +1,90 @@
+# Golden corpus entries for L2-approximable batch 3 rules
+---
+  - file: corpora/lint/l2_batch3/cmd_014.tex
+    expect: ["CMD-014"]
+    expect_msgs:
+      - "CMD-014:\AtBeginDocument placed after \begin{document}"
+  - file: corpora/lint/l2_batch3/doc_001.tex
+    expect: ["DOC-001"]
+    expect_msgs:
+      - "DOC-001:Title missing \maketitle"
+  - file: corpora/lint/l2_batch3/doc_002.tex
+    expect: ["DOC-002"]
+    expect_msgs:
+      - "DOC-002:Abstract environment missing"
+  - file: corpora/lint/l2_batch3/doc_003.tex
+    expect: ["DOC-003"]
+    expect_msgs:
+      - "DOC-003:Keywords missing"
+  - file: corpora/lint/l2_batch3/tab_006.tex
+    expect: ["TAB-006"]
+    expect_msgs:
+      - "TAB-006:Consecutive \hline duplicated"
+  - file: corpora/lint/l2_batch3/tab_009.tex
+    expect: ["TAB-009"]
+    expect_msgs:
+      - "TAB-009:Floating table missing \label"
+  - file: corpora/lint/l2_batch3/tab_010.tex
+    expect: ["TAB-010"]
+    expect_msgs:
+      - "TAB-010:Footnote placed inside table environment"
+  - file: corpora/lint/l2_batch3/tab_011.tex
+    expect: ["TAB-011"]
+    expect_msgs:
+      - "TAB-011:Top/bottom \hline instead of \toprule/\bottomrule"
+  - file: corpora/lint/l2_batch3/tab_014.tex
+    expect: ["TAB-014"]
+    expect_msgs:
+      - "TAB-014:Empty multicolumn alignment spec {} encountered"
+  - file: corpora/lint/l2_batch3/pkg_007.tex
+    expect: ["PKG-007"]
+    expect_msgs:
+      - "PKG-007:hyperref loaded before geometry"
+  - file: corpora/lint/l2_batch3/pkg_009.tex
+    expect: ["PKG-009"]
+    expect_msgs:
+      - "PKG-009:TikZ libraries loaded inside document body"
+  - file: corpora/lint/l2_batch3/pkg_011.tex
+    expect: ["PKG-011"]
+    expect_msgs:
+      - "PKG-011:booktabs required but not loaded for \toprule"
+  - file: corpora/lint/l2_batch3/pkg_012.tex
+    expect: ["PKG-012"]
+    expect_msgs:
+      - "PKG-012:csquotes not loaded when \enquote used"
+  - file: corpora/lint/l2_batch3/pkg_015.tex
+    expect: ["PKG-015"]
+    expect_msgs:
+      - "PKG-015:inputenc loaded under XeLaTeX/LuaLaTeX"
+  - file: corpora/lint/l2_batch3/pkg_020.tex
+    expect: ["PKG-020"]
+    expect_msgs:
+      - "PKG-020:tikz external library not loaded when externalising"
+  - file: corpora/lint/l2_batch3/pkg_022.tex
+    expect: ["PKG-022"]
+    expect_msgs:
+      - "PKG-022:Obsolete package (epsfig, subfigure, natbib) detected"
+  - file: corpora/lint/l2_batch3/pkg_023.tex
+    expect: ["PKG-023"]
+    expect_msgs:
+      - "PKG-023:unicode‑math must load before microtype"
+  - file: corpora/lint/l2_batch3/lang_002.tex
+    expect: ["LANG-002"]
+    expect_msgs:
+      - "LANG-002:babel language option missing"
+  - file: corpora/lint/l2_batch3/lang_004.tex
+    expect: ["LANG-004"]
+    expect_msgs:
+      - "LANG-004:Polyglossia loaded alongside babel – mutual exclusion"
+  - file: corpora/lint/l2_batch3/tikz_007.tex
+    expect: ["TIKZ-007"]
+    expect_msgs:
+      - "TIKZ-007:TikZ loaded after hyperref – reorder required"
+  - file: corpora/lint/l2_batch3/fig_010.tex
+    expect: ["FIG-010"]
+    expect_msgs:
+      - "FIG-010:Subfigure environment without \subcaption"
+  - file: corpora/lint/l2_batch3/fig_013.tex
+    expect: ["FIG-013"]
+    expect_msgs:
+      - "FIG-013:Graphicx option scale used instead of width"


### PR DESCRIPTION
## Summary
- **22 new L2-approximable rules** — package ordering, document structure, table hygiene
- **CMD** (1): AtBeginDocument after \begin{document}
- **DOC** (3): maketitle, abstract, keywords presence checks
- **TAB** (5): consecutive hline, missing label, footnote in table, hline vs booktabs, empty multicolumn
- **PKG** (8): hyperref/geometry ordering, TikZ lib in body, booktabs/csquotes command-pkg checks, inputenc under XeLaTeX, obsolete packages, tikz external lib, unicode-math/microtype ordering
- **LANG** (2): bare babel, polyglossia+babel mutual exclusion
- **TIKZ** (1): TikZ loaded after hyperref
- **FIG** (2): subfigure without subcaption, scale vs width option
- Total: **406/623 rules (65.2%)**

## Verification
- `dune build`: exit 0
- `dune build @fmt`: exit 0
- `validate_messages.sh`: 396/396, 0 mismatches
- `dune runtest --force`: all green
  - [l2-batch3] PASS 91 cases
  - [golden] PASS 162 cases (22 new)

## Test plan
- [x] 91 unit tests covering all 22 rules
- [x] 22 corpus files + 22 golden YAML entries
- [x] Full regression suite green (all existing tests pass)