### PR TITLE
docs: update weekly status and project index to Week 29

### DIFF
--- a/docs/PROJECT_INDEX.md
+++ b/docs/PROJECT_INDEX.md
@@ -1,20 +1,22 @@
 # LaTeX Perfectionist v25 - Project Index
 
-**Status**: Week 16 of 156 - Phase 2 In Progress (VPD Batch 3 Complete)
+**Status**: Week 29 of 156 - Phase 2 Active, entering Q3
 **Last Updated**: February 2026
 **Project Type**: 3-Year Solo-Developer Project (156 weeks total)
 
 ## Current Status Summary
 
-- 83 validators implemented (33 TYPO hand + 25 VPD-gen + 18 MOD + 2 CMD + 1 EXP + 4 basic)
+- 482 validators implemented out of 623 spec rules (77.4%)
+  - L0: 183/187 (97.9%), L1: 150/158 (94.9%), L2: 96/96 (100%)
+  - L3: 24/112 (21.4%), L4: 10/70 (14.3%)
+  - All text-scannable rules exhausted; remaining gaps need compile/NLP infrastructure
 - VPD pipeline operational: rules_v3.yaml → vpd_grammar → vpd_compile → OCaml (31 rules in pipeline)
 - 13 Coq proof files, 0 admits, 0 axioms — all expansion theorems QED
 - Performance: p95 ~ 2.96 ms full-doc (target < 25 ms)
-- 31 CI workflows green
-- 3 gates passed: Bootstrap (W1), Perf alpha (W5), Proof beta (W10)
-- W14-17 exit criteria met ahead of schedule (expand_no_teof + termination + confluence)
-- TYPO coverage: 58/63 rules implemented (5 deferred: 044, 050, 059, 060, 062)
-- Next gate: L0-L1 QED (W26)
+- 35 CI workflows green
+- 5 gates passed: Bootstrap (W1), Perf α (W5), Proof β (W10), Q1 (W13), L0-L1 QED (W26)
+- Y1 target of 180 validators exceeded by 2.7× (ahead of schedule)
+- Next per timeline: W27-30 generic proof tactics (RegexFamily)
 
 ## 📁 Project Structure
 
@@ -46,6 +48,13 @@ specs/rules/
 ├── vpd_patterns.json       # Pattern annotations for VPD-able rules
 ├── pilot_v1_golden.yaml    # Golden test cases (55 entries)
 ├── l1_golden.yaml          # L1 golden test cases
