### PR TITLE
feat: implement 22 L3_Semantics text-scannable approximation rules

### DIFF
--- a/corpora/lint/l3_text_approx/bib_002.tex
+++ b/corpora/lint/l3_text_approx/bib_002.tex
@@ -1,0 +1,7 @@
+@article{smith2020,
+  author = {Smith, John},
+  title = {A Study},
+  journal = {Nature},
+  year = {2020},
+  doi = {10.1234/foo},
+}

--- a/corpora/lint/l3_text_approx/bib_003.tex
+++ b/corpora/lint/l3_text_approx/bib_003.tex
@@ -1,0 +1,6 @@
+@article{jones2021,
+  author = {Jones, Alice},
+  title = {Observations},
+  journal = {Physical Review Letters},
+  year = {2021},
+}

--- a/corpora/lint/l3_text_approx/bib_004.tex
+++ b/corpora/lint/l3_text_approx/bib_004.tex
@@ -1,0 +1,5 @@
+@Book{knuth1984,
+  author = {Knuth, Donald},
+  title = {The TeXbook},
+  year = {1984},
+}

--- a/corpora/lint/l3_text_approx/bib_005.tex
+++ b/corpora/lint/l3_text_approx/bib_005.tex
@@ -1,0 +1,6 @@
+@online{web2023,
+  author = {Doe, Jane},
+  title = {A Web Resource},
+  year = {2023},
+  url = {http://example.com/resource},
+}

--- a/corpora/lint/l3_text_approx/bib_006.tex
+++ b/corpora/lint/l3_text_approx/bib_006.tex
@@ -1,0 +1,6 @@
+@article{doe2022,
+  author = {John Smith},
+  title = {Some Paper},
+  journal = {Nature},
+  year = {2022},
+}

--- a/corpora/lint/l3_text_approx/bib_008.tex
+++ b/corpora/lint/l3_text_approx/bib_008.tex
@@ -1,0 +1,6 @@
+@article{key2020,
+  Author = {Smith, John},
+  Title = {Some Title},
+  Journal = {Nature},
+  Year = {2020},
+}

--- a/corpora/lint/l3_text_approx/bib_009.tex
+++ b/corpora/lint/l3_text_approx/bib_009.tex
@@ -1,0 +1,5 @@
+@InProceedings{conf2021,
+  author = {Smith, John},
+  title = {A Conference Paper},
+  year = {2021},
+}

--- a/corpora/lint/l3_text_approx/bib_010.tex
+++ b/corpora/lint/l3_text_approx/bib_010.tex
@@ -1,0 +1,7 @@
+@article{num2020,
+  author = {Smith, John},
+  title = {Monthly Data},
+  journal = {Science},
+  year = {2020},
+  month = {3},
+}

--- a/corpora/lint/l3_text_approx/bib_011.tex
+++ b/corpora/lint/l3_text_approx/bib_011.tex
@@ -1,0 +1,7 @@
+@article{legacy2019,
+  author = {Smith, John},
+  title = {Old Reference},
+  journal = {Nature},
+  year = {2019},
+  note = {URL: http://example.com/old},
+}

--- a/corpora/lint/l3_text_approx/bib_012.tex
+++ b/corpora/lint/l3_text_approx/bib_012.tex
@@ -1,0 +1,6 @@
+@article{etal2020,
+  author = {Smith, John and Doe, Jane et al.},
+  title = {Collaborative Work},
+  journal = {Science},
+  year = {2020},
+}

--- a/corpora/lint/l3_text_approx/bib_015.tex
+++ b/corpora/lint/l3_text_approx/bib_015.tex
@@ -1,0 +1,6 @@
+@article{period2021,
+  author = {Smith, John},
+  title = {My Great Title.},
+  journal = {Nature},
+  year = {2021},
+}

--- a/corpora/lint/l3_text_approx/bib_016.tex
+++ b/corpora/lint/l3_text_approx/bib_016.tex
@@ -1,0 +1,8 @@
+@article{both2022,
+  author = {Smith, John},
+  title = {Redundant Locators},
+  journal = {Nature},
+  year = {2022},
+  doi = {10.1234/test},
+  url = {http://example.com/paper},
+}

--- a/corpora/lint/l3_text_approx/font_005.tex
+++ b/corpora/lint/l3_text_approx/font_005.tex
@@ -1,0 +1,5 @@
+\documentclass{article}
+\usepackage{fontspec}
+\begin{document}
+Hello world.
+\end{document}

--- a/corpora/lint/l3_text_approx/lay_015.tex
+++ b/corpora/lint/l3_text_approx/lay_015.tex
@@ -1,0 +1,5 @@
+\documentclass{article}
+\linespread{0.5}
+\begin{document}
+Hello world.
+\end{document}

--- a/corpora/lint/l3_text_approx/lay_020.tex
+++ b/corpora/lint/l3_text_approx/lay_020.tex
@@ -1,0 +1,5 @@
+\documentclass{article}
+\setcounter{topnumber}{4}
+\begin{document}
+Hello world.
+\end{document}

--- a/corpora/lint/l3_text_approx/lay_022.tex
+++ b/corpora/lint/l3_text_approx/lay_022.tex
@@ -1,0 +1,5 @@
+\documentclass{article}
+\setlength{\parskip}{-3pt}
+\begin{document}
+Hello world.
+\end{document}

--- a/corpora/lint/l3_text_approx/meta_001.tex
+++ b/corpora/lint/l3_text_approx/meta_001.tex
@@ -1,0 +1,5 @@
+\documentclass{article}
+\usepackage{hyperref}
+\begin{document}
+Hello world.
+\end{document}

--- a/corpora/lint/l3_text_approx/pdf_010.tex
+++ b/corpora/lint/l3_text_approx/pdf_010.tex
@@ -1,0 +1,5 @@
+\documentclass{article}
+\begin{document}
+\section{My_Section}
+Hello world.
+\end{document}

--- a/corpora/lint/l3_text_approx/pkg_018.tex
+++ b/corpora/lint/l3_text_approx/pkg_018.tex
@@ -1,0 +1,5 @@
+\documentclass{article}
+\usepackage[draft]{hyperref}
+\begin{document}
+Hello world.
+\end{document}

--- a/corpora/lint/l3_text_approx/pkg_019.tex
+++ b/corpora/lint/l3_text_approx/pkg_019.tex
@@ -1,0 +1,5 @@
+\documentclass{article}
+\usepackage[margin=0.5cm]{geometry}
+\begin{document}
+Hello world.
+\end{document}

--- a/corpora/lint/l3_text_approx/ref_008.tex
+++ b/corpora/lint/l3_text_approx/ref_008.tex
@@ -1,0 +1,13 @@
+@article{samekey,
+  author = {Smith, John},
+  title = {First Paper},
+  journal = {Nature},
+  year = {2020},
+}
+
+@article{samekey,
+  author = {Doe, Jane},
+  title = {Second Paper},
+  journal = {Science},
+  year = {2021},
+}

--- a/corpora/lint/l3_text_approx/tikz_005.tex
+++ b/corpora/lint/l3_text_approx/tikz_005.tex
@@ -1,0 +1,7 @@
+\documentclass{article}
+\usepackage{tikz}
+\begin{document}
+\begin{tikzpicture}
+\draw (0,0) -- (1,1);
+\end{tikzpicture}
+\end{document}

--- a/latex-parse/src/dune
+++ b/latex-parse/src/dune
@@ -336,6 +336,7 @@
   ../../specs/rules/l2_batch3_golden.yaml
   ../../specs/rules/l2_batch4_golden.yaml
   ../../specs/rules/l5_expl3_tikz_golden.yaml
+  ../../specs/rules/l3_text_approx_golden.yaml
   (source_tree ../../corpora)))
 
 (test
@@ -371,4 +372,9 @@
 (test
  (name test_validators_l5_expl3_tikz)
  (modules test_validators_l5_expl3_tikz)
+ (libraries latex_parse_lib unix))
+
+(test
+ (name test_validators_l3_text_approx)
+ (modules test_validators_l3_text_approx)
  (libraries latex_parse_lib unix))

--- a/latex-parse/src/test_golden_corpus.ml
+++ b/latex-parse/src/test_golden_corpus.ml
@@ -277,6 +277,9 @@ let () =
   run_golden_suite "l5_expl3_tikz"
     (Filename.concat base_dir "specs/rules/l5_expl3_tikz_golden.yaml")
     base_dir;
+  run_golden_suite "l3_text_approx"
+    (Filename.concat base_dir "specs/rules/l3_text_approx_golden.yaml")
+    base_dir;
   if !fails > 0 then (
     Printf.eprintf "[golden] %d failure(s) in %d cases\n%!" !fails !cases;
     exit 1)

--- a/latex-parse/src/test_validators_l3_text_approx.ml
+++ b/latex-parse/src/test_validators_l3_text_approx.ml
@@ -1,0 +1,795 @@
+(** Unit tests for L3 text-scannable approximation rules: 22 rules.
+    BIB-002..016, PKG-018/019, FONT-005, LAY-015/020/022, REF-008, META-001,
+    PDF-010, TIKZ-005.
+
+    ~100 total test cases. *)
+
+open Latex_parse_lib
+
+let fails = ref 0
+let cases = ref 0
+
+let expect cond msg =
+  incr cases;
+  if not cond then (
+    Printf.eprintf "FAIL: %s\n%!" msg;
+    incr fails)
+
+let run msg f =
+  let tag = Printf.sprintf "case %d: %s" (!cases + 1) msg in
+  f tag
+
+let find_result id results =
+  List.find_opt (fun (r : Validators.result) -> r.id = id) results
+
+let fires id src =
+  let results = Validators.run_all src in
+  match find_result id results with Some _ -> true | None -> false
+
+let does_not_fire id src =
+  let results = Validators.run_all src in
+  match find_result id results with Some _ -> false | None -> true
+
+let () =
+  Unix.putenv "L0_VALIDATORS" "pilot";
+
+  (* ══════════════════════════════════════════════════════════════════════
+     BIB-002: DOI not normalised to https://doi.org/ form
+     ══════════════════════════════════════════════════════════════════════ *)
+  run "BIB-002 fires: bare DOI" (fun tag ->
+      expect
+        (fires "BIB-002"
+           {|@article{key1,
+  author = {Smith, John},
+  doi = {10.1234/foo}
+}|})
+        (tag ^ ": bare DOI not https"));
+  run "BIB-002 fires: http DOI" (fun tag ->
+      expect
+        (fires "BIB-002"
+           {|@article{key1,
+  doi = {http://doi.org/10.1234/foo}
+}|})
+        (tag ^ ": http DOI not https"));
+  run "BIB-002 clean: https://doi.org/ DOI" (fun tag ->
+      expect
+        (does_not_fire "BIB-002"
+           {|@article{key1,
+  doi = {https://doi.org/10.1234/foo}
+}|})
+        (tag ^ ": normalised https doi"));
+  run "BIB-002 clean: no DOI field" (fun tag ->
+      expect
+        (does_not_fire "BIB-002"
+           {|@article{key1,
+  author = {Smith, John},
+  title = {A Paper}
+}|})
+        (tag ^ ": no doi field"));
+
+  (* ══════════════════════════════════════════════════════════════════════
+     BIB-003: Journal title capitalisation inconsistent
+     ══════════════════════════════════════════════════════════════════════ *)
+  run "BIB-003 fires: multiple cap words" (fun tag ->
+      expect
+        (fires "BIB-003"
+           {|@article{key1,
+  journal = {Physical Review Letters}
+}|})
+        (tag ^ ": Physical Review Letters"));
+  run "BIB-003 fires: two capitalised words" (fun tag ->
+      expect
+        (fires "BIB-003" {|@article{key1,
+  journal = {Nature Physics}
+}|})
+        (tag ^ ": Nature Physics"));
+  run "BIB-003 clean: abbreviation lowercase" (fun tag ->
+      expect
+        (does_not_fire "BIB-003"
+           {|@article{key1,
+  journal = {phys. rev. lett.}
+}|})
+        (tag ^ ": abbreviated lowercase"));
+  run "BIB-003 clean: single capitalised word" (fun tag ->
+      expect
+        (does_not_fire "BIB-003" {|@article{key1,
+  journal = {Nature}
+}|})
+        (tag ^ ": single cap word ok"));
+  run "BIB-003 clean: no journal field" (fun tag ->
+      expect
+        (does_not_fire "BIB-003" {|@article{key1,
+  title = {A Paper}
+}|})
+        (tag ^ ": no journal field"));
+
+  (* ══════════════════════════════════════════════════════════════════════
+     BIB-004: Book entry lacks publisher field
+     ══════════════════════════════════════════════════════════════════════ *)
+  run "BIB-004 fires: @Book without publisher" (fun tag ->
+      expect
+        (fires "BIB-004"
+           {|@Book{key1,
+  author = {Doe, Jane},
+  title = {My Book}
+}|})
+        (tag ^ ": Book without publisher"));
+  run "BIB-004 fires: @book lowercase without publisher" (fun tag ->
+      expect
+        (fires "BIB-004"
+           {|@book{key2,
+  author = {Doe, Jane},
+  title = {Another Book}
+}|})
+        (tag ^ ": book lowercase no publisher"));
+  run "BIB-004 clean: @Book with publisher" (fun tag ->
+      expect
+        (does_not_fire "BIB-004"
+           {|@Book{key1,
+  author = {Doe, Jane},
+  title = {My Book},
+  publisher = {Springer}
+}|})
+        (tag ^ ": Book with publisher"));
+  run "BIB-004 clean: @article (not book)" (fun tag ->
+      expect
+        (does_not_fire "BIB-004"
+           {|@article{key1,
+  author = {Doe, Jane},
+  title = {A Paper}
+}|})
+        (tag ^ ": article not book"));
+
+  (* ══════════════════════════════════════════════════════════════════════
+     BIB-005: URL present without urldate
+     ══════════════════════════════════════════════════════════════════════ *)
+  run "BIB-005 fires: url without urldate" (fun tag ->
+      expect
+        (fires "BIB-005"
+           {|@article{key1,
+  author = {Smith, John},
+  url = {http://example.com}
+}|})
+        (tag ^ ": url without urldate"));
+  run "BIB-005 fires: url with https but no urldate" (fun tag ->
+      expect
+        (fires "BIB-005" {|@misc{key2,
+  url = {https://example.org/path}
+}|})
+        (tag ^ ": https url no urldate"));
+  run "BIB-005 clean: url with urldate" (fun tag ->
+      expect
+        (does_not_fire "BIB-005"
+           {|@article{key1,
+  url = {http://example.com},
+  urldate = {2024-01-15}
+}|})
+        (tag ^ ": url with urldate"));
+  run "BIB-005 clean: no url field" (fun tag ->
+      expect
+        (does_not_fire "BIB-005"
+           {|@article{key1,
+  author = {Smith, John},
+  title = {A Paper}
+}|})
+        (tag ^ ": no url field"));
+
+  (* ══════════════════════════════════════════════════════════════════════
+     BIB-006: Author names not in "von Last, First" scheme
+     ══════════════════════════════════════════════════════════════════════ *)
+  run "BIB-006 fires: First Last pattern" (fun tag ->
+      expect
+        (fires "BIB-006" {|@article{key1,
+  author = {John Smith}
+}|})
+        (tag ^ ": John Smith = First Last"));
+  run "BIB-006 fires: First Last in multi-author" (fun tag ->
+      expect
+        (fires "BIB-006"
+           {|@article{key1,
+  author = {Alice Johnson and Bob Williams}
+}|})
+        (tag ^ ": First Last multi-author"));
+  run "BIB-006 clean: Last, First" (fun tag ->
+      expect
+        (does_not_fire "BIB-006" {|@article{key1,
+  author = {Smith, John}
+}|})
+        (tag ^ ": Smith, John ok"));
+  run "BIB-006 clean: Last, First multi-author" (fun tag ->
+      expect
+        (does_not_fire "BIB-006"
+           {|@article{key1,
+  author = {Smith, John and Doe, Jane}
+}|})
+        (tag ^ ": Last, First multi ok"));
+
+  (* ══════════════════════════════════════════════════════════════════════
+     BIB-008: CamelCase field names
+     ══════════════════════════════════════════════════════════════════════ *)
+  run "BIB-008 fires: Title capitalised field" (fun tag ->
+      expect
+        (fires "BIB-008" {|@article{key1,
+  Title = {Some Title}
+}|})
+        (tag ^ ": Title capitalised"));
+  run "BIB-008 fires: Author capitalised field" (fun tag ->
+      expect
+        (fires "BIB-008" {|@article{key1,
+  Author = {Doe, Jane}
+}|})
+        (tag ^ ": Author capitalised"));
+  run "BIB-008 clean: lowercase field" (fun tag ->
+      expect
+        (does_not_fire "BIB-008" {|@article{key1,
+  title = {Some Title}
+}|})
+        (tag ^ ": lowercase title ok"));
+  run "BIB-008 clean: no bib entries" (fun tag ->
+      expect
+        (does_not_fire "BIB-008" {|Just some plain text with Title = {foo}.|})
+        (tag ^ ": no bib entry context"));
+
+  (* ══════════════════════════════════════════════════════════════════════
+     BIB-009: inproceedings missing booktitle
+     ══════════════════════════════════════════════════════════════════════ *)
+  run "BIB-009 fires: @InProceedings no booktitle" (fun tag ->
+      expect
+        (fires "BIB-009"
+           {|@InProceedings{key1,
+  author = {Doe, Jane},
+  title = {A Paper}
+}|})
+        (tag ^ ": InProceedings no booktitle"));
+  run "BIB-009 fires: @inproceedings lowercase no booktitle" (fun tag ->
+      expect
+        (fires "BIB-009" {|@inproceedings{key2,
+  author = {Smith, John}
+}|})
+        (tag ^ ": inproceedings no booktitle"));
+  run "BIB-009 clean: @InProceedings with booktitle" (fun tag ->
+      expect
+        (does_not_fire "BIB-009"
+           {|@InProceedings{key1,
+  author = {Doe, Jane},
+  booktitle = {Proceedings of ICML}
+}|})
+        (tag ^ ": has booktitle"));
+  run "BIB-009 clean: @article (not inproceedings)" (fun tag ->
+      expect
+        (does_not_fire "BIB-009"
+           {|@article{key1,
+  author = {Doe, Jane},
+  title = {A Paper}
+}|})
+        (tag ^ ": article not inproceedings"));
+
+  (* ══════════════════════════════════════════════════════════════════════
+     BIB-010: month uses numeric literal
+     ══════════════════════════════════════════════════════════════════════ *)
+  run "BIB-010 fires: month = {3}" (fun tag ->
+      expect
+        (fires "BIB-010" {|@article{key1,
+  month = {3}
+}|})
+        (tag ^ ": month numeric brace"));
+  run "BIB-010 fires: month = \"March\"" (fun tag ->
+      expect
+        (fires "BIB-010" {|@article{key1,
+  month = "March"
+}|})
+        (tag ^ ": month quoted string"));
+  run "BIB-010 clean: month = mar (bare macro)" (fun tag ->
+      expect
+        (does_not_fire "BIB-010" {|@article{key1,
+  month = mar
+}|})
+        (tag ^ ": bare macro ok"));
+  run "BIB-010 clean: no month field" (fun tag ->
+      expect
+        (does_not_fire "BIB-010" {|@article{key1,
+  author = {Smith, John}
+}|})
+        (tag ^ ": no month field"));
+
+  (* ══════════════════════════════════════════════════════════════════════
+     BIB-011: Legacy note URL
+     ══════════════════════════════════════════════════════════════════════ *)
+  run "BIB-011 fires: note = {URL: http...}" (fun tag ->
+      expect
+        (fires "BIB-011" {|@article{key1,
+  note = {URL: http://example.com}
+}|})
+        (tag ^ ": note URL: prefix"));
+  run "BIB-011 fires: note = {http://...}" (fun tag ->
+      expect
+        (fires "BIB-011"
+           {|@article{key1,
+  note = {http://example.com/paper}
+}|})
+        (tag ^ ": note bare http"));
+  run "BIB-011 clean: url in url field" (fun tag ->
+      expect
+        (does_not_fire "BIB-011"
+           {|@article{key1,
+  url = {http://example.com},
+  note = {Some general note}
+}|})
+        (tag ^ ": url in url field ok"));
+  run "BIB-011 clean: note without URL" (fun tag ->
+      expect
+        (does_not_fire "BIB-011"
+           {|@article{key1,
+  note = {Published in print edition}
+}|})
+        (tag ^ ": note no URL"));
+
+  (* ══════════════════════════════════════════════════════════════════════
+     BIB-012: et al. hard-coded in author
+     ══════════════════════════════════════════════════════════════════════ *)
+  run "BIB-012 fires: et al. in author" (fun tag ->
+      expect
+        (fires "BIB-012"
+           {|@article{key1,
+  author = {Smith, John and others et al.}
+}|})
+        (tag ^ ": et al. hardcoded"));
+  run "BIB-012 fires: et al. trailing" (fun tag ->
+      expect
+        (fires "BIB-012" {|@article{key1,
+  author = {Doe, Jane et al.}
+}|})
+        (tag ^ ": et al. trailing"));
+  run "BIB-012 clean: no et al." (fun tag ->
+      expect
+        (does_not_fire "BIB-012"
+           {|@article{key1,
+  author = {Smith, John and Others}
+}|})
+        (tag ^ ": and Others ok"));
+  run "BIB-012 clean: no author field" (fun tag ->
+      expect
+        (does_not_fire "BIB-012" {|@article{key1,
+  title = {A Paper}
+}|})
+        (tag ^ ": no author"));
+
+  (* ══════════════════════════════════════════════════════════════════════
+     BIB-015: Trailing period in title/note
+     ══════════════════════════════════════════════════════════════════════ *)
+  run "BIB-015 fires: title with trailing period" (fun tag ->
+      expect
+        (fires "BIB-015" {|@article{key1,
+  title = {My Title.}
+}|})
+        (tag ^ ": title trailing period"));
+  run "BIB-015 fires: note with trailing period" (fun tag ->
+      expect
+        (fires "BIB-015" {|@article{key1,
+  note = {Some note text.}
+}|})
+        (tag ^ ": note trailing period"));
+  run "BIB-015 clean: title without trailing period" (fun tag ->
+      expect
+        (does_not_fire "BIB-015" {|@article{key1,
+  title = {My Title}
+}|})
+        (tag ^ ": no trailing period"));
+  run "BIB-015 clean: no title or note" (fun tag ->
+      expect
+        (does_not_fire "BIB-015" {|@article{key1,
+  author = {Smith, John}
+}|})
+        (tag ^ ": no title/note"));
+
+  (* ══════════════════════════════════════════════════════════════════════
+     BIB-016: Both DOI and URL present
+     ══════════════════════════════════════════════════════════════════════ *)
+  run "BIB-016 fires: doi + url in same entry" (fun tag ->
+      expect
+        (fires "BIB-016"
+           {|@article{key1,
+  doi = {10.1234/foo},
+  url = {http://example.com}
+}|})
+        (tag ^ ": both doi and url"));
+  run "BIB-016 fires: doi + url with https" (fun tag ->
+      expect
+        (fires "BIB-016"
+           {|@article{key1,
+  doi = {https://doi.org/10.1234/foo},
+  url = {https://example.com/paper}
+}|})
+        (tag ^ ": doi + https url"));
+  run "BIB-016 clean: doi only" (fun tag ->
+      expect
+        (does_not_fire "BIB-016" {|@article{key1,
+  doi = {10.1234/foo}
+}|})
+        (tag ^ ": doi only ok"));
+  run "BIB-016 clean: url only" (fun tag ->
+      expect
+        (does_not_fire "BIB-016"
+           {|@article{key1,
+  url = {http://example.com}
+}|})
+        (tag ^ ": url only ok"));
+  run "BIB-016 clean: doi + urldate (no bare url)" (fun tag ->
+      expect
+        (does_not_fire "BIB-016"
+           {|@article{key1,
+  doi = {10.1234/foo},
+  urldate = {2024-01-15}
+}|})
+        (tag ^ ": doi + urldate, no url"));
+
+  (* ══════════════════════════════════════════════════════════════════════
+     PKG-018: hyperref draft left enabled
+     ══════════════════════════════════════════════════════════════════════ *)
+  run "PKG-018 fires: usepackage[draft]{hyperref}" (fun tag ->
+      expect
+        (fires "PKG-018"
+           {|\documentclass{article}
+\usepackage[draft]{hyperref}
+\begin{document}\end{document}|})
+        (tag ^ ": draft option in usepackage"));
+  run "PKG-018 fires: hypersetup{draft=true}" (fun tag ->
+      expect
+        (fires "PKG-018"
+           {|\documentclass{article}
+\usepackage{hyperref}
+\hypersetup{draft=true}
+\begin{document}\end{document}|})
+        (tag ^ ": draft=true in hypersetup"));
+  run "PKG-018 clean: usepackage{hyperref} no draft" (fun tag ->
+      expect
+        (does_not_fire "PKG-018"
+           {|\documentclass{article}
+\usepackage{hyperref}
+\begin{document}\end{document}|})
+        (tag ^ ": no draft option"));
+  run "PKG-018 clean: no hyperref" (fun tag ->
+      expect
+        (does_not_fire "PKG-018"
+           {|\documentclass{article}
+\begin{document}\end{document}|})
+        (tag ^ ": no hyperref"));
+
+  (* ══════════════════════════════════════════════════════════════════════
+     PKG-019: geometry margin < 1 cm
+     ══════════════════════════════════════════════════════════════════════ *)
+  run "PKG-019 fires: geometry margin=0.5cm" (fun tag ->
+      expect
+        (fires "PKG-019"
+           {|\documentclass{article}
+\geometry{margin=0.5cm}
+\begin{document}\end{document}|})
+        (tag ^ ": margin 0.5cm"));
+  run "PKG-019 fires: geometry left=0.2cm" (fun tag ->
+      expect
+        (fires "PKG-019"
+           {|\documentclass{article}
+\geometry{left=0.2cm}
+\begin{document}\end{document}|})
+        (tag ^ ": left 0.2cm"));
+  run "PKG-019 fires: geometry bottom=0cm" (fun tag ->
+      expect
+        (fires "PKG-019"
+           {|\documentclass{article}
+\geometry{bottom=0cm}
+\begin{document}\end{document}|})
+        (tag ^ ": bottom 0cm"));
+  run "PKG-019 clean: geometry margin=2cm" (fun tag ->
+      expect
+        (does_not_fire "PKG-019"
+           {|\documentclass{article}
+\geometry{margin=2cm}
+\begin{document}\end{document}|})
+        (tag ^ ": margin 2cm ok"));
+  run "PKG-019 clean: no geometry" (fun tag ->
+      expect
+        (does_not_fire "PKG-019"
+           {|\documentclass{article}
+\begin{document}\end{document}|})
+        (tag ^ ": no geometry"));
+
+  (* ══════════════════════════════════════════════════════════════════════
+     FONT-005: fontspec fallback to Latin Modern
+     ══════════════════════════════════════════════════════════════════════ *)
+  run "FONT-005 fires: fontspec without setmainfont" (fun tag ->
+      expect
+        (fires "FONT-005"
+           {|\documentclass{article}
+\usepackage{fontspec}
+\begin{document}\end{document}|})
+        (tag ^ ": fontspec no setmainfont"));
+  run "FONT-005 fires: fontspec + setmainfont{Latin Modern Roman}" (fun tag ->
+      expect
+        (fires "FONT-005"
+           {|\documentclass{article}
+\usepackage{fontspec}
+\setmainfont{Latin Modern Roman}
+\begin{document}\end{document}|})
+        (tag ^ ": explicit Latin Modern"));
+  run "FONT-005 clean: fontspec + setmainfont{TeX Gyre Termes}" (fun tag ->
+      expect
+        (does_not_fire "FONT-005"
+           {|\documentclass{article}
+\usepackage{fontspec}
+\setmainfont{TeX Gyre Termes}
+\begin{document}\end{document}|})
+        (tag ^ ": non-LM font ok"));
+  run "FONT-005 clean: no fontspec" (fun tag ->
+      expect
+        (does_not_fire "FONT-005"
+           {|\documentclass{article}
+\begin{document}\end{document}|})
+        (tag ^ ": no fontspec"));
+
+  (* ══════════════════════════════════════════════════════════════════════
+     LAY-015: Line spacing < 1 or > 2
+     ══════════════════════════════════════════════════════════════════════ *)
+  run "LAY-015 fires: linespread{0.8}" (fun tag ->
+      expect
+        (fires "LAY-015"
+           {|\documentclass{article}
+\linespread{0.8}
+\begin{document}\end{document}|})
+        (tag ^ ": linespread 0.8"));
+  run "LAY-015 fires: setstretch{3.0}" (fun tag ->
+      expect
+        (fires "LAY-015"
+           {|\documentclass{article}
+\usepackage{setspace}
+\setstretch{3.0}
+\begin{document}\end{document}|})
+        (tag ^ ": setstretch 3.0"));
+  run "LAY-015 fires: linespread{0.5}" (fun tag ->
+      expect
+        (fires "LAY-015"
+           {|\documentclass{article}
+\linespread{0.5}
+\begin{document}\end{document}|})
+        (tag ^ ": linespread 0.5"));
+  run "LAY-015 clean: linespread{1.5}" (fun tag ->
+      expect
+        (does_not_fire "LAY-015"
+           {|\documentclass{article}
+\linespread{1.5}
+\begin{document}\end{document}|})
+        (tag ^ ": linespread 1.5 ok"));
+  run "LAY-015 clean: no spacing commands" (fun tag ->
+      expect
+        (does_not_fire "LAY-015"
+           {|\documentclass{article}
+\begin{document}\end{document}|})
+        (tag ^ ": no spacing commands"));
+
+  (* ══════════════════════════════════════════════════════════════════════
+     LAY-020: Float placement params modified
+     ══════════════════════════════════════════════════════════════════════ *)
+  run "LAY-020 fires: setcounter{topnumber}" (fun tag ->
+      expect
+        (fires "LAY-020"
+           {|\documentclass{article}
+\setcounter{topnumber}{2}
+\begin{document}\end{document}|})
+        (tag ^ ": setcounter topnumber"));
+  run "LAY-020 fires: renewcommand topfraction" (fun tag ->
+      expect
+        (fires "LAY-020"
+           {|\documentclass{article}
+\renewcommand{\topfraction}{0.9}
+\begin{document}\end{document}|})
+        (tag ^ ": renewcommand topfraction"));
+  run "LAY-020 fires: setcounter{bottomnumber}" (fun tag ->
+      expect
+        (fires "LAY-020"
+           {|\documentclass{article}
+\setcounter{bottomnumber}{1}
+\begin{document}\end{document}|})
+        (tag ^ ": setcounter bottomnumber"));
+  run "LAY-020 clean: no float params" (fun tag ->
+      expect
+        (does_not_fire "LAY-020"
+           {|\documentclass{article}
+\begin{document}\end{document}|})
+        (tag ^ ": no float params"));
+
+  (* ══════════════════════════════════════════════════════════════════════
+     LAY-022: Global negative parskip
+     ══════════════════════════════════════════════════════════════════════ *)
+  run "LAY-022 fires: negative parskip" (fun tag ->
+      expect
+        (fires "LAY-022"
+           {|\documentclass{article}
+\setlength{\parskip}{-3pt}
+\begin{document}\end{document}|})
+        (tag ^ ": negative parskip"));
+  run "LAY-022 fires: negative parskip small" (fun tag ->
+      expect
+        (fires "LAY-022"
+           {|\documentclass{article}
+\setlength{\parskip}{-1mm}
+\begin{document}\end{document}|})
+        (tag ^ ": negative parskip -1mm"));
+  run "LAY-022 clean: positive parskip" (fun tag ->
+      expect
+        (does_not_fire "LAY-022"
+           {|\documentclass{article}
+\setlength{\parskip}{6pt}
+\begin{document}\end{document}|})
+        (tag ^ ": positive parskip ok"));
+  run "LAY-022 clean: no parskip" (fun tag ->
+      expect
+        (does_not_fire "LAY-022"
+           {|\documentclass{article}
+\begin{document}\end{document}|})
+        (tag ^ ": no parskip"));
+
+  (* ══════════════════════════════════════════════════════════════════════
+     REF-008: Duplicate cite key in .bib file
+     ══════════════════════════════════════════════════════════════════════ *)
+  run "REF-008 fires: duplicate key" (fun tag ->
+      expect
+        (fires "REF-008"
+           {|@article{samekey,
+  author = {Smith, John}
+}
+@article{samekey,
+  author = {Doe, Jane}
+}|})
+        (tag ^ ": duplicate samekey"));
+  run "REF-008 fires: duplicate across types" (fun tag ->
+      expect
+        (fires "REF-008"
+           {|@article{mykey,
+  title = {Paper A}
+}
+@inproceedings{mykey,
+  title = {Paper B}
+}|})
+        (tag ^ ": duplicate mykey across types"));
+  run "REF-008 clean: unique keys" (fun tag ->
+      expect
+        (does_not_fire "REF-008"
+           {|@article{key1,
+  author = {Smith, John}
+}
+@article{key2,
+  author = {Doe, Jane}
+}|})
+        (tag ^ ": unique keys ok"));
+  run "REF-008 clean: single entry" (fun tag ->
+      expect
+        (does_not_fire "REF-008"
+           {|@article{onlykey,
+  author = {Smith, John}
+}|})
+        (tag ^ ": single entry ok"));
+
+  (* ══════════════════════════════════════════════════════════════════════
+     META-001: PDF /Producer not set
+     ══════════════════════════════════════════════════════════════════════ *)
+  run "META-001 fires: hyperref without pdfproducer" (fun tag ->
+      expect
+        (fires "META-001"
+           {|\documentclass{article}
+\usepackage{hyperref}
+\begin{document}\end{document}|})
+        (tag ^ ": hyperref no pdfproducer"));
+  run "META-001 fires: hyperref with options, no pdfproducer" (fun tag ->
+      expect
+        (fires "META-001"
+           {|\documentclass{article}
+\usepackage[colorlinks=true]{hyperref}
+\begin{document}\end{document}|})
+        (tag ^ ": hyperref opts no pdfproducer"));
+  run "META-001 clean: hyperref + pdfproducer" (fun tag ->
+      expect
+        (does_not_fire "META-001"
+           {|\documentclass{article}
+\usepackage{hyperref}
+\hypersetup{pdfproducer=MyTool}
+\begin{document}\end{document}|})
+        (tag ^ ": hyperref + pdfproducer"));
+  run "META-001 clean: no hyperref" (fun tag ->
+      expect
+        (does_not_fire "META-001"
+           {|\documentclass{article}
+\begin{document}\end{document}|})
+        (tag ^ ": no hyperref"));
+
+  (* ══════════════════════════════════════════════════════════════════════
+     PDF-010: Bookmark text contains _ or # without texorpdfstring
+     ══════════════════════════════════════════════════════════════════════ *)
+  run "PDF-010 fires: section with underscore" (fun tag ->
+      expect
+        (fires "PDF-010"
+           {|\documentclass{article}
+\begin{document}
+\section{A_B}
+\end{document}|})
+        (tag ^ ": section with _"));
+  run "PDF-010 fires: subsection with hash" (fun tag ->
+      expect
+        (fires "PDF-010"
+           {|\documentclass{article}
+\begin{document}
+\subsection{Item #1}
+\end{document}|})
+        (tag ^ ": subsection with #"));
+  run "PDF-010 clean: section no special chars" (fun tag ->
+      expect
+        (does_not_fire "PDF-010"
+           {|\documentclass{article}
+\begin{document}
+\section{Introduction}
+\end{document}|})
+        (tag ^ ": section clean text"));
+  run "PDF-010 clean: texorpdfstring used" (fun tag ->
+      expect
+        (does_not_fire "PDF-010"
+           {|\documentclass{article}
+\begin{document}
+\section{\texorpdfstring{A_B}{AB}}
+\end{document}|})
+        (tag ^ ": texorpdfstring used"));
+  run "PDF-010 clean: no section commands" (fun tag ->
+      expect
+        (does_not_fire "PDF-010" {|Just plain text with _ and # chars.|})
+        (tag ^ ": no section commands"));
+
+  (* ══════════════════════════════════════════════════════════════════════
+     TIKZ-005: TikZ externalisation not enabled
+     ══════════════════════════════════════════════════════════════════════ *)
+  run "TIKZ-005 fires: tikzpicture without external" (fun tag ->
+      expect
+        (fires "TIKZ-005"
+           {|\documentclass{article}
+\begin{document}
+\begin{tikzpicture}
+\draw (0,0) -- (1,1);
+\end{tikzpicture}
+\end{document}|})
+        (tag ^ ": tikzpicture no external"));
+  run "TIKZ-005 fires: multiple tikzpicture no external" (fun tag ->
+      expect
+        (fires "TIKZ-005"
+           {|\begin{tikzpicture}
+\draw (0,0) circle (1);
+\end{tikzpicture}
+\begin{tikzpicture}
+\fill (0,0) rectangle (2,2);
+\end{tikzpicture}|})
+        (tag ^ ": two tikzpictures no external"));
+  run "TIKZ-005 clean: usetikzlibrary{external}" (fun tag ->
+      expect
+        (does_not_fire "TIKZ-005"
+           {|\usetikzlibrary{external}
+\begin{tikzpicture}
+\draw (0,0) -- (1,1);
+\end{tikzpicture}|})
+        (tag ^ ": external library loaded"));
+  run "TIKZ-005 clean: tikzexternalize" (fun tag ->
+      expect
+        (does_not_fire "TIKZ-005"
+           {|\tikzexternalize
+\begin{tikzpicture}
+\draw (0,0) -- (1,1);
+\end{tikzpicture}|})
+        (tag ^ ": tikzexternalize command"));
+  run "TIKZ-005 clean: no tikzpicture" (fun tag ->
+      expect
+        (does_not_fire "TIKZ-005"
+           {|\documentclass{article}
+\begin{document}
+Hello world.
+\end{document}|})
+        (tag ^ ": no tikzpicture"));
+
+  (* ══════════════════════════════════════════════════════════════════════
+     Summary
+     ══════════════════════════════════════════════════════════════════════ *)
+  Printf.printf "l3-text-approx: %d/%d passed\n%!" (!cases - !fails) !cases;
+  if !fails > 0 then exit 1

--- a/latex-parse/src/validators.ml
+++ b/latex-parse/src/validators.ml
@@ -9620,6 +9620,782 @@ let r_rtl_005 : rule =
   in
   { id = "RTL-005"; run }
 
+(* ── BIB rules: bibliography field / entry hygiene ──────────────── *)
+
+(* Helper: split bib content into individual entries. Each entry starts with
+   @type{key, and ends at the next @ or EOF. *)
+let split_bib_entries (s : string) : string list =
+  let re = Str.regexp "@[a-zA-Z]+{" in
+  let entries = ref [] in
+  let starts = ref [] in
+  let i = ref 0 in
+  (try
+     while true do
+       let pos = Str.search_forward re s !i in
+       starts := pos :: !starts;
+       i := pos + 1
+     done
+   with Not_found -> ());
+  let starts_list = List.rev !starts in
+  let n = String.length s in
+  let rec build = function
+    | [] -> ()
+    | [ p ] -> entries := String.sub s p (n - p) :: !entries
+    | p :: (q :: _ as rest) ->
+        entries := String.sub s p (q - p) :: !entries;
+        build rest
+  in
+  build starts_list;
+  List.rev !entries
+
+(* Helper: count regex matches *)
+let count_matches (re : Str.regexp) (s : string) : int =
+  let cnt = ref 0 in
+  let i = ref 0 in
+  (try
+     while true do
+       let _ = Str.search_forward re s !i in
+       incr cnt;
+       i := Str.match_end ()
+     done
+   with Not_found -> ());
+  !cnt
+
+(* BIB-002: DOI not normalised to https://doi.org/ form *)
+let r_bib_002 : rule =
+  let re_doi = Str.regexp {|doi[ \t]*=[ \t]*{|} in
+  let re_good = Str.regexp_string "https://doi.org/" in
+  let run s =
+    let cnt = ref 0 in
+    let i = ref 0 in
+    (try
+       while true do
+         let pos = Str.search_forward re_doi s !i in
+         let after = Str.match_end () in
+         let is_good =
+           try
+             let _ = Str.search_forward re_good s after in
+             Str.match_beginning () = after
+           with Not_found -> false
+         in
+         if not is_good then incr cnt;
+         i := pos + 1
+       done
+     with Not_found -> ());
+    if !cnt > 0 then
+      Some
+        {
+          id = "BIB-002";
+          severity = Info;
+          message = "DOI not normalised to https://doi.org/ form";
+          count = !cnt;
+        }
+    else None
+  in
+  { id = "BIB-002"; run }
+
+(* BIB-003: Journal title capitalisation inconsistent with @string definition *)
+let r_bib_003 : rule =
+  let re_journal = Str.regexp {|journal[ \t]*=[ \t]*{|} in
+  let re_cap_word = Str.regexp {|[A-Z][a-z]+|} in
+  let run s =
+    let cnt = ref 0 in
+    let i = ref 0 in
+    (try
+       while true do
+         let pos = Str.search_forward re_journal s !i in
+         let after = Str.match_end () in
+         (* find closing brace *)
+         let j = ref after in
+         let depth = ref 1 in
+         let n = String.length s in
+         while !j < n && !depth > 0 do
+           (match s.[!j] with '{' -> incr depth | '}' -> decr depth | _ -> ());
+           if !depth > 0 then incr j
+         done;
+         let content = String.sub s after (!j - after) in
+         (* Count capitalised words *)
+         let cap_count = count_matches re_cap_word content in
+         if cap_count >= 2 then incr cnt;
+         i := pos + 1
+       done
+     with Not_found -> ());
+    if !cnt > 0 then
+      Some
+        {
+          id = "BIB-003";
+          severity = Info;
+          message =
+            "Journal title capitalisation inconsistent with @string definition";
+          count = !cnt;
+        }
+    else None
+  in
+  { id = "BIB-003"; run }
+
+(* BIB-004: Book entry lacks publisher field *)
+let r_bib_004 : rule =
+  let re_book = Str.regexp {|@[Bb]ook{|} in
+  let re_publisher = Str.regexp {|publisher[ \t]*=|} in
+  let run s =
+    let entries = split_bib_entries s in
+    let cnt = ref 0 in
+    List.iter
+      (fun entry ->
+        let is_book =
+          try
+            let _ = Str.search_forward re_book entry 0 in
+            true
+          with Not_found -> false
+        in
+        if is_book then
+          let has_pub =
+            try
+              let _ = Str.search_forward re_publisher entry 0 in
+              true
+            with Not_found -> false
+          in
+          if not has_pub then incr cnt)
+      entries;
+    if !cnt > 0 then
+      Some
+        {
+          id = "BIB-004";
+          severity = Warning;
+          message = "Book entry lacks publisher field";
+          count = !cnt;
+        }
+    else None
+  in
+  { id = "BIB-004"; run }
+
+(* BIB-005: URL present without urldate *)
+let r_bib_005 : rule =
+  let re_url = Str.regexp {|url[ \t]*=[ \t]*{|} in
+  let re_urldate = Str.regexp {|urldate[ \t]*=[ \t]*{|} in
+  let run s =
+    let entries = split_bib_entries s in
+    let cnt = ref 0 in
+    List.iter
+      (fun entry ->
+        (* Count url= matches minus urldate= matches to get true url count *)
+        let url_count = count_matches re_url entry in
+        let urldate_count = count_matches re_urldate entry in
+        let has_url = url_count > urldate_count in
+        if has_url then
+          let has_urldate = urldate_count > 0 in
+          if not has_urldate then incr cnt)
+      entries;
+    if !cnt > 0 then
+      Some
+        {
+          id = "BIB-005";
+          severity = Info;
+          message = "URL present without urldate";
+          count = !cnt;
+        }
+    else None
+  in
+  { id = "BIB-005"; run }
+
+(* BIB-006: Author/editor names not in "von Last, First" scheme *)
+let r_bib_006 : rule =
+  let re_author = Str.regexp {|author[ \t]*=[ \t]*{|} in
+  let re_first_last = Str.regexp {|{[A-Z][a-z]+ [A-Z]|} in
+  let run s =
+    let cnt = ref 0 in
+    let i = ref 0 in
+    (try
+       while true do
+         let pos = Str.search_forward re_author s !i in
+         let after = Str.match_end () in
+         (* find closing brace *)
+         let j = ref after in
+         let depth = ref 1 in
+         let n = String.length s in
+         while !j < n && !depth > 0 do
+           (match s.[!j] with '{' -> incr depth | '}' -> decr depth | _ -> ());
+           if !depth > 0 then incr j
+         done;
+         let content = String.sub s (after - 1) (!j - after + 2) in
+         let is_first_last =
+           try
+             let _ = Str.search_forward re_first_last content 0 in
+             (* Check there's no comma before the match — if comma present, it's
+                "Last, First" which is fine *)
+             let matched_pos = Str.match_beginning () in
+             let before = String.sub content 0 matched_pos in
+             not (String.contains before ',')
+           with Not_found -> false
+         in
+         if is_first_last then incr cnt;
+         i := pos + 1
+       done
+     with Not_found -> ());
+    if !cnt > 0 then
+      Some
+        {
+          id = "BIB-006";
+          severity = Info;
+          message = "Author/editor names not in “von Last, First” scheme";
+          count = !cnt;
+        }
+    else None
+  in
+  { id = "BIB-006"; run }
+
+(* BIB-008: Camel-case field names detected *)
+let r_bib_008 : rule =
+  let re = Str.regexp {|[A-Z][a-z]+ *= *{|} in
+  let re_entry = Str.regexp "@[a-zA-Z]+{" in
+  let run s =
+    (* Only flag inside bib entries *)
+    let has_bib =
+      try
+        let _ = Str.search_forward re_entry s 0 in
+        true
+      with Not_found -> false
+    in
+    if not has_bib then None
+    else
+      let cnt = count_matches re s in
+      if cnt > 0 then
+        Some
+          {
+            id = "BIB-008";
+            severity = Info;
+            message = "Camel‑case field names detected (e.g. `Title` → `title`)";
+            count = cnt;
+          }
+      else None
+  in
+  { id = "BIB-008"; run }
+
+(* BIB-009: In-proceedings entry missing required `booktitle` field *)
+let r_bib_009 : rule =
+  let re_inproc = Str.regexp {|@[Ii]n[Pp]roceedings{|} in
+  let re_booktitle = Str.regexp {|booktitle[ \t]*=|} in
+  let run s =
+    let entries = split_bib_entries s in
+    let cnt = ref 0 in
+    List.iter
+      (fun entry ->
+        let is_inproc =
+          try
+            let _ = Str.search_forward re_inproc entry 0 in
+            true
+          with Not_found -> false
+        in
+        if is_inproc then
+          let has_bt =
+            try
+              let _ = Str.search_forward re_booktitle entry 0 in
+              true
+            with Not_found -> false
+          in
+          if not has_bt then incr cnt)
+      entries;
+    if !cnt > 0 then
+      Some
+        {
+          id = "BIB-009";
+          severity = Error;
+          message = "In‑proceedings entry missing required `booktitle` field";
+          count = !cnt;
+        }
+    else None
+  in
+  { id = "BIB-009"; run }
+
+(* BIB-010: `month` field uses numeric literal instead of `#jan#` macro *)
+let r_bib_010 : rule =
+  let re = Str.regexp {|month[ \t]*=[ \t]*[{0-9"]|} in
+  let run s =
+    let cnt = count_matches re s in
+    if cnt > 0 then
+      Some
+        {
+          id = "BIB-010";
+          severity = Info;
+          message =
+            "`month` field uses numeric literal instead of `#jan#` macro";
+          count = cnt;
+        }
+    else None
+  in
+  { id = "BIB-010"; run }
+
+(* BIB-011: Legacy `note = {URL: ...}` field detected; move to `url` *)
+let r_bib_011 : rule =
+  let re = Str.regexp {|note[ \t]*=[ \t]*{\(URL:\|http\)|} in
+  let run s =
+    let cnt = count_matches re s in
+    if cnt > 0 then
+      Some
+        {
+          id = "BIB-011";
+          severity = Info;
+          message = "Legacy `note = {URL: …}` field detected; move to `url`";
+          count = cnt;
+        }
+    else None
+  in
+  { id = "BIB-011"; run }
+
+(* BIB-012: `et al.` hard-coded in author list instead of letting Bib(La)TeX
+   truncate *)
+let r_bib_012 : rule =
+  let re_author = Str.regexp {|author[ \t]*=[ \t]*{|} in
+  let re_etal = Str.regexp_string "et al." in
+  let run s =
+    let cnt = ref 0 in
+    let i = ref 0 in
+    (try
+       while true do
+         let pos = Str.search_forward re_author s !i in
+         let after = Str.match_end () in
+         (* find closing brace *)
+         let j = ref after in
+         let depth = ref 1 in
+         let n = String.length s in
+         while !j < n && !depth > 0 do
+           (match s.[!j] with '{' -> incr depth | '}' -> decr depth | _ -> ());
+           if !depth > 0 then incr j
+         done;
+         let content = String.sub s after (!j - after) in
+         let has_etal =
+           try
+             let _ = Str.search_forward re_etal content 0 in
+             true
+           with Not_found -> false
+         in
+         if has_etal then incr cnt;
+         i := pos + 1
+       done
+     with Not_found -> ());
+    if !cnt > 0 then
+      Some
+        {
+          id = "BIB-012";
+          severity = Warning;
+          message =
+            "`et al.` hard‑coded in author list instead of letting Bib(La)TeX \
+             truncate";
+          count = !cnt;
+        }
+    else None
+  in
+  { id = "BIB-012"; run }
+
+(* BIB-015: Trailing period in `title` or `note` field is redundant *)
+let r_bib_015 : rule =
+  let re = Str.regexp {|\(title\|note\)[ \t]*=[ \t]*{|} in
+  let run s =
+    let cnt = ref 0 in
+    let i = ref 0 in
+    (try
+       while true do
+         let pos = Str.search_forward re s !i in
+         let after = Str.match_end () in
+         (* find closing brace *)
+         let j = ref after in
+         let depth = ref 1 in
+         let n = String.length s in
+         while !j < n && !depth > 0 do
+           (match s.[!j] with '{' -> incr depth | '}' -> decr depth | _ -> ());
+           if !depth > 0 then incr j
+         done;
+         (* Check if char before closing brace is a period *)
+         if !j > after && s.[!j - 1] = '.' then incr cnt;
+         i := pos + 1
+       done
+     with Not_found -> ());
+    if !cnt > 0 then
+      Some
+        {
+          id = "BIB-015";
+          severity = Info;
+          message = "Trailing period in `title` or `note` field is redundant";
+          count = !cnt;
+        }
+    else None
+  in
+  { id = "BIB-015"; run }
+
+(* BIB-016: Both DOI and URL present — duplicate locator information *)
+let r_bib_016 : rule =
+  let re_doi = Str.regexp {|doi[ \t]*=[ \t]*{|} in
+  let re_url = Str.regexp {|url[ \t]*=[ \t]*{|} in
+  let re_urldate = Str.regexp {|urldate[ \t]*=[ \t]*{|} in
+  let run s =
+    let entries = split_bib_entries s in
+    let cnt = ref 0 in
+    List.iter
+      (fun entry ->
+        let has_doi =
+          try
+            let _ = Str.search_forward re_doi entry 0 in
+            true
+          with Not_found -> false
+        in
+        (* Count url= matches minus urldate= matches to get true url count *)
+        let url_count = count_matches re_url entry in
+        let urldate_count = count_matches re_urldate entry in
+        let has_url = url_count > urldate_count in
+        if has_doi && has_url then incr cnt)
+      entries;
+    if !cnt > 0 then
+      Some
+        {
+          id = "BIB-016";
+          severity = Info;
+          message = "Both DOI and URL present—duplicate locator information";
+          count = !cnt;
+        }
+    else None
+  in
+  { id = "BIB-016"; run }
+
+(* ── PKG rules: package configuration issues ───────────────────── *)
+
+(* PKG-018: hyperref option draft left enabled *)
+let r_pkg_018 : rule =
+  let re_pkg = Str.regexp {|\\usepackage\[[^]]*draft[^]]*\]{hyperref}|} in
+  let re_setup1 = Str.regexp_string "\\hypersetup{draft}" in
+  let re_setup2 = Str.regexp_string "\\hypersetup{draft=true" in
+  let re_setup3 = Str.regexp {|\\hypersetup{[^}]*draft=true|} in
+  let run s =
+    let c1 = count_matches re_pkg s in
+    let c2 = count_matches re_setup1 s in
+    let c3 = count_matches re_setup2 s in
+    let c4 = count_matches re_setup3 s in
+    let cnt = c1 + c2 + c3 + c4 in
+    (* Avoid double-counting: re_setup2 is prefix of re_setup3 matches *)
+    let cnt = min cnt (c1 + max c2 0 + max c4 c3) in
+    if cnt > 0 then
+      Some
+        {
+          id = "PKG-018";
+          severity = Info;
+          message = "hyperref option draft left enabled";
+          count = cnt;
+        }
+    else None
+  in
+  { id = "PKG-018"; run }
+
+(* PKG-019: geometry margin < 1 cm *)
+let r_pkg_019 : rule =
+  let re_margin_frac =
+    Str.regexp
+      {|\\\(usepackage\[[^]]*\|geometry{[^}]*\)\(margin\|left\|right\|top\|bottom\)=0\.[0-9]+cm|}
+  in
+  let re_margin_zero =
+    Str.regexp
+      {|\\\(usepackage\[[^]]*\|geometry{[^}]*\)\(margin\|left\|right\|top\|bottom\)=0cm|}
+  in
+  let run s =
+    let c1 = count_matches re_margin_frac s in
+    let c2 = count_matches re_margin_zero s in
+    let cnt = c1 + c2 in
+    if cnt > 0 then
+      Some
+        {
+          id = "PKG-019";
+          severity = Warning;
+          message = "geometry margin < 1 cm";
+          count = cnt;
+        }
+    else None
+  in
+  { id = "PKG-019"; run }
+
+(* ── FONT rules ────────────────────────────────────────────────── *)
+
+(* FONT-005: Fontspec fallback to Latin Modern detected *)
+let r_font_005 : rule =
+  let re_fontspec = Str.regexp_string "\\usepackage{fontspec}" in
+  let re_setmain = Str.regexp_string "\\setmainfont" in
+  let run s =
+    let has_fontspec =
+      try
+        let _ = Str.search_forward re_fontspec s 0 in
+        true
+      with Not_found -> false
+    in
+    if not has_fontspec then None
+    else
+      let has_setmain =
+        try
+          let _ = Str.search_forward re_setmain s 0 in
+          true
+        with Not_found -> false
+      in
+      if has_setmain then
+        (* Check if it explicitly sets Latin Modern *)
+        let re_lm = Str.regexp_string "\\setmainfont{Latin Modern" in
+        let is_lm =
+          try
+            let _ = Str.search_forward re_lm s 0 in
+            true
+          with Not_found -> false
+        in
+        if is_lm then
+          Some
+            {
+              id = "FONT-005";
+              severity = Info;
+              message = "Fontspec fallback to Latin Modern detected";
+              count = 1;
+            }
+        else None
+      else
+        Some
+          {
+            id = "FONT-005";
+            severity = Info;
+            message = "Fontspec fallback to Latin Modern detected";
+            count = 1;
+          }
+  in
+  { id = "FONT-005"; run }
+
+(* ── LAY rules: layout / spacing issues ────────────────────────── *)
+
+(* LAY-015: Line spacing < 1 or > 2 *)
+let r_lay_015 : rule =
+  let re_linespread = Str.regexp {|\\linespread{\([0-9.]+\)}|} in
+  let re_setstretch = Str.regexp {|\\setstretch{\([0-9.]+\)}|} in
+  let run s =
+    let cnt = ref 0 in
+    let check re =
+      let i = ref 0 in
+      try
+        while true do
+          let _ = Str.search_forward re s !i in
+          let v = Str.matched_group 1 s in
+          (try
+             let f = float_of_string v in
+             if f < 1.0 || f > 2.0 then incr cnt
+           with Failure _ -> ());
+          i := Str.match_end ()
+        done
+      with Not_found -> ()
+    in
+    check re_linespread;
+    check re_setstretch;
+    if !cnt > 0 then
+      Some
+        {
+          id = "LAY-015";
+          severity = Info;
+          message = "Line spacing < 1 or > 2";
+          count = !cnt;
+        }
+    else None
+  in
+  { id = "LAY-015"; run }
+
+(* LAY-020: Float placement parameters modified (\topnumber ...) *)
+let r_lay_020 : rule =
+  let re_counter =
+    Str.regexp {|\\setcounter{\(topnumber\|bottomnumber\|totalnumber\)}|}
+  in
+  let re_fraction = Str.regexp {|\\renewcommand{\\topfraction}|} in
+  let run s =
+    let c1 = count_matches re_counter s in
+    let c2 = count_matches re_fraction s in
+    let cnt = c1 + c2 in
+    if cnt > 0 then
+      Some
+        {
+          id = "LAY-020";
+          severity = Info;
+          message = "Float placement parameters modified (\\topnumber …)";
+          count = cnt;
+        }
+    else None
+  in
+  { id = "LAY-020"; run }
+
+(* LAY-022: Global negative \parskip detected *)
+let r_lay_022 : rule =
+  let re = Str.regexp_string "\\setlength{\\parskip}{-" in
+  let run s =
+    let cnt = count_matches re s in
+    if cnt > 0 then
+      Some
+        {
+          id = "LAY-022";
+          severity = Warning;
+          message = {|Global negative \parskip detected|};
+          count = cnt;
+        }
+    else None
+  in
+  { id = "LAY-022"; run }
+
+(* ── REF rules ─────────────────────────────────────────────────── *)
+
+(* REF-008: Duplicate cite key in .bib file *)
+let r_ref_008 : rule =
+  let re_entry = Str.regexp {|@[a-zA-Z]+{[ \t]*\([^, \t\n}]+\)|} in
+  let run s =
+    let keys = Hashtbl.create 64 in
+    let i = ref 0 in
+    (try
+       while true do
+         let _ = Str.search_forward re_entry s !i in
+         let key = Str.matched_group 1 s in
+         (match Hashtbl.find_opt keys key with
+         | Some n -> Hashtbl.replace keys key (n + 1)
+         | None -> Hashtbl.replace keys key 1);
+         i := Str.match_end ()
+       done
+     with Not_found -> ());
+    let cnt =
+      Hashtbl.fold (fun _ n acc -> if n > 1 then acc + 1 else acc) keys 0
+    in
+    if cnt > 0 then
+      Some
+        {
+          id = "REF-008";
+          severity = Warning;
+          message = "Duplicate cite key in .bib file";
+          count = cnt;
+        }
+    else None
+  in
+  { id = "REF-008"; run }
+
+(* ── META rules ────────────────────────────────────────────────── *)
+
+(* META-001: PDF /Producer not set to deterministic hash *)
+let r_meta_001 : rule =
+  let re_hyperref_with_opts = Str.regexp {|\\usepackage\[[^]]*\]{hyperref}|} in
+  let re_hyperref_no_opts = Str.regexp_string "\\usepackage{hyperref}" in
+  let re_producer = Str.regexp_string "pdfproducer=" in
+  let run s =
+    let has_hyperref =
+      try
+        let _ = Str.search_forward re_hyperref_with_opts s 0 in
+        true
+      with Not_found -> (
+        try
+          let _ = Str.search_forward re_hyperref_no_opts s 0 in
+          true
+        with Not_found -> false)
+    in
+    if not has_hyperref then None
+    else
+      let has_producer =
+        try
+          let _ = Str.search_forward re_producer s 0 in
+          true
+        with Not_found -> false
+      in
+      if has_producer then None
+      else
+        Some
+          {
+            id = "META-001";
+            severity = Info;
+            message = "PDF /Producer not set to deterministic hash";
+            count = 1;
+          }
+  in
+  { id = "META-001"; run }
+
+(* ── PDF rules ─────────────────────────────────────────────────── *)
+
+(* PDF-010: Outline/bookmark text contains '_' or '#' -- use \texorpdfstring *)
+let r_pdf_010 : rule =
+  let re_sec =
+    Str.regexp {|\\\(section\|subsection\|subsubsection\|chapter\){|}
+  in
+  let re_texorpdf = Str.regexp_string "\\texorpdfstring" in
+  let run s =
+    let cnt = ref 0 in
+    let i = ref 0 in
+    let n = String.length s in
+    (try
+       while true do
+         let pos = Str.search_forward re_sec s !i in
+         let after = Str.match_end () in
+         (* find matching closing brace *)
+         let j = ref after in
+         let depth = ref 1 in
+         while !j < n && !depth > 0 do
+           (match s.[!j] with '{' -> incr depth | '}' -> decr depth | _ -> ());
+           if !depth > 0 then incr j
+         done;
+         let content = String.sub s after (!j - after) in
+         let has_special =
+           String.contains content '_' || String.contains content '#'
+         in
+         let has_texorpdf =
+           try
+             let _ = Str.search_forward re_texorpdf content 0 in
+             true
+           with Not_found -> false
+         in
+         if has_special && not has_texorpdf then incr cnt;
+         i := pos + 1
+       done
+     with Not_found -> ());
+    if !cnt > 0 then
+      Some
+        {
+          id = "PDF-010";
+          severity = Info;
+          message =
+            "Outline/bookmark text contains '_' or '#' – use \\texorpdfstring";
+          count = !cnt;
+        }
+    else None
+  in
+  { id = "PDF-010"; run }
+
+(* ── TIKZ rules ────────────────────────────────────────────────── *)
+
+(* TIKZ-005: TikZ externalisation not enabled for large figures *)
+let r_tikz_005 : rule =
+  let re_tikz = Str.regexp_string "\\begin{tikzpicture}" in
+  let re_ext_lib = Str.regexp_string "\\usetikzlibrary{external}" in
+  let re_ext_cmd = Str.regexp_string "\\tikzexternalize" in
+  let run s =
+    let has_tikz =
+      try
+        let _ = Str.search_forward re_tikz s 0 in
+        true
+      with Not_found -> false
+    in
+    if not has_tikz then None
+    else
+      let has_ext_lib =
+        try
+          let _ = Str.search_forward re_ext_lib s 0 in
+          true
+        with Not_found -> false
+      in
+      let has_ext_cmd =
+        try
+          let _ = Str.search_forward re_ext_cmd s 0 in
+          true
+        with Not_found -> false
+      in
+      if has_ext_lib || has_ext_cmd then None
+      else
+        Some
+          {
+            id = "TIKZ-005";
+            severity = Info;
+            message = "TikZ externalisation not enabled for large figures";
+            count = 1;
+          }
+  in
+  { id = "TIKZ-005"; run }
+
 let rules_l2_approx : rule list =
   [
     r_fig_001;
@@ -9722,6 +10498,28 @@ let rules_l2_approx : rule list =
     r_lay_024;
     r_meta_002;
     r_rtl_005;
+    r_bib_002;
+    r_bib_003;
+    r_bib_004;
+    r_bib_005;
+    r_bib_006;
+    r_bib_008;
+    r_bib_009;
+    r_bib_010;
+    r_bib_011;
+    r_bib_012;
+    r_bib_015;
+    r_bib_016;
+    r_pkg_018;
+    r_pkg_019;
+    r_font_005;
+    r_lay_015;
+    r_lay_020;
+    r_lay_022;
+    r_ref_008;
+    r_meta_001;
+    r_pdf_010;
+    r_tikz_005;
   ]
 
 (* ── CMD rules: command definition checks ────────────────────────────── *)
@@ -15962,6 +16760,17 @@ let precondition_of_rule_id (id : string) : layer =
   | "LAY-024" -> L2
   | "META-002" -> L2
   | "RTL-005" -> L2
+  (* batch 6: L3 text-scannable approximations — L2_Ast overrides *)
+  | "BIB-002" | "BIB-003" | "BIB-004" | "BIB-005" | "BIB-006" -> L2
+  | "BIB-008" | "BIB-009" | "BIB-010" | "BIB-011" | "BIB-012" -> L2
+  | "BIB-015" | "BIB-016" -> L2
+  | "PKG-018" | "PKG-019" -> L2
+  | "FONT-005" -> L2
+  | "LAY-015" | "LAY-020" | "LAY-022" -> L2
+  | "REF-008" -> L2
+  | "META-001" -> L2
+  | "PDF-010" -> L2
+  | "TIKZ-005" -> L2
   (* Prefix-based mappings *)
   | _ when String.length id >= 5 && String.sub id 0 5 = "TYPO-" -> L0
   | _ when String.length id >= 4 && String.sub id 0 4 = "ENC-" -> L0

--- a/specs/rules/l3_text_approx_golden.yaml
+++ b/specs/rules/l3_text_approx_golden.yaml
@@ -1,0 +1,45 @@
+cases:
+  - file: corpora/lint/l3_text_approx/bib_002.tex
+    expect: ["BIB-002"]
+  - file: corpora/lint/l3_text_approx/bib_003.tex
+    expect: ["BIB-003"]
+  - file: corpora/lint/l3_text_approx/bib_004.tex
+    expect: ["BIB-004"]
+  - file: corpora/lint/l3_text_approx/bib_005.tex
+    expect: ["BIB-005"]
+  - file: corpora/lint/l3_text_approx/bib_006.tex
+    expect: ["BIB-006"]
+  - file: corpora/lint/l3_text_approx/bib_008.tex
+    expect: ["BIB-008"]
+  - file: corpora/lint/l3_text_approx/bib_009.tex
+    expect: ["BIB-009"]
+  - file: corpora/lint/l3_text_approx/bib_010.tex
+    expect: ["BIB-010"]
+  - file: corpora/lint/l3_text_approx/bib_011.tex
+    expect: ["BIB-011"]
+  - file: corpora/lint/l3_text_approx/bib_012.tex
+    expect: ["BIB-012"]
+  - file: corpora/lint/l3_text_approx/bib_015.tex
+    expect: ["BIB-015"]
+  - file: corpora/lint/l3_text_approx/bib_016.tex
+    expect: ["BIB-016"]
+  - file: corpora/lint/l3_text_approx/pkg_018.tex
+    expect: ["PKG-018"]
+  - file: corpora/lint/l3_text_approx/pkg_019.tex
+    expect: ["PKG-019"]
+  - file: corpora/lint/l3_text_approx/font_005.tex
+    expect: ["FONT-005"]
+  - file: corpora/lint/l3_text_approx/lay_015.tex
+    expect: ["LAY-015"]
+  - file: corpora/lint/l3_text_approx/lay_020.tex
+    expect: ["LAY-020"]
+  - file: corpora/lint/l3_text_approx/lay_022.tex
+    expect: ["LAY-022"]
+  - file: corpora/lint/l3_text_approx/ref_008.tex
+    expect: ["REF-008"]
+  - file: corpora/lint/l3_text_approx/meta_001.tex
+    expect: ["META-001"]
+  - file: corpora/lint/l3_text_approx/pdf_010.tex
+    expect: ["PDF-010"]
+  - file: corpora/lint/l3_text_approx/tikz_005.tex
+    expect: ["TIKZ-005"]


### PR DESCRIPTION
## Summary

- Implement 22 L3_Semantics rules as L2 text-scannable approximations using regex
- **BIB** (12 rules): DOI normalisation, journal capitalisation, missing publisher/booktitle, URL without urldate, author name scheme, camelCase fields, numeric month, legacy note URLs, hard-coded et al., trailing periods, duplicate DOI+URL
- **PKG** (2 rules): hyperref draft left enabled, geometry margin < 1 cm
- **FONT** (1 rule): fontspec fallback to Latin Modern
- **LAY** (3 rules): line spacing out of range, float placement params modified, negative parskip
- **REF** (1 rule): duplicate cite keys in .bib
- **META** (1 rule): PDF /Producer not set
- **PDF** (1 rule): bookmark text with _ or # without texorpdfstring
- **TIKZ** (1 rule): TikZ externalisation not enabled
- New helpers: `split_bib_entries`, `count_matches`
- Coverage: 459/623 spec rules (73.7%), up from 437/623 (70.1%)

## Test plan

- [x] `dune build` — 0 errors
- [x] `dune build @fmt` — 0 diffs
- [x] `bash scripts/validate_messages.sh` — 459 rules, 0 mismatches
- [x] `L0_VALIDATORS=pilot dune runtest --force` — 0 failures
- [x] l3-text-approx: 94/94 unit tests pass
- [x] golden corpus: 236 cases PASS (22 new corpus files)