### PR TITLE
feat(proofs): faithful proof batch 5 — final substring tier (153→161)

### DIFF
--- a/proofs/generated/L0_MATH.v
+++ b/proofs/generated/L0_MATH.v
@@ -18,8 +18,9 @@ Definition math_027_chk (s : string) : bool := false.
 (** MATH-076: No VPD pattern — conservative model. *)
 Definition math_076_chk (s : string) : bool := false.
 
-(** MATH-083: No VPD pattern — conservative model. *)
-Definition math_083_chk (s : string) : bool := false.
+(** MATH-083: count_substring_strip_math — UTF-8 bytes, full string (conservative over-approx). *)
+Definition math_083_chk (s : string) : bool :=
+  string_contains_bytes s [226; 136; 146].
 
 (** MATH-089: No VPD pattern — conservative model. *)
 Definition math_089_chk (s : string) : bool := false.

--- a/proofs/generated/L0_SPC.v
+++ b/proofs/generated/L0_SPC.v
@@ -87,8 +87,9 @@ Definition spc_023_chk (s : string) : bool := false.
 (** SPC-024: No VPD pattern — conservative model. *)
 Definition spc_024_chk (s : string) : bool := false.
 
-(** SPC-025: No VPD pattern — conservative model. *)
-Definition spc_025_chk (s : string) : bool := false.
+(** SPC-025: multi_substring (UTF-8 bytes). *)
+Definition spc_025_chk (s : string) : bool :=
+  multi_bytes_check [[32; 92; 100; 111; 116; 115]; [32; 226; 128; 166]] s.
 
 (** SPC-026: No VPD pattern — conservative model. *)
 Definition spc_026_chk (s : string) : bool := false.
@@ -114,8 +115,9 @@ Definition spc_031_chk (s : string) : bool :=
 (** SPC-032: No VPD pattern — conservative model. *)
 Definition spc_032_chk (s : string) : bool := false.
 
-(** SPC-033: No VPD pattern — conservative model. *)
-Definition spc_033_chk (s : string) : bool := false.
+(** SPC-033: multi_substring (UTF-8 bytes). *)
+Definition spc_033_chk (s : string) : bool :=
+  multi_bytes_check [[226; 128; 137; 226; 128; 147]; [226; 128; 137; 45; 45]] s.
 
 (** SPC-034: No VPD pattern — conservative model. *)
 Definition spc_034_chk (s : string) : bool := false.

--- a/proofs/generated/L0_STYLE.v
+++ b/proofs/generated/L0_STYLE.v
@@ -48,11 +48,13 @@ Definition style_012_chk (s : string) : bool := false.
 (** STYLE-013: No VPD pattern — conservative model. *)
 Definition style_013_chk (s : string) : bool := false.
 
-(** STYLE-014: No VPD pattern — conservative model. *)
-Definition style_014_chk (s : string) : bool := false.
+(** STYLE-014: count_char "'" (ASCII 39). *)
+Definition style_014_chk (s : string) : bool :=
+  string_contains s (ascii_of_nat 39).
 
-(** STYLE-015: No VPD pattern — conservative model. *)
-Definition style_015_chk (s : string) : bool := false.
+(** STYLE-015: count_substring ".  ". *)
+Definition style_015_chk (s : string) : bool :=
+  string_contains_substring s ".  ".
 
 (** STYLE-016: No VPD pattern — conservative model. *)
 Definition style_016_chk (s : string) : bool := false.
@@ -111,11 +113,13 @@ Definition style_033_chk (s : string) : bool := false.
 (** STYLE-034: No VPD pattern — conservative model. *)
 Definition style_034_chk (s : string) : bool := false.
 
-(** STYLE-035: No VPD pattern — conservative model. *)
-Definition style_035_chk (s : string) : bool := false.
+(** STYLE-035: count_substring "and/or". *)
+Definition style_035_chk (s : string) : bool :=
+  string_contains_substring s "and/or".
 