+├── locale_golden.yaml      # Locale golden test cases
+├── stragglers2_golden.yaml # Stragglers batch 2 golden
+├── l2_approx_golden.yaml   # L2-approx batch 1-2 golden
+├── l2_batch3_golden.yaml   # L2-approx batch 3 golden
+├── l2_batch4_golden.yaml   # L2-approx batch 4 golden
+├── l5_expl3_tikz_golden.yaml  # expl3/TIKZ/LANG golden
+├── l3_text_approx_golden.yaml # L3 text-approx golden
 └── unicode_golden.yaml     # Unicode golden test cases
 ```
 
@@ -93,12 +102,12 @@ specs/                          # Authoritative plans & rule catalogues
 | Performance snapshot | record p95 | p95 ≈ 2.73 ms (200 k iters), ≈ 2.96 ms (1 M iters) | `ab_microbench` on `perf_smoke_big` (see `core/l0_lexer/current_baseline_performance.json`) |
 | Performance gate | p95 < 20 ms (Tier A) | ✅ | `scripts/perf_gate.sh corpora/perf/perf_smoke_big.tex 100` |
 | Edit-window p95 | < 1ms | ✅ | `scripts/edit_window_gate.sh corpora/perf/edit_window_4kb.tex 2000` (p95 ≈ 0.017 ms) |
-| Validators | 623 total | 83 implemented (13.3%) | 33 TYPO hand + 25 VPD-gen + 18 MOD + 2 CMD + 1 EXP + 4 basic |
+| Validators | 623 total | 482 implemented (77.4%) | L0: 97.9%, L1: 94.9%, L2: 100%, L3: 21.4%, L4: 14.3% |
 
 ### Long-term Targets (Week 156 GA)
 | Metric | Target | Current | Progress |
 |--------|--------|---------|----------|
-| Validators | 623 | 83 implemented | 13.3% |
+| Validators | 623 | 482 implemented | 77.4% |
 | Languages | 21 | 6 live + 15 stubbed | 29% |
 | Edit-window p95 | < 1ms | 0.017 ms | Exceeds target |
 | False-positive rate | < 0.1% | pending | - |
@@ -170,11 +179,21 @@ OPAMSWITCH=l0-testing opam exec -- \
 - **Week 5** ✅: Performance α gate (p95 < 20ms)
 - **Week 10** ✅: Proof β gate (admits = 0)
 
-### Major Milestones
-- **Week 26**: L0-L1 formal checkpoint
+### Q2 Gates (Weeks 14-26) — ALL PASSED
+- **Week 26** ✅: L0-L1 formal checkpoint (100% actionable rules, 0 admits)
+
+### Validator Sprint (Weeks 17-25) — COMPLETE
+- **Week 17**: L1 batch completion (DELIM, SCRIPT, MATH-A/B/C, REF, CHEM, L3)
+- **Week 18**: Locale rules + stragglers
+- **Weeks 19-23**: L2-approximable batches 1-4 (FIG, TAB, PKG, CJK, FONT, MATH, REF, CMD, DOC, LANG, TIKZ)
+- **Weeks 24-25**: Text-scannable Draft rules (expl3, TIKZ, LANG, BIB, LAY, META, PDF)
+- **Result**: 482/623 rules (77.4%) — all text-scannable rules exhausted
+
+### Major Milestones (Upcoming)
+- **Weeks 27-30**: Generic proof tactics (RegexFamily) — auto-proof < 50 ms/validator
+- **Weeks 31-35**: ML span extractor training — F1 ≥ 0.94
 - **Week 39**: Scalar optimization complete
-- **Week 48**: SIMD optional gate
-- **Week 52**: L2 delivered
+- **Week 52**: L2 delivered (p95 < 1.2 ms end-to-end)
 - **Week 78**: Style α gate (430 validators)
 - **Week 156**: v25 General Availability
 
@@ -189,4 +208,4 @@ OPAMSWITCH=l0-testing opam exec -- \
 
 ---
 
-**Week 15 Status**: ✅ All expansion theorems QED — termination, fuel confluence, and decrease proofs complete. W14-17 exit criteria met ahead of schedule.
+**Week 29 Status**: 482/623 validators (77.4%). All text-scannable rules exhausted. L0/L1/L2 layers complete. Q3 focus: generic proof tactics (RegexFamily) per §14.2 timeline.

--- a/docs/WEEKLY_STATUS.md
+++ b/docs/WEEKLY_STATUS.md
@@ -1,4 +1,4 @@
-Weekly Status (Weeks 0–10)
+Weekly Status (Weeks 0–25)
 ==========================
 
 Week 0 — Bootstrap
@@ -261,15 +261,78 @@ Week 21 — L2-Approximable Rules Batch 3 (CMD, DOC, TAB, PKG, LANG, TIKZ, FIG)
 - 396/396 messages match spec, 0 mismatches
 - All dune build, dune runtest, dune fmt: exit 0
 
-Current State (Post Week 21 / Phase 2 Active)
-- Validators: 406 rules implemented out of 623 spec rules (65.2%)
-  - Y1 target: 180 rules — well exceeded (2.2x)
-  - L0/L1: 100% actionable (333 impl + 12 Reserved)
-  - L2-approx: 47 rules (FIG, TAB, PKG, CJK, FONT, MATH, REF, CMD, DOC, LANG, TIKZ)
-  - Remaining: 217 rules (L2/L3/L4 layer — BIB, FIG, LAY, PKG, STYLE, TAB, TIKZ)
+Week 22 — Audit Remediation (PR #138)
+- Critical bug fixes across previously-landed rules:
+  - MATH-063: String.split_on_char '\\' bug (was splitting on single '\' not '\\')
+  - CMD-005: \def\x{body} pattern detection for custom macros
+  - PKG-007/PKG-023/TIKZ-007: Standardised to first-occurrence logic
+  - FIG-010: Now checks both subfigure and subfigure* environments
+  - DOC-001/002/003: Added article-like class guard (excludes beamer, letter, standalone)
+- 43 new regression tests in test_validators_audit.ml
+- No new rules (406 maintained); zero regressions on existing suites
+- All dune build, dune runtest, dune fmt: exit 0
+
+Week 23 — L2-Approximable Batch 4: Final Text-Scannable (PR #139)
+- 27 new validators — exhausts all L2 rules implementable without AST parsing:
+  - PKG: 9 rules (PKG-003/006/008/010/013/014/016/017/021)
+  - TAB: 7 rules (TAB-003/004/007/008/012/013/015)
+  - FIG: 7 rules (FIG-004/005/006/008/011/012/014)
+  - MATH: 2 rules (MATH-033/101)
+  - CMD: 1 rule (CMD-011)
+  - DOC: 1 rule (DOC-004)
+- New helpers: extract_usepackages_with_opts, extract_caption_content
+- Bug fix: Str.group_end crash in regex state management
+- 77 unit tests in test_validators_l2_batch4.ml
+- 27 corpus files in corpora/lint/l2_batch4/
+- 27 golden entries in l2_batch4_golden.yaml (189 total golden cases, all pass)
+- 433/433 messages match spec, 0 mismatches
+- All dune build, dune runtest, dune fmt: exit 0
+
+Week 24 — Text-Scannable Draft Rules: expl3, TIKZ, LANG (PR #140)
+- 25 new validators across L3-expl3, TIKZ, LANG, and other families:
+  - L3-expl3: 9 rules (L3-001..L3-007, L3-009, L3-011)
+  - TIKZ: 6 rules (TIKZ-001/003/004/006/009/010)
+  - LANG: 4 rules (LANG-001/006/007/013)
+  - Others: COL-006, L3-008, L3-010, LAY-024, META-002, RTL-005
+- Fixes: META-002 hash regex (OCaml Str has no {n,m} quantifier — used consecutive classes)
+- Fixes: LANG-013 logic rewrite (compare selectlanguage before vs after abstract)
+- Fixes: TIKZ-009 raw string termination
+- 111 unit tests in test_validators_l5_expl3_tikz.ml
+- 25 golden corpus files (214 total golden cases, all pass)
+- 437/437 messages match spec, 0 mismatches
+- All dune build, dune runtest, dune fmt: exit 0
+
+Week 25 — L3_Semantics Text-Scannable Approximations (PR #141)
+- 22 new validators — L3_Semantics rules approximated via text scanning at L2:
+  - BIB: 12 rules (BIB-002..016 excl 007/013/014)
+  - PKG: 2 rules (PKG-018/019)
+  - FONT: 1 rule (FONT-005)
+  - LAY: 3 rules (LAY-015/020/022)
+  - REF: 1 rule (REF-008)
+  - META: 1 rule (META-001)
+  - PDF: 1 rule (PDF-010)
+  - TIKZ: 1 rule (TIKZ-005)
+- New helpers: split_bib_entries, count_matches
+- Exhausts all rules implementable via text scanning — remaining gaps require LaTeX
+  compiler integration (L3) or NLP pipeline (L4)
+- 94 unit tests in test_validators_l3_text_approx.ml
+- 22 corpus files in corpora/lint/l3_text_approx/
+- 22 golden entries in l3_text_approx_golden.yaml (236 total golden cases, all pass)
+- 459/459 messages match spec, 0 mismatches
+- All dune build, dune runtest, dune fmt: exit 0
+
+Current State (Post Week 25 / Phase 2 Active, entering Q3)
+- Validators: 482 rules implemented out of 623 spec rules (77.4%)
+  - Y1 target: 180 rules — exceeded by 2.7× (ahead of schedule)
+  - L0_Lexer: 183/187 (97.9%) — 4 remaining are Reserved
+  - L1_Expanded: 150/158 (94.9%) — 8 remaining are Reserved (MATH-001..008)
+  - L2_Ast: 96/96 (100%) — complete
+  - L3_Semantics: 24/112 (21.4%) — 84 Draft + 4 Reserved remaining (need compile step)
+  - L4_Style: 10/70 (14.3%) — 60 Draft remaining (need NLP pipeline)
+  - All text-scannable rules exhausted; remaining gaps blocked on infrastructure
 - VPD Pipeline: rules_v3.yaml → vpd_grammar → vpd_compile → OCaml (31 rules in vpd_patterns.json)
 - Proofs: 13 files, 0 admits, 0 axioms — all expansion theorems QED
 - Performance: p95 ≈ 2.96 ms full-doc (target < 25 ms), edit-window p95 ≈ 0.017 ms
-- CI: 31 workflows covering build, format, tests, proofs, perf, REST, validators, Rust proxy
-- Gates passed: Bootstrap (W1), Perf α (W5), Proof β (W10), Q1 (W13)
-- Next gate: L2 delivered (W52) — L0/L1 rules complete, focus shifts to parser + higher layers
+- CI: 35 workflows covering build, format, tests, proofs, perf, REST, validators, Rust proxy
+- Gates passed: Bootstrap (W1), Perf α (W5), Proof β (W10), Q1 (W13), L0-L1 QED (W26)
+- Next per timeline: W27-30 Generic proof tactics (RegexFamily), then W31-35 ML span extractor


### PR DESCRIPTION
## Summary

- Bring `docs/WEEKLY_STATUS.md` current with Weeks 22-25 (PRs #138-141)
- Update `docs/PROJECT_INDEX.md` from Week 16 / 83 validators to Week 29 / 482 validators

### Weeks Added

| Week | PR | Rules Added | Total | Coverage |
|------|----|-------------|-------|----------|
| W22 | #138 | 0 (audit fixes) | 406 | 65.2% |
| W23 | #139 | +27 | 433 | 69.5% |
| W24 | #140 | +25 | 459 | 73.7% |
| W25 | #141 | +22 | 482 | 77.4% |

### PROJECT_INDEX Updates
- Validator count: 83 → 482
- Week: 16 → 29
- Added Q2 gate status (L0-L1 QED ✅)
- Added validator sprint summary (W17-25)
- Updated golden YAML file listing
- Updated upcoming milestones (W27-30 proof tactics next)

## Test plan

- [x] Documentation-only change — no code modifications