-(** STYLE-036: No VPD pattern — conservative model. *)
-Definition style_036_chk (s : string) : bool := false.
+(** STYLE-036: multi_substring [cf., ibid., et al., viz., e.g., i.e.]. *)
+Definition style_036_chk (s : string) : bool :=
+  multi_substring_check ["cf."; "ibid."; "et al."; "viz."; "e.g."; "i.e."] s.
 
 (** STYLE-037: No VPD pattern — conservative model. *)
 Definition style_037_chk (s : string) : bool := false.
@@ -126,8 +130,9 @@ Definition style_038_chk (s : string) : bool := false.
 (** STYLE-039: No VPD pattern — conservative model. *)
 Definition style_039_chk (s : string) : bool := false.
 
-(** STYLE-040: No VPD pattern — conservative model. *)
-Definition style_040_chk (s : string) : bool := false.
+(** STYLE-040: count_char "!" (ASCII 33). *)
+Definition style_040_chk (s : string) : bool :=
+  string_contains s (ascii_of_nat 33).
 
 (** STYLE-041: No VPD pattern — conservative model. *)
 Definition style_041_chk (s : string) : bool := false.

--- a/specs/rules/vpd_patterns.json
+++ b/specs/rules/vpd_patterns.json
@@ -1741,5 +1741,82 @@
       "needle": "et al."
     },
     "severity": "Warning"
+  },
+  "STYLE-014": {
+    "layer": "L0",
+    "pattern": {
+      "family": "count_char",
+      "char": "'"
+    },
+    "severity": "Info"
+  },
+  "STYLE-015": {
+    "layer": "L0",
+    "pattern": {
+      "family": "count_substring",
+      "needle": ".  "
+    },
+    "severity": "Info"
+  },
+  "STYLE-035": {
+    "layer": "L0",
+    "pattern": {
+      "family": "count_substring",
+      "needle": "and/or"
+    },
+    "severity": "Info"
+  },
+  "STYLE-036": {
+    "layer": "L0",
+    "pattern": {
+      "family": "multi_substring",
+      "needles": [
+        "cf.",
+        "ibid.",
+        "et al.",
+        "viz.",
+        "e.g.",
+        "i.e."
+      ]
+    },
+    "severity": "Info"
+  },
+  "STYLE-040": {
+    "layer": "L0",
+    "pattern": {
+      "family": "count_char",
+      "char": "!"
+    },
+    "severity": "Info"
+  },
+  "SPC-025": {
+    "layer": "L0",
+    "pattern": {
+      "family": "multi_substring",
+      "needles": [
+        " \\dots",
+        " …"
+      ]
+    },
+    "severity": "Info"
+  },
+  "SPC-033": {
+    "layer": "L0",
+    "pattern": {
+      "family": "multi_substring",
+      "needles": [
+        " –",
+        " --"
+      ]
+    },
+    "severity": "Warning"
+  },
+  "MATH-083": {
+    "layer": "L2",
+    "pattern": {
+      "family": "count_substring_strip_math",
+      "needle": "−"
+    },
+    "severity": "Warning"
   }
 }


### PR DESCRIPTION
## Summary
- Add 8 VPD entries: STYLE-014/015/035/036/040, SPC-025/033, MATH-083
- **Faithful proofs: 153 → 161** (+8), conservative: 454 → 446
- This exhausts all rules convertible via substring/char matching

## Notable entries
- STYLE-014: Uses `count_char '` (apostrophe) — sound because all 25 contractions require `'`, avoids case-sensitivity issue with `String.lowercase_ascii`
- STYLE-036: `multi_substring ["cf.", "ibid.", "et al.", "viz.", "e.g.", "i.e."]` — Latin phrases
- SPC-033: `multi_substring` with thin-space+en-dash UTF-8 byte combinations

## Test plan
- [x] `gen_coq_proofs.py --check` → 161 faithful, 446 conservative
- [x] `dune clean && dune build` — 0 admits
- [x] `dune runtest` — all tests pass