### PR TITLE
feat(proofs): faithful proof batch 7 — math-segment sweep (197→259)

### DIFF
--- a/proofs/generated/L1_CHEM.v
+++ b/proofs/generated/L1_CHEM.v
@@ -13,15 +13,17 @@ Open Scope string_scope.
 Definition chem_001_chk (s : string) : bool :=
   string_contains_substring s "\ce{".
 
-(** CHEM-002: No VPD pattern — conservative model. *)
-Definition chem_002_chk (s : string) : bool := false.
+(** CHEM-002: multi_substring [$, \(, \[, \begin{equation, \begin{align, \begin{gather, \begin{multline, \begin{eqnarray, \begin{math}, \begin{displaymath}]. *)
+Definition chem_002_chk (s : string) : bool :=
+  multi_substring_check ["$"; "\("; "\["; "\begin{equation"; "\begin{align"; "\begin{gather"; "\begin{multline"; "\begin{eqnarray"; "\begin{math}"; "\begin{displaymath}"] s.
 
 (** CHEM-003: count_substring '\\ce{'. *)
 Definition chem_003_chk (s : string) : bool :=
   string_contains_substring s "\ce{".
 
-(** CHEM-004: No VPD pattern — conservative model. *)
-Definition chem_004_chk (s : string) : bool := false.
+(** CHEM-004: multi_substring [$, \(, \[, \begin{equation, \begin{align, \begin{gather, \begin{multline, \begin{eqnarray, \begin{math}, \begin{displaymath}]. *)
+Definition chem_004_chk (s : string) : bool :=
+  multi_substring_check ["$"; "\("; "\["; "\begin{equation"; "\begin{align"; "\begin{gather"; "\begin{multline"; "\begin{eqnarray"; "\begin{math}"; "\begin{displaymath}"] s.
 
 (** CHEM-005: multi_substring [->, \rightarrow, \longrightarrow]. *)
 Definition chem_005_chk (s : string) : bool :=
@@ -35,8 +37,9 @@ Definition chem_006_chk (s : string) : bool :=
 Definition chem_007_chk (s : string) : bool :=
   string_contains_substring s "\text{".
 
-(** CHEM-008: No VPD pattern — conservative model. *)
-Definition chem_008_chk (s : string) : bool := false.
+(** CHEM-008: multi_substring [$, \(, \[, \begin{equation, \begin{align, \begin{gather, \begin{multline, \begin{eqnarray, \begin{math}, \begin{displaymath}]. *)
+Definition chem_008_chk (s : string) : bool :=
+  multi_substring_check ["$"; "\("; "\["; "\begin{equation"; "\begin{align"; "\begin{gather"; "\begin{multline"; "\begin{eqnarray"; "\begin{math}"; "\begin{displaymath}"] s.
 
 (** CHEM-009: multi_substring [<->, <=>]. *)
 Definition chem_009_chk (s : string) : bool :=

--- a/proofs/generated/L1_CJK.v
+++ b/proofs/generated/L1_CJK.v
@@ -9,11 +9,13 @@ Open Scope string_scope.
 
 (* ── Check functions ── *)
 
-(** CJK-008: No VPD pattern — conservative model. *)
-Definition cjk_008_chk (s : string) : bool := false.
+(** CJK-008: multi_substring [$, \(, \[, \begin{equation, \begin{align, \begin{gather, \begin{multline, \begin{eqnarray, \begin{math}, \begin{displaymath}]. *)
+Definition cjk_008_chk (s : string) : bool :=
+  multi_substring_check ["$"; "\("; "\["; "\begin{equation"; "\begin{align"; "\begin{gather"; "\begin{multline"; "\begin{eqnarray"; "\begin{math}"; "\begin{displaymath}"] s.
 
-(** CJK-015: No VPD pattern — conservative model. *)
-Definition cjk_015_chk (s : string) : bool := false.
+(** CJK-015: multi_substring [$, \(, \[, \begin{equation, \begin{align, \begin{gather, \begin{multline, \begin{eqnarray, \begin{math}, \begin{displaymath}]. *)
+Definition cjk_015_chk (s : string) : bool :=
+  multi_substring_check ["$"; "\("; "\["; "\begin{equation"; "\begin{align"; "\begin{gather"; "\begin{multline"; "\begin{eqnarray"; "\begin{math}"; "\begin{displaymath}"] s.
 
 (* ── Soundness theorems ── *)
 

--- a/proofs/generated/L1_DELIM.v
+++ b/proofs/generated/L1_DELIM.v
@@ -34,11 +34,13 @@ Definition delim_006_chk (s : string) : bool := false.
 Definition delim_007_chk (s : string) : bool :=
   multi_substring_check ["\langle"; "\rangle"] s.
 
-(** DELIM-008: No VPD pattern — conservative model. *)
-Definition delim_008_chk (s : string) : bool := false.
+(** DELIM-008: multi_substring [$, \(, \[, \begin{equation, \begin{align, \begin{gather, \begin{multline, \begin{eqnarray, \begin{math}, \begin{displaymath}]. *)
+Definition delim_008_chk (s : string) : bool :=
+  multi_substring_check ["$"; "\("; "\["; "\begin{equation"; "\begin{align"; "\begin{gather"; "\begin{multline"; "\begin{eqnarray"; "\begin{math}"; "\begin{displaymath}"] s.
 
-(** DELIM-009: No VPD pattern — conservative model. *)
-Definition delim_009_chk (s : string) : bool := false.
+(** DELIM-009: multi_substring [$, \(, \[, \begin{equation, \begin{align, \begin{gather, \begin{multline, \begin{eqnarray, \begin{math}, \begin{displaymath}]. *)
+Definition delim_009_chk (s : string) : bool :=
+  multi_substring_check ["$"; "\("; "\["; "\begin{equation"; "\begin{align"; "\begin{gather"; "\begin{multline"; "\begin{eqnarray"; "\begin{math}"; "\begin{displaymath}"] s.
 
 (** DELIM-010: No VPD pattern — conservative model. *)
 Definition delim_010_chk (s : string) : bool := false.

--- a/proofs/generated/L1_FONT.v
+++ b/proofs/generated/L1_FONT.v
@@ -12,8 +12,9 @@ Open Scope string_scope.
 (** FONT-001: No VPD pattern — conservative model. *)
 Definition font_001_chk (s : string) : bool := false.
 
-(** FONT-004: No VPD pattern — conservative model. *)
-Definition font_004_chk (s : string) : bool := false.
+(** FONT-004: multi_substring [$, \(, \[, \begin{equation, \begin{align, \begin{gather, \begin{multline, \begin{eqnarray, \begin{math}, \begin{displaymath}]. *)
+Definition font_004_chk (s : string) : bool :=
+  multi_substring_check ["$"; "\("; "\["; "\begin{equation"; "\begin{align"; "\begin{gather"; "\begin{multline"; "\begin{eqnarray"; "\begin{math}"; "\begin{displaymath}"] s.
 
 (* ── Soundness theorems ── *)
 

--- a/proofs/generated/L1_MATH.v
+++ b/proofs/generated/L1_MATH.v
@@ -9,8 +9,9 @@ Open Scope string_scope.
 
 (* ── Check functions ── *)
 
-(** MATH-009: No VPD pattern — conservative model. *)
-Definition math_009_chk (s : string) : bool := false.
+(** MATH-009: multi_substring [$, \(, \[, \begin{equation, \begin{align, \begin{gather, \begin{multline, \begin{eqnarray, \begin{math}, \begin{displaymath}]. *)
+Definition math_009_chk (s : string) : bool :=
+  multi_substring_check ["$"; "\("; "\["; "\begin{equation"; "\begin{align"; "\begin{gather"; "\begin{multline"; "\begin{eqnarray"; "\begin{math}"; "\begin{displaymath}"] s.
 
 (** MATH-010: count_substring (UTF-8 bytes). *)
 Definition math_010_chk (s : string) : bool :=
@@ -36,23 +37,28 @@ Definition math_014_chk (s : string) : bool :=
 Definition math_015_chk (s : string) : bool :=
   string_contains_substring s "\stackrel{".
 
-(** MATH-016: No VPD pattern — conservative model. *)
-Definition math_016_chk (s : string) : bool := false.
+(** MATH-016: multi_substring [$, \(, \[, \begin{equation, \begin{align, \begin{gather, \begin{multline, \begin{eqnarray, \begin{math}, \begin{displaymath}]. *)
+Definition math_016_chk (s : string) : bool :=
+  multi_substring_check ["$"; "\("; "\["; "\begin{equation"; "\begin{align"; "\begin{gather"; "\begin{multline"; "\begin{eqnarray"; "\begin{math}"; "\begin{displaymath}"] s.
 
-(** MATH-017: No VPD pattern — conservative model. *)
-Definition math_017_chk (s : string) : bool := false.
+(** MATH-017: multi_substring [$, \(, \[, \begin{equation, \begin{align, \begin{gather, \begin{multline, \begin{eqnarray, \begin{math}, \begin{displaymath}]. *)
+Definition math_017_chk (s : string) : bool :=
+  multi_substring_check ["$"; "\("; "\["; "\begin{equation"; "\begin{align"; "\begin{gather"; "\begin{multline"; "\begin{eqnarray"; "\begin{math}"; "\begin{displaymath}"] s.
 
-(** MATH-018: No VPD pattern — conservative model. *)
-Definition math_018_chk (s : string) : bool := false.
+(** MATH-018: multi_substring [$, \(, \[, \begin{equation, \begin{align, \begin{gather, \begin{multline, \begin{eqnarray, \begin{math}, \begin{displaymath}]. *)
+Definition math_018_chk (s : string) : bool :=
+  multi_substring_check ["$"; "\("; "\["; "\begin{equation"; "\begin{align"; "\begin{gather"; "\begin{multline"; "\begin{eqnarray"; "\begin{math}"; "\begin{displaymath}"] s.
 
 (** MATH-019: No VPD pattern — conservative model. *)
 Definition math_019_chk (s : string) : bool := false.
 
-(** MATH-020: No VPD pattern — conservative model. *)
-Definition math_020_chk (s : string) : bool := false.
+(** MATH-020: multi_substring [$, \(, \[, \begin{equation, \begin{align, \begin{gather, \begin{multline, \begin{eqnarray, \begin{math}, \begin{displaymath}]. *)
+Definition math_020_chk (s : string) : bool :=
+  multi_substring_check ["$"; "\("; "\["; "\begin{equation"; "\begin{align"; "\begin{gather"; "\begin{multline"; "\begin{eqnarray"; "\begin{math}"; "\begin{displaymath}"] s.
 
-(** MATH-021: No VPD pattern — conservative model. *)
-Definition math_021_chk (s : string) : bool := false.
+(** MATH-021: multi_substring [$, \(, \[, \begin{equation, \begin{align, \begin{gather, \begin{multline, \begin{eqnarray, \begin{math}, \begin{displaymath}]. *)
+Definition math_021_chk (s : string) : bool :=
+  multi_substring_check ["$"; "\("; "\["; "\begin{equation"; "\begin{align"; "\begin{gather"; "\begin{multline"; "\begin{eqnarray"; "\begin{math}"; "\begin{displaymath}"] s.
 
 (** MATH-022: count_substring '\\textbf{'. *)
 Definition math_022_chk (s : string) : bool :=
@@ -62,8 +68,9 @@ Definition math_022_chk (s : string) : bool :=
 Definition math_030_chk (s : string) : bool :=
   string_contains_substring s "\displaystyle".
 
-(** MATH-031: No VPD pattern — conservative model. *)
-Definition math_031_chk (s : string) : bool := false.
+(** MATH-031: multi_substring [$, \(, \[, \begin{equation, \begin{align, \begin{gather, \begin{multline, \begin{eqnarray, \begin{math}, \begin{displaymath}]. *)
+Definition math_031_chk (s : string) : bool :=
+  multi_substring_check ["$"; "\("; "\["; "\begin{equation"; "\begin{align"; "\begin{gather"; "\begin{multline"; "\begin{eqnarray"; "\begin{math}"; "\begin{displaymath}"] s.
 
 (** MATH-033: count_substring '\\pm'. *)
 Definition math_033_chk (s : string) : bool :=
@@ -73,11 +80,13 @@ Definition math_033_chk (s : string) : bool :=
 Definition math_034_chk (s : string) : bool :=
   string_contains_substring s "\int".
 
-(** MATH-035: No VPD pattern — conservative model. *)
-Definition math_035_chk (s : string) : bool := false.
+(** MATH-035: multi_substring [$, \(, \[, \begin{equation, \begin{align, \begin{gather, \begin{multline, \begin{eqnarray, \begin{math}, \begin{displaymath}]. *)
+Definition math_035_chk (s : string) : bool :=
+  multi_substring_check ["$"; "\("; "\["; "\begin{equation"; "\begin{align"; "\begin{gather"; "\begin{multline"; "\begin{eqnarray"; "\begin{math}"; "\begin{displaymath}"] s.
 
-(** MATH-036: No VPD pattern — conservative model. *)
-Definition math_036_chk (s : string) : bool := false.
+(** MATH-036: multi_substring [$, \(, \[, \begin{equation, \begin{align, \begin{gather, \begin{multline, \begin{eqnarray, \begin{math}, \begin{displaymath}]. *)
+Definition math_036_chk (s : string) : bool :=
+  multi_substring_check ["$"; "\("; "\["; "\begin{equation"; "\begin{align"; "\begin{gather"; "\begin{multline"; "\begin{eqnarray"; "\begin{math}"; "\begin{displaymath}"] s.
 
 (** MATH-037: count_substring '\\sfrac{'. *)
 Definition math_037_chk (s : string) : bool :=
@@ -87,42 +96,52 @@ Definition math_037_chk (s : string) : bool :=
 Definition math_038_chk (s : string) : bool :=
   string_contains_substring s "\frac{".
 
-(** MATH-039: No VPD pattern — conservative model. *)
-Definition math_039_chk (s : string) : bool := false.
+(** MATH-039: multi_substring [$, \(, \[, \begin{equation, \begin{align, \begin{gather, \begin{multline, \begin{eqnarray, \begin{math}, \begin{displaymath}]. *)
+Definition math_039_chk (s : string) : bool :=
+  multi_substring_check ["$"; "\("; "\["; "\begin{equation"; "\begin{align"; "\begin{gather"; "\begin{multline"; "\begin{eqnarray"; "\begin{math}"; "\begin{displaymath}"] s.
 
-(** MATH-040: No VPD pattern — conservative model. *)
-Definition math_040_chk (s : string) : bool := false.
+(** MATH-040: multi_substring [$, \(, \[, \begin{equation, \begin{align, \begin{gather, \begin{multline, \begin{eqnarray, \begin{math}, \begin{displaymath}]. *)
+Definition math_040_chk (s : string) : bool :=
+  multi_substring_check ["$"; "\("; "\["; "\begin{equation"; "\begin{align"; "\begin{gather"; "\begin{multline"; "\begin{eqnarray"; "\begin{math}"; "\begin{displaymath}"] s.
 
 (** MATH-041: No VPD pattern — conservative model. *)
 Definition math_041_chk (s : string) : bool := false.
 
-(** MATH-042: No VPD pattern — conservative model. *)
-Definition math_042_chk (s : string) : bool := false.
+(** MATH-042: multi_substring [$, \(, \[, \begin{equation, \begin{align, \begin{gather, \begin{multline, \begin{eqnarray, \begin{math}, \begin{displaymath}]. *)
+Definition math_042_chk (s : string) : bool :=
+  multi_substring_check ["$"; "\("; "\["; "\begin{equation"; "\begin{align"; "\begin{gather"; "\begin{multline"; "\begin{eqnarray"; "\begin{math}"; "\begin{displaymath}"] s.
 
-(** MATH-043: No VPD pattern — conservative model. *)
-Definition math_043_chk (s : string) : bool := false.
+(** MATH-043: multi_substring [$, \(, \[, \begin{equation, \begin{align, \begin{gather, \begin{multline, \begin{eqnarray, \begin{math}, \begin{displaymath}]. *)
+Definition math_043_chk (s : string) : bool :=
+  multi_substring_check ["$"; "\("; "\["; "\begin{equation"; "\begin{align"; "\begin{gather"; "\begin{multline"; "\begin{eqnarray"; "\begin{math}"; "\begin{displaymath}"] s.
 
-(** MATH-044: No VPD pattern — conservative model. *)
-Definition math_044_chk (s : string) : bool := false.
+(** MATH-044: multi_substring [$, \(, \[, \begin{equation, \begin{align, \begin{gather, \begin{multline, \begin{eqnarray, \begin{math}, \begin{displaymath}]. *)
+Definition math_044_chk (s : string) : bool :=
+  multi_substring_check ["$"; "\("; "\["; "\begin{equation"; "\begin{align"; "\begin{gather"; "\begin{multline"; "\begin{eqnarray"; "\begin{math}"; "\begin{displaymath}"] s.
 
-(** MATH-045: No VPD pattern — conservative model. *)
-Definition math_045_chk (s : string) : bool := false.
+(** MATH-045: multi_substring [$, \(, \[, \begin{equation, \begin{align, \begin{gather, \begin{multline, \begin{eqnarray, \begin{math}, \begin{displaymath}]. *)
+Definition math_045_chk (s : string) : bool :=
+  multi_substring_check ["$"; "\("; "\["; "\begin{equation"; "\begin{align"; "\begin{gather"; "\begin{multline"; "\begin{eqnarray"; "\begin{math}"; "\begin{displaymath}"] s.
 
-(** MATH-046: No VPD pattern — conservative model. *)
-Definition math_046_chk (s : string) : bool := false.
+(** MATH-046: multi_substring [$, \(, \[, \begin{equation, \begin{align, \begin{gather, \begin{multline, \begin{eqnarray, \begin{math}, \begin{displaymath}]. *)
+Definition math_046_chk (s : string) : bool :=
+  multi_substring_check ["$"; "\("; "\["; "\begin{equation"; "\begin{align"; "\begin{gather"; "\begin{multline"; "\begin{eqnarray"; "\begin{math}"; "\begin{displaymath}"] s.
 
-(** MATH-047: No VPD pattern — conservative model. *)
-Definition math_047_chk (s : string) : bool := false.
+(** MATH-047: multi_substring [$, \(, \[, \begin{equation, \begin{align, \begin{gather, \begin{multline, \begin{eqnarray, \begin{math}, \begin{displaymath}]. *)
+Definition math_047_chk (s : string) : bool :=
+  multi_substring_check ["$"; "\("; "\["; "\begin{equation"; "\begin{align"; "\begin{gather"; "\begin{multline"; "\begin{eqnarray"; "\begin{math}"; "\begin{displaymath}"] s.
 
-(** MATH-048: No VPD pattern — conservative model. *)
-Definition math_048_chk (s : string) : bool := false.
+(** MATH-048: multi_substring [$, \(, \[, \begin{equation, \begin{align, \begin{gather, \begin{multline, \begin{eqnarray, \begin{math}, \begin{displaymath}]. *)
+Definition math_048_chk (s : string) : bool :=
+  multi_substring_check ["$"; "\("; "\["; "\begin{equation"; "\begin{align"; "\begin{gather"; "\begin{multline"; "\begin{eqnarray"; "\begin{math}"; "\begin{displaymath}"] s.
 
 (** MATH-049: count_substring '\\times'. *)
 Definition math_049_chk (s : string) : bool :=
   string_contains_substring s "\times".
 
-(** MATH-050: No VPD pattern — conservative model. *)
-Definition math_050_chk (s : string) : bool := false.
+(** MATH-050: multi_substring [$, \(, \[, \begin{equation, \begin{align, \begin{gather, \begin{multline, \begin{eqnarray, \begin{math}, \begin{displaymath}]. *)
+Definition math_050_chk (s : string) : bool :=
+  multi_substring_check ["$"; "\("; "\["; "\begin{equation"; "\begin{align"; "\begin{gather"; "\begin{multline"; "\begin{eqnarray"; "\begin{math}"; "\begin{displaymath}"] s.
 
 (** MATH-051: count_substring '\\sqrt{'. *)
 Definition math_051_chk (s : string) : bool :=
@@ -136,28 +155,33 @@ Definition math_052_chk (s : string) : bool :=
 Definition math_053_chk (s : string) : bool :=
   string_contains_substring s "\left(".
 
-(** MATH-055: No VPD pattern — conservative model. *)
-Definition math_055_chk (s : string) : bool := false.
+(** MATH-055: multi_substring [$, \(, \[, \begin{equation, \begin{align, \begin{gather, \begin{multline, \begin{eqnarray, \begin{math}, \begin{displaymath}]. *)
+Definition math_055_chk (s : string) : bool :=
+  multi_substring_check ["$"; "\("; "\["; "\begin{equation"; "\begin{align"; "\begin{gather"; "\begin{multline"; "\begin{eqnarray"; "\begin{math}"; "\begin{displaymath}"] s.
 
-(** MATH-056: No VPD pattern — conservative model. *)
-Definition math_056_chk (s : string) : bool := false.
+(** MATH-056: multi_substring [$, \(, \[, \begin{equation, \begin{align, \begin{gather, \begin{multline, \begin{eqnarray, \begin{math}, \begin{displaymath}]. *)
+Definition math_056_chk (s : string) : bool :=
+  multi_substring_check ["$"; "\("; "\["; "\begin{equation"; "\begin{align"; "\begin{gather"; "\begin{multline"; "\begin{eqnarray"; "\begin{math}"; "\begin{displaymath}"] s.
 
 (** MATH-057: count_substring '\\frac'. *)
 Definition math_057_chk (s : string) : bool :=
   string_contains_substring s "\frac".
 
-(** MATH-058: No VPD pattern — conservative model. *)
-Definition math_058_chk (s : string) : bool := false.
+(** MATH-058: multi_substring [$, \(, \[, \begin{equation, \begin{align, \begin{gather, \begin{multline, \begin{eqnarray, \begin{math}, \begin{displaymath}]. *)
+Definition math_058_chk (s : string) : bool :=
+  multi_substring_check ["$"; "\("; "\["; "\begin{equation"; "\begin{align"; "\begin{gather"; "\begin{multline"; "\begin{eqnarray"; "\begin{math}"; "\begin{displaymath}"] s.
 
-(** MATH-059: No VPD pattern — conservative model. *)
-Definition math_059_chk (s : string) : bool := false.
+(** MATH-059: multi_substring [$, \(, \[, \begin{equation, \begin{align, \begin{gather, \begin{multline, \begin{eqnarray, \begin{math}, \begin{displaymath}]. *)
+Definition math_059_chk (s : string) : bool :=
+  multi_substring_check ["$"; "\("; "\["; "\begin{equation"; "\begin{align"; "\begin{gather"; "\begin{multline"; "\begin{eqnarray"; "\begin{math}"; "\begin{displaymath}"] s.
 
 (** MATH-060: multi_substring [\int, \mathrm{d}]. *)
 Definition math_060_chk (s : string) : bool :=
   multi_substring_check ["\int"; "\mathrm{d}"] s.
 
-(** MATH-061: No VPD pattern — conservative model. *)
-Definition math_061_chk (s : string) : bool := false.
+(** MATH-061: multi_substring [$, \(, \[, \begin{equation, \begin{align, \begin{gather, \begin{multline, \begin{eqnarray, \begin{math}, \begin{displaymath}]. *)
+Definition math_061_chk (s : string) : bool :=
+  multi_substring_check ["$"; "\("; "\["; "\begin{equation"; "\begin{align"; "\begin{gather"; "\begin{multline"; "\begin{eqnarray"; "\begin{math}"; "\begin{displaymath}"] s.
 
 (** MATH-065: count_substring '\\hspace'. *)
 Definition math_065_chk (s : string) : bool :=
@@ -171,8 +195,9 @@ Definition math_066_chk (s : string) : bool :=
 Definition math_067_chk (s : string) : bool :=
   string_contains_substring s "\limits".
 
-(** MATH-068: No VPD pattern — conservative model. *)
-Definition math_068_chk (s : string) : bool := false.
+(** MATH-068: multi_substring [$, \(, \[, \begin{equation, \begin{align, \begin{gather, \begin{multline, \begin{eqnarray, \begin{math}, \begin{displaymath}]. *)
+Definition math_068_chk (s : string) : bool :=
+  multi_substring_check ["$"; "\("; "\["; "\begin{equation"; "\begin{align"; "\begin{gather"; "\begin{multline"; "\begin{eqnarray"; "\begin{math}"; "\begin{displaymath}"] s.
 
 (** MATH-069: multi_substring [\mathbfsf, \bm{\mathsf{]. *)
 Definition math_069_chk (s : string) : bool :=
@@ -186,11 +211,13 @@ Definition math_070_chk (s : string) : bool :=
 Definition math_071_chk (s : string) : bool :=
   string_contains_substring s "\cancel{".
 
-(** MATH-072: No VPD pattern — conservative model. *)
-Definition math_072_chk (s : string) : bool := false.
+(** MATH-072: multi_substring [$, \(, \[, \begin{equation, \begin{align, \begin{gather, \begin{multline, \begin{eqnarray, \begin{math}, \begin{displaymath}]. *)
+Definition math_072_chk (s : string) : bool :=
+  multi_substring_check ["$"; "\("; "\["; "\begin{equation"; "\begin{align"; "\begin{gather"; "\begin{multline"; "\begin{eqnarray"; "\begin{math}"; "\begin{displaymath}"] s.
 
-(** MATH-073: No VPD pattern — conservative model. *)
-Definition math_073_chk (s : string) : bool := false.
+(** MATH-073: multi_substring [$, \(, \[, \begin{equation, \begin{align, \begin{gather, \begin{multline, \begin{eqnarray, \begin{math}, \begin{displaymath}]. *)
+Definition math_073_chk (s : string) : bool :=
+  multi_substring_check ["$"; "\("; "\["; "\begin{equation"; "\begin{align"; "\begin{gather"; "\begin{multline"; "\begin{eqnarray"; "\begin{math}"; "\begin{displaymath}"] s.
 
 (** MATH-074: count_substring '\\node'. *)
 Definition math_074_chk (s : string) : bool :=
@@ -207,8 +234,9 @@ Definition math_078_chk (s : string) : bool :=
 Definition math_079_chk (s : string) : bool :=
   string_contains_substring s "\displaystyle".
 
-(** MATH-081: No VPD pattern — conservative model. *)
-Definition math_081_chk (s : string) : bool := false.
+(** MATH-081: multi_substring [$, \(, \[, \begin{equation, \begin{align, \begin{gather, \begin{multline, \begin{eqnarray, \begin{math}, \begin{displaymath}]. *)
+Definition math_081_chk (s : string) : bool :=
+  multi_substring_check ["$"; "\("; "\["; "\begin{equation"; "\begin{align"; "\begin{gather"; "\begin{multline"; "\begin{eqnarray"; "\begin{math}"; "\begin{displaymath}"] s.
 
 (** MATH-082: count_substring '\\!\\!'. *)
 Definition math_082_chk (s : string) : bool :=
@@ -226,38 +254,44 @@ Definition math_085_chk (s : string) : bool :=
 Definition math_086_chk (s : string) : bool :=
   string_contains_substring s "\sqrt{\sqrt{".
 
-(** MATH-087: No VPD pattern — conservative model. *)
-Definition math_087_chk (s : string) : bool := false.
+(** MATH-087: multi_substring [$, \(, \[, \begin{equation, \begin{align, \begin{gather, \begin{multline, \begin{eqnarray, \begin{math}, \begin{displaymath}]. *)
+Definition math_087_chk (s : string) : bool :=
+  multi_substring_check ["$"; "\("; "\["; "\begin{equation"; "\begin{align"; "\begin{gather"; "\begin{multline"; "\begin{eqnarray"; "\begin{math}"; "\begin{displaymath}"] s.
 
-(** MATH-088: No VPD pattern — conservative model. *)
-Definition math_088_chk (s : string) : bool := false.
+(** MATH-088: multi_substring [$, \(, \[, \begin{equation, \begin{align, \begin{gather, \begin{multline, \begin{eqnarray, \begin{math}, \begin{displaymath}]. *)
+Definition math_088_chk (s : string) : bool :=
+  multi_substring_check ["$"; "\("; "\["; "\begin{equation"; "\begin{align"; "\begin{gather"; "\begin{multline"; "\begin{eqnarray"; "\begin{math}"; "\begin{displaymath}"] s.
 
 (** MATH-090: count_substring '\\frac{\\frac{\\frac{'. *)
 Definition math_090_chk (s : string) : bool :=
   string_contains_substring s "\frac{\frac{\frac{".
 
-(** MATH-091: No VPD pattern — conservative model. *)
-Definition math_091_chk (s : string) : bool := false.
+(** MATH-091: multi_substring [$, \(, \[, \begin{equation, \begin{align, \begin{gather, \begin{multline, \begin{eqnarray, \begin{math}, \begin{displaymath}]. *)
+Definition math_091_chk (s : string) : bool :=
+  multi_substring_check ["$"; "\("; "\["; "\begin{equation"; "\begin{align"; "\begin{gather"; "\begin{multline"; "\begin{eqnarray"; "\begin{math}"; "\begin{displaymath}"] s.
 
 (** MATH-092: No VPD pattern — conservative model. *)
 Definition math_092_chk (s : string) : bool := false.
 
-(** MATH-093: No VPD pattern — conservative model. *)
-Definition math_093_chk (s : string) : bool := false.
+(** MATH-093: multi_substring [$, \(, \[, \begin{equation, \begin{align, \begin{gather, \begin{multline, \begin{eqnarray, \begin{math}, \begin{displaymath}]. *)
+Definition math_093_chk (s : string) : bool :=
+  multi_substring_check ["$"; "\("; "\["; "\begin{equation"; "\begin{align"; "\begin{gather"; "\begin{multline"; "\begin{eqnarray"; "\begin{math}"; "\begin{displaymath}"] s.
 
 (** MATH-094: count_substring '\\kern'. *)
 Definition math_094_chk (s : string) : bool :=
   string_contains_substring s "\kern".
 
-(** MATH-095: No VPD pattern — conservative model. *)
-Definition math_095_chk (s : string) : bool := false.
+(** MATH-095: multi_substring [$, \(, \[, \begin{equation, \begin{align, \begin{gather, \begin{multline, \begin{eqnarray, \begin{math}, \begin{displaymath}]. *)
+Definition math_095_chk (s : string) : bool :=
+  multi_substring_check ["$"; "\("; "\["; "\begin{equation"; "\begin{align"; "\begin{gather"; "\begin{multline"; "\begin{eqnarray"; "\begin{math}"; "\begin{displaymath}"] s.
 
 (** MATH-096: count_substring '\\mathbf{'. *)
 Definition math_096_chk (s : string) : bool :=
   string_contains_substring s "\mathbf{".
 
-(** MATH-097: No VPD pattern — conservative model. *)
-Definition math_097_chk (s : string) : bool := false.
+(** MATH-097: multi_substring [$, \(, \[, \begin{equation, \begin{align, \begin{gather, \begin{multline, \begin{eqnarray, \begin{math}, \begin{displaymath}]. *)
+Definition math_097_chk (s : string) : bool :=
+  multi_substring_check ["$"; "\("; "\["; "\begin{equation"; "\begin{align"; "\begin{gather"; "\begin{multline"; "\begin{eqnarray"; "\begin{math}"; "\begin{displaymath}"] s.
 
 (** MATH-098: count_substring '\\qquad'. *)
 Definition math_098_chk (s : string) : bool :=

--- a/proofs/generated/L1_PT.v
+++ b/proofs/generated/L1_PT.v
@@ -9,8 +9,9 @@ Open Scope string_scope.
 
 (* ── Check functions ── *)
 
-(** PT-002: No VPD pattern — conservative model. *)
-Definition pt_002_chk (s : string) : bool := false.
+(** PT-002: multi_substring [$, \(, \[, \begin{equation, \begin{align, \begin{gather, \begin{multline, \begin{eqnarray, \begin{math}, \begin{displaymath}]. *)
+Definition pt_002_chk (s : string) : bool :=
+  multi_substring_check ["$"; "\("; "\["; "\begin{equation"; "\begin{align"; "\begin{gather"; "\begin{multline"; "\begin{eqnarray"; "\begin{math}"; "\begin{displaymath}"] s.
 
 (* ── Soundness theorems ── *)
 

--- a/proofs/generated/L1_RTL.v
+++ b/proofs/generated/L1_RTL.v
@@ -13,8 +13,9 @@ Open Scope string_scope.
 Definition rtl_003_chk (s : string) : bool :=
   multi_substring_check ["\beginR"; "\endR"] s.
 
-(** RTL-004: No VPD pattern — conservative model. *)
-Definition rtl_004_chk (s : string) : bool := false.
+(** RTL-004: multi_substring [$, \(, \[, \begin{equation, \begin{align, \begin{gather, \begin{multline, \begin{eqnarray, \begin{math}, \begin{displaymath}]. *)
+Definition rtl_004_chk (s : string) : bool :=
+  multi_substring_check ["$"; "\("; "\["; "\begin{equation"; "\begin{align"; "\begin{gather"; "\begin{multline"; "\begin{eqnarray"; "\begin{math}"; "\begin{displaymath}"] s.
 
 (* ── Soundness theorems ── *)
 

--- a/proofs/generated/L1_SCRIPT.v
+++ b/proofs/generated/L1_SCRIPT.v
@@ -9,20 +9,25 @@ Open Scope string_scope.
 
 (* ── Check functions ── *)
 
-(** SCRIPT-001: No VPD pattern — conservative model. *)
-Definition script_001_chk (s : string) : bool := false.
+(** SCRIPT-001: multi_substring [$, \(, \[, \begin{equation, \begin{align, \begin{gather, \begin{multline, \begin{eqnarray, \begin{math}, \begin{displaymath}]. *)
+Definition script_001_chk (s : string) : bool :=
+  multi_substring_check ["$"; "\("; "\["; "\begin{equation"; "\begin{align"; "\begin{gather"; "\begin{multline"; "\begin{eqnarray"; "\begin{math}"; "\begin{displaymath}"] s.
 
-(** SCRIPT-002: No VPD pattern — conservative model. *)
-Definition script_002_chk (s : string) : bool := false.
+(** SCRIPT-002: multi_substring [$, \(, \[, \begin{equation, \begin{align, \begin{gather, \begin{multline, \begin{eqnarray, \begin{math}, \begin{displaymath}]. *)
+Definition script_002_chk (s : string) : bool :=
+  multi_substring_check ["$"; "\("; "\["; "\begin{equation"; "\begin{align"; "\begin{gather"; "\begin{multline"; "\begin{eqnarray"; "\begin{math}"; "\begin{displaymath}"] s.
 
-(** SCRIPT-003: No VPD pattern — conservative model. *)
-Definition script_003_chk (s : string) : bool := false.
+(** SCRIPT-003: multi_substring [$, \(, \[, \begin{equation, \begin{align, \begin{gather, \begin{multline, \begin{eqnarray, \begin{math}, \begin{displaymath}]. *)
+Definition script_003_chk (s : string) : bool :=
+  multi_substring_check ["$"; "\("; "\["; "\begin{equation"; "\begin{align"; "\begin{gather"; "\begin{multline"; "\begin{eqnarray"; "\begin{math}"; "\begin{displaymath}"] s.
 
-(** SCRIPT-004: No VPD pattern — conservative model. *)
-Definition script_004_chk (s : string) : bool := false.
+(** SCRIPT-004: multi_substring [$, \(, \[, \begin{equation, \begin{align, \begin{gather, \begin{multline, \begin{eqnarray, \begin{math}, \begin{displaymath}]. *)
+Definition script_004_chk (s : string) : bool :=
+  multi_substring_check ["$"; "\("; "\["; "\begin{equation"; "\begin{align"; "\begin{gather"; "\begin{multline"; "\begin{eqnarray"; "\begin{math}"; "\begin{displaymath}"] s.
 
-(** SCRIPT-005: No VPD pattern — conservative model. *)
-Definition script_005_chk (s : string) : bool := false.
+(** SCRIPT-005: multi_substring [$, \(, \[, \begin{equation, \begin{align, \begin{gather, \begin{multline, \begin{eqnarray, \begin{math}, \begin{displaymath}]. *)
+Definition script_005_chk (s : string) : bool :=
+  multi_substring_check ["$"; "\("; "\["; "\begin{equation"; "\begin{align"; "\begin{gather"; "\begin{multline"; "\begin{eqnarray"; "\begin{math}"; "\begin{displaymath}"] s.
 
 (** SCRIPT-006: count_substring (UTF-8 bytes). *)
 Definition script_006_chk (s : string) : bool :=
@@ -36,49 +41,61 @@ Definition script_007_chk (s : string) : bool :=
 Definition script_008_chk (s : string) : bool :=
   multi_substring_check ["\ce{"; "\mathrm{"] s.
 
-(** SCRIPT-009: No VPD pattern — conservative model. *)
-Definition script_009_chk (s : string) : bool := false.
+(** SCRIPT-009: multi_substring [$, \(, \[, \begin{equation, \begin{align, \begin{gather, \begin{multline, \begin{eqnarray, \begin{math}, \begin{displaymath}]. *)
+Definition script_009_chk (s : string) : bool :=
+  multi_substring_check ["$"; "\("; "\["; "\begin{equation"; "\begin{align"; "\begin{gather"; "\begin{multline"; "\begin{eqnarray"; "\begin{math}"; "\begin{displaymath}"] s.
 
 (** SCRIPT-010: count_substring '\\limits'. *)
 Definition script_010_chk (s : string) : bool :=
   string_contains_substring s "\limits".
 
-(** SCRIPT-011: No VPD pattern — conservative model. *)
-Definition script_011_chk (s : string) : bool := false.
+(** SCRIPT-011: multi_substring [$, \(, \[, \begin{equation, \begin{align, \begin{gather, \begin{multline, \begin{eqnarray, \begin{math}, \begin{displaymath}]. *)
+Definition script_011_chk (s : string) : bool :=
+  multi_substring_check ["$"; "\("; "\["; "\begin{equation"; "\begin{align"; "\begin{gather"; "\begin{multline"; "\begin{eqnarray"; "\begin{math}"; "\begin{displaymath}"] s.
 
-(** SCRIPT-012: No VPD pattern — conservative model. *)
-Definition script_012_chk (s : string) : bool := false.
+(** SCRIPT-012: multi_substring [$, \(, \[, \begin{equation, \begin{align, \begin{gather, \begin{multline, \begin{eqnarray, \begin{math}, \begin{displaymath}]. *)
+Definition script_012_chk (s : string) : bool :=
+  multi_substring_check ["$"; "\("; "\["; "\begin{equation"; "\begin{align"; "\begin{gather"; "\begin{multline"; "\begin{eqnarray"; "\begin{math}"; "\begin{displaymath}"] s.
 
-(** SCRIPT-013: No VPD pattern — conservative model. *)
-Definition script_013_chk (s : string) : bool := false.
+(** SCRIPT-013: multi_substring [$, \(, \[, \begin{equation, \begin{align, \begin{gather, \begin{multline, \begin{eqnarray, \begin{math}, \begin{displaymath}]. *)
+Definition script_013_chk (s : string) : bool :=
+  multi_substring_check ["$"; "\("; "\["; "\begin{equation"; "\begin{align"; "\begin{gather"; "\begin{multline"; "\begin{eqnarray"; "\begin{math}"; "\begin{displaymath}"] s.
 
-(** SCRIPT-014: No VPD pattern — conservative model. *)
-Definition script_014_chk (s : string) : bool := false.
+(** SCRIPT-014: multi_substring [$, \(, \[, \begin{equation, \begin{align, \begin{gather, \begin{multline, \begin{eqnarray, \begin{math}, \begin{displaymath}]. *)
+Definition script_014_chk (s : string) : bool :=
+  multi_substring_check ["$"; "\("; "\["; "\begin{equation"; "\begin{align"; "\begin{gather"; "\begin{multline"; "\begin{eqnarray"; "\begin{math}"; "\begin{displaymath}"] s.
 
-(** SCRIPT-015: No VPD pattern — conservative model. *)
-Definition script_015_chk (s : string) : bool := false.
+(** SCRIPT-015: multi_substring [$, \(, \[, \begin{equation, \begin{align, \begin{gather, \begin{multline, \begin{eqnarray, \begin{math}, \begin{displaymath}]. *)
+Definition script_015_chk (s : string) : bool :=
+  multi_substring_check ["$"; "\("; "\["; "\begin{equation"; "\begin{align"; "\begin{gather"; "\begin{multline"; "\begin{eqnarray"; "\begin{math}"; "\begin{displaymath}"] s.
 
-(** SCRIPT-016: No VPD pattern — conservative model. *)
-Definition script_016_chk (s : string) : bool := false.
+(** SCRIPT-016: multi_substring [$, \(, \[, \begin{equation, \begin{align, \begin{gather, \begin{multline, \begin{eqnarray, \begin{math}, \begin{displaymath}]. *)
+Definition script_016_chk (s : string) : bool :=
+  multi_substring_check ["$"; "\("; "\["; "\begin{equation"; "\begin{align"; "\begin{gather"; "\begin{multline"; "\begin{eqnarray"; "\begin{math}"; "\begin{displaymath}"] s.
 
-(** SCRIPT-017: No VPD pattern — conservative model. *)
-Definition script_017_chk (s : string) : bool := false.
+(** SCRIPT-017: multi_substring [$, \(, \[, \begin{equation, \begin{align, \begin{gather, \begin{multline, \begin{eqnarray, \begin{math}, \begin{displaymath}]. *)
+Definition script_017_chk (s : string) : bool :=
+  multi_substring_check ["$"; "\("; "\["; "\begin{equation"; "\begin{align"; "\begin{gather"; "\begin{multline"; "\begin{eqnarray"; "\begin{math}"; "\begin{displaymath}"] s.
 
-(** SCRIPT-018: No VPD pattern — conservative model. *)
-Definition script_018_chk (s : string) : bool := false.
+(** SCRIPT-018: multi_substring [$, \(, \[, \begin{equation, \begin{align, \begin{gather, \begin{multline, \begin{eqnarray, \begin{math}, \begin{displaymath}]. *)
+Definition script_018_chk (s : string) : bool :=
+  multi_substring_check ["$"; "\("; "\["; "\begin{equation"; "\begin{align"; "\begin{gather"; "\begin{multline"; "\begin{eqnarray"; "\begin{math}"; "\begin{displaymath}"] s.
 
-(** SCRIPT-019: No VPD pattern — conservative model. *)
-Definition script_019_chk (s : string) : bool := false.
+(** SCRIPT-019: multi_substring [$, \(, \[, \begin{equation, \begin{align, \begin{gather, \begin{multline, \begin{eqnarray, \begin{math}, \begin{displaymath}]. *)
+Definition script_019_chk (s : string) : bool :=
+  multi_substring_check ["$"; "\("; "\["; "\begin{equation"; "\begin{align"; "\begin{gather"; "\begin{multline"; "\begin{eqnarray"; "\begin{math}"; "\begin{displaymath}"] s.
 
 (** SCRIPT-020: multi_substring [\mathrm{, \text{]. *)
 Definition script_020_chk (s : string) : bool :=
   multi_substring_check ["\mathrm{"; "\text{"] s.
 
-(** SCRIPT-021: No VPD pattern — conservative model. *)
-Definition script_021_chk (s : string) : bool := false.
+(** SCRIPT-021: multi_substring [$, \(, \[, \begin{equation, \begin{align, \begin{gather, \begin{multline, \begin{eqnarray, \begin{math}, \begin{displaymath}]. *)
+Definition script_021_chk (s : string) : bool :=
+  multi_substring_check ["$"; "\("; "\["; "\begin{equation"; "\begin{align"; "\begin{gather"; "\begin{multline"; "\begin{eqnarray"; "\begin{math}"; "\begin{displaymath}"] s.
 
-(** SCRIPT-022: No VPD pattern — conservative model. *)
-Definition script_022_chk (s : string) : bool := false.
+(** SCRIPT-022: multi_substring [$, \(, \[, \begin{equation, \begin{align, \begin{gather, \begin{multline, \begin{eqnarray, \begin{math}, \begin{displaymath}]. *)
+Definition script_022_chk (s : string) : bool :=
+  multi_substring_check ["$"; "\("; "\["; "\begin{equation"; "\begin{align"; "\begin{gather"; "\begin{multline"; "\begin{eqnarray"; "\begin{math}"; "\begin{displaymath}"] s.
 
 (* ── Soundness theorems ── *)
 

--- a/proofs/generated/L1_TYPO.v
+++ b/proofs/generated/L1_TYPO.v
@@ -9,8 +9,9 @@ Open Scope string_scope.
 
 (* ── Check functions ── *)
 
-(** TYPO-059: No VPD pattern — conservative model. *)
-Definition typo_059_chk (s : string) : bool := false.
+(** TYPO-059: multi_substring [$, \(, \[, \begin{equation, \begin{align, \begin{gather, \begin{multline, \begin{eqnarray, \begin{math}, \begin{displaymath}]. *)
+Definition typo_059_chk (s : string) : bool :=
+  multi_substring_check ["$"; "\("; "\["; "\begin{equation"; "\begin{align"; "\begin{gather"; "\begin{multline"; "\begin{eqnarray"; "\begin{math}"; "\begin{displaymath}"] s.
 
 (* ── Soundness theorems ── *)
 

--- a/specs/rules/vpd_patterns.json
+++ b/specs/rules/vpd_patterns.json
@@ -2047,5 +2047,1183 @@
       "needle": "\\def\\arraystretch"
     },
     "severity": "Info"
+  },
+  "MATH-009": {
+    "layer": "L1",
+    "pattern": {
+      "family": "multi_substring",
+      "needles": [
+        "$",
+        "\\(",
+        "\\[",
+        "\\begin{equation",
+        "\\begin{align",
+        "\\begin{gather",
+        "\\begin{multline",
+        "\\begin{eqnarray",
+        "\\begin{math}",
+        "\\begin{displaymath}"
+      ]
+    },
+    "severity": "Info"
+  },
+  "MATH-016": {
+    "layer": "L1",
+    "pattern": {
+      "family": "multi_substring",
+      "needles": [
+        "$",
+        "\\(",
+        "\\[",
+        "\\begin{equation",
+        "\\begin{align",
+        "\\begin{gather",
+        "\\begin{multline",
+        "\\begin{eqnarray",
+        "\\begin{math}",
+        "\\begin{displaymath}"
+      ]
+    },
+    "severity": "Info"
+  },
+  "MATH-017": {
+    "layer": "L1",
+    "pattern": {
+      "family": "multi_substring",
+      "needles": [
+        "$",
+        "\\(",
+        "\\[",
+        "\\begin{equation",
+        "\\begin{align",
+        "\\begin{gather",
+        "\\begin{multline",
+        "\\begin{eqnarray",
+        "\\begin{math}",
+        "\\begin{displaymath}"
+      ]
+    },
+    "severity": "Info"
+  },
+  "MATH-018": {
+    "layer": "L1",
+    "pattern": {
+      "family": "multi_substring",
+      "needles": [
+        "$",
+        "\\(",
+        "\\[",
+        "\\begin{equation",
+        "\\begin{align",
+        "\\begin{gather",
+        "\\begin{multline",
+        "\\begin{eqnarray",
+        "\\begin{math}",
+        "\\begin{displaymath}"
+      ]
+    },
+    "severity": "Info"
+  },
+  "MATH-020": {
+    "layer": "L1",
+    "pattern": {
+      "family": "multi_substring",
+      "needles": [
+        "$",
+        "\\(",
+        "\\[",
+        "\\begin{equation",
+        "\\begin{align",
+        "\\begin{gather",
+        "\\begin{multline",
+        "\\begin{eqnarray",
+        "\\begin{math}",
+        "\\begin{displaymath}"
+      ]
+    },
+    "severity": "Info"
+  },
+  "MATH-021": {
+    "layer": "L1",
+    "pattern": {
+      "family": "multi_substring",
+      "needles": [
+        "$",
+        "\\(",
+        "\\[",
+        "\\begin{equation",
+        "\\begin{align",
+        "\\begin{gather",
+        "\\begin{multline",
+        "\\begin{eqnarray",
+        "\\begin{math}",
+        "\\begin{displaymath}"
+      ]
+    },
+    "severity": "Info"
+  },
+  "MATH-031": {
+    "layer": "L1",
+    "pattern": {
+      "family": "multi_substring",
+      "needles": [
+        "$",
+        "\\(",
+        "\\[",
+        "\\begin{equation",
+        "\\begin{align",
+        "\\begin{gather",
+        "\\begin{multline",
+        "\\begin{eqnarray",
+        "\\begin{math}",
+        "\\begin{displaymath}"
+      ]
+    },
+    "severity": "Info"
+  },
+  "MATH-035": {
+    "layer": "L1",
+    "pattern": {
+      "family": "multi_substring",
+      "needles": [
+        "$",
+        "\\(",
+        "\\[",
+        "\\begin{equation",
+        "\\begin{align",
+        "\\begin{gather",
+        "\\begin{multline",
+        "\\begin{eqnarray",
+        "\\begin{math}",
+        "\\begin{displaymath}"
+      ]
+    },
+    "severity": "Info"
+  },
+  "MATH-036": {
+    "layer": "L1",
+    "pattern": {
+      "family": "multi_substring",
+      "needles": [
+        "$",
+        "\\(",
+        "\\[",
+        "\\begin{equation",
+        "\\begin{align",
+        "\\begin{gather",
+        "\\begin{multline",
+        "\\begin{eqnarray",
+        "\\begin{math}",
+        "\\begin{displaymath}"
+      ]
+    },
+    "severity": "Info"
+  },
+  "MATH-039": {
+    "layer": "L1",
+    "pattern": {
+      "family": "multi_substring",
+      "needles": [
+        "$",
+        "\\(",
+        "\\[",
+        "\\begin{equation",
+        "\\begin{align",
+        "\\begin{gather",
+        "\\begin{multline",
+        "\\begin{eqnarray",
+        "\\begin{math}",
+        "\\begin{displaymath}"
+      ]
+    },
+    "severity": "Info"
+  },
+  "MATH-040": {
+    "layer": "L1",
+    "pattern": {
+      "family": "multi_substring",
+      "needles": [
+        "$",
+        "\\(",
+        "\\[",
+        "\\begin{equation",
+        "\\begin{align",
+        "\\begin{gather",
+        "\\begin{multline",
+        "\\begin{eqnarray",
+        "\\begin{math}",
+        "\\begin{displaymath}"
+      ]
+    },
+    "severity": "Info"
+  },
+  "MATH-042": {
+    "layer": "L1",
+    "pattern": {
+      "family": "multi_substring",
+      "needles": [
+        "$",
+        "\\(",
+        "\\[",
+        "\\begin{equation",
+        "\\begin{align",
+        "\\begin{gather",
+        "\\begin{multline",
+        "\\begin{eqnarray",
+        "\\begin{math}",
+        "\\begin{displaymath}"
+      ]
+    },
+    "severity": "Info"
+  },
+  "MATH-043": {
+    "layer": "L1",
+    "pattern": {
+      "family": "multi_substring",
+      "needles": [
+        "$",
+        "\\(",
+        "\\[",
+        "\\begin{equation",
+        "\\begin{align",
+        "\\begin{gather",
+        "\\begin{multline",
+        "\\begin{eqnarray",
+        "\\begin{math}",
+        "\\begin{displaymath}"
+      ]
+    },
+    "severity": "Info"
+  },
+  "MATH-044": {
+    "layer": "L1",
+    "pattern": {
+      "family": "multi_substring",
+      "needles": [
+        "$",
+        "\\(",
+        "\\[",
+        "\\begin{equation",
+        "\\begin{align",
+        "\\begin{gather",
+        "\\begin{multline",
+        "\\begin{eqnarray",
+        "\\begin{math}",
+        "\\begin{displaymath}"
+      ]
+    },
+    "severity": "Info"
+  },
+  "MATH-045": {
+    "layer": "L1",
+    "pattern": {
+      "family": "multi_substring",
+      "needles": [
+        "$",
+        "\\(",
+        "\\[",
+        "\\begin{equation",
+        "\\begin{align",
+        "\\begin{gather",
+        "\\begin{multline",
+        "\\begin{eqnarray",
+        "\\begin{math}",
+        "\\begin{displaymath}"
+      ]
+    },
+    "severity": "Info"
+  },
+  "MATH-046": {
+    "layer": "L1",
+    "pattern": {
+      "family": "multi_substring",
+      "needles": [
+        "$",
+        "\\(",
+        "\\[",
+        "\\begin{equation",
+        "\\begin{align",
+        "\\begin{gather",
+        "\\begin{multline",
+        "\\begin{eqnarray",
+        "\\begin{math}",
+        "\\begin{displaymath}"
+      ]
+    },
+    "severity": "Info"
+  },
+  "MATH-047": {
+    "layer": "L1",
+    "pattern": {
+      "family": "multi_substring",
+      "needles": [
+        "$",
+        "\\(",
+        "\\[",
+        "\\begin{equation",
+        "\\begin{align",
+        "\\begin{gather",
+        "\\begin{multline",
+        "\\begin{eqnarray",
+        "\\begin{math}",
+        "\\begin{displaymath}"
+      ]
+    },
+    "severity": "Info"
+  },
+  "MATH-048": {
+    "layer": "L1",
+    "pattern": {
+      "family": "multi_substring",
+      "needles": [
+        "$",
+        "\\(",
+        "\\[",
+        "\\begin{equation",
+        "\\begin{align",
+        "\\begin{gather",
+        "\\begin{multline",
+        "\\begin{eqnarray",
+        "\\begin{math}",
+        "\\begin{displaymath}"
+      ]
+    },
+    "severity": "Info"
+  },
+  "MATH-050": {
+    "layer": "L1",
+    "pattern": {
+      "family": "multi_substring",
+      "needles": [
+        "$",
+        "\\(",
+        "\\[",
+        "\\begin{equation",
+        "\\begin{align",
+        "\\begin{gather",
+        "\\begin{multline",
+        "\\begin{eqnarray",
+        "\\begin{math}",
+        "\\begin{displaymath}"
+      ]
+    },
+    "severity": "Info"
+  },
+  "MATH-055": {
+    "layer": "L1",
+    "pattern": {
+      "family": "multi_substring",
+      "needles": [
+        "$",
+        "\\(",
+        "\\[",
+        "\\begin{equation",
+        "\\begin{align",
+        "\\begin{gather",
+        "\\begin{multline",
+        "\\begin{eqnarray",
+        "\\begin{math}",
+        "\\begin{displaymath}"
+      ]
+    },
+    "severity": "Info"
+  },
+  "MATH-056": {
+    "layer": "L1",
+    "pattern": {
+      "family": "multi_substring",
+      "needles": [
+        "$",
+        "\\(",
+        "\\[",
+        "\\begin{equation",
+        "\\begin{align",
+        "\\begin{gather",
+        "\\begin{multline",
+        "\\begin{eqnarray",
+        "\\begin{math}",
+        "\\begin{displaymath}"
+      ]
+    },
+    "severity": "Info"
+  },
+  "MATH-058": {
+    "layer": "L1",
+    "pattern": {
+      "family": "multi_substring",
+      "needles": [
+        "$",
+        "\\(",
+        "\\[",
+        "\\begin{equation",
+        "\\begin{align",
+        "\\begin{gather",
+        "\\begin{multline",
+        "\\begin{eqnarray",
+        "\\begin{math}",
+        "\\begin{displaymath}"
+      ]
+    },
+    "severity": "Info"
+  },
+  "MATH-059": {
+    "layer": "L1",
+    "pattern": {
+      "family": "multi_substring",
+      "needles": [
+        "$",
+        "\\(",
+        "\\[",
+        "\\begin{equation",
+        "\\begin{align",
+        "\\begin{gather",
+        "\\begin{multline",
+        "\\begin{eqnarray",
+        "\\begin{math}",
+        "\\begin{displaymath}"
+      ]
+    },
+    "severity": "Info"
+  },
+  "MATH-061": {
+    "layer": "L1",
+    "pattern": {
+      "family": "multi_substring",
+      "needles": [
+        "$",
+        "\\(",
+        "\\[",
+        "\\begin{equation",
+        "\\begin{align",
+        "\\begin{gather",
+        "\\begin{multline",
+        "\\begin{eqnarray",
+        "\\begin{math}",
+        "\\begin{displaymath}"
+      ]
+    },
+    "severity": "Info"
+  },
+  "MATH-068": {
+    "layer": "L1",
+    "pattern": {
+      "family": "multi_substring",
+      "needles": [
+        "$",
+        "\\(",
+        "\\[",
+        "\\begin{equation",
+        "\\begin{align",
+        "\\begin{gather",
+        "\\begin{multline",
+        "\\begin{eqnarray",
+        "\\begin{math}",
+        "\\begin{displaymath}"
+      ]
+    },
+    "severity": "Info"
+  },
+  "MATH-072": {
+    "layer": "L1",
+    "pattern": {
+      "family": "multi_substring",
+      "needles": [
+        "$",
+        "\\(",
+        "\\[",
+        "\\begin{equation",
+        "\\begin{align",
+        "\\begin{gather",
+        "\\begin{multline",
+        "\\begin{eqnarray",
+        "\\begin{math}",
+        "\\begin{displaymath}"
+      ]
+    },
+    "severity": "Info"
+  },
+  "MATH-073": {
+    "layer": "L1",
+    "pattern": {
+      "family": "multi_substring",
+      "needles": [
+        "$",
+        "\\(",
+        "\\[",
+        "\\begin{equation",
+        "\\begin{align",
+        "\\begin{gather",
+        "\\begin{multline",
+        "\\begin{eqnarray",
+        "\\begin{math}",
+        "\\begin{displaymath}"
+      ]
+    },
+    "severity": "Info"
+  },
+  "MATH-081": {
+    "layer": "L1",
+    "pattern": {
+      "family": "multi_substring",
+      "needles": [
+        "$",
+        "\\(",
+        "\\[",
+        "\\begin{equation",
+        "\\begin{align",
+        "\\begin{gather",
+        "\\begin{multline",
+        "\\begin{eqnarray",
+        "\\begin{math}",
+        "\\begin{displaymath}"
+      ]
+    },
+    "severity": "Info"
+  },
+  "MATH-087": {
+    "layer": "L1",
+    "pattern": {
+      "family": "multi_substring",
+      "needles": [
+        "$",
+        "\\(",
+        "\\[",
+        "\\begin{equation",
+        "\\begin{align",
+        "\\begin{gather",
+        "\\begin{multline",
+        "\\begin{eqnarray",
+        "\\begin{math}",
+        "\\begin{displaymath}"
+      ]
+    },
+    "severity": "Info"
+  },
+  "MATH-088": {
+    "layer": "L1",
+    "pattern": {
+      "family": "multi_substring",
+      "needles": [
+        "$",
+        "\\(",
+        "\\[",
+        "\\begin{equation",
+        "\\begin{align",
+        "\\begin{gather",
+        "\\begin{multline",
+        "\\begin{eqnarray",
+        "\\begin{math}",
+        "\\begin{displaymath}"
+      ]
+    },
+    "severity": "Info"
+  },
+  "MATH-091": {
+    "layer": "L1",
+    "pattern": {
+      "family": "multi_substring",
+      "needles": [
+        "$",
+        "\\(",
+        "\\[",
+        "\\begin{equation",
+        "\\begin{align",
+        "\\begin{gather",
+        "\\begin{multline",
+        "\\begin{eqnarray",
+        "\\begin{math}",
+        "\\begin{displaymath}"
+      ]
+    },
+    "severity": "Info"
+  },
+  "MATH-093": {
+    "layer": "L1",
+    "pattern": {
+      "family": "multi_substring",
+      "needles": [
+        "$",
+        "\\(",
+        "\\[",
+        "\\begin{equation",
+        "\\begin{align",
+        "\\begin{gather",
+        "\\begin{multline",
+        "\\begin{eqnarray",
+        "\\begin{math}",
+        "\\begin{displaymath}"
+      ]
+    },
+    "severity": "Info"
+  },
+  "MATH-095": {
+    "layer": "L1",
+    "pattern": {
+      "family": "multi_substring",
+      "needles": [
+        "$",
+        "\\(",
+        "\\[",
+        "\\begin{equation",
+        "\\begin{align",
+        "\\begin{gather",
+        "\\begin{multline",
+        "\\begin{eqnarray",
+        "\\begin{math}",
+        "\\begin{displaymath}"
+      ]
+    },
+    "severity": "Info"
+  },
+  "MATH-097": {
+    "layer": "L1",
+    "pattern": {
+      "family": "multi_substring",
+      "needles": [
+        "$",
+        "\\(",
+        "\\[",
+        "\\begin{equation",
+        "\\begin{align",
+        "\\begin{gather",
+        "\\begin{multline",
+        "\\begin{eqnarray",
+        "\\begin{math}",
+        "\\begin{displaymath}"
+      ]
+    },
+    "severity": "Info"
+  },
+  "SCRIPT-001": {
+    "layer": "L1",
+    "pattern": {
+      "family": "multi_substring",
+      "needles": [
+        "$",
+        "\\(",
+        "\\[",
+        "\\begin{equation",
+        "\\begin{align",
+        "\\begin{gather",
+        "\\begin{multline",
+        "\\begin{eqnarray",
+        "\\begin{math}",
+        "\\begin{displaymath}"
+      ]
+    },
+    "severity": "Info"
+  },
+  "SCRIPT-002": {
+    "layer": "L1",
+    "pattern": {
+      "family": "multi_substring",
+      "needles": [
+        "$",
+        "\\(",
+        "\\[",
+        "\\begin{equation",
+        "\\begin{align",
+        "\\begin{gather",
+        "\\begin{multline",
+        "\\begin{eqnarray",
+        "\\begin{math}",
+        "\\begin{displaymath}"
+      ]
+    },
+    "severity": "Info"
+  },
+  "SCRIPT-003": {
+    "layer": "L1",
+    "pattern": {
+      "family": "multi_substring",
+      "needles": [
+        "$",
+        "\\(",
+        "\\[",
+        "\\begin{equation",
+        "\\begin{align",
+        "\\begin{gather",
+        "\\begin{multline",
+        "\\begin{eqnarray",
+        "\\begin{math}",
+        "\\begin{displaymath}"
+      ]
+    },
+    "severity": "Info"
+  },
+  "SCRIPT-004": {
+    "layer": "L1",
+    "pattern": {
+      "family": "multi_substring",
+      "needles": [
+        "$",
+        "\\(",
+        "\\[",
+        "\\begin{equation",
+        "\\begin{align",
+        "\\begin{gather",
+        "\\begin{multline",
+        "\\begin{eqnarray",
+        "\\begin{math}",
+        "\\begin{displaymath}"
+      ]
+    },
+    "severity": "Info"
+  },
+  "SCRIPT-005": {
+    "layer": "L1",
+    "pattern": {
+      "family": "multi_substring",
+      "needles": [
+        "$",
+        "\\(",
+        "\\[",
+        "\\begin{equation",
+        "\\begin{align",
+        "\\begin{gather",
+        "\\begin{multline",
+        "\\begin{eqnarray",
+        "\\begin{math}",
+        "\\begin{displaymath}"
+      ]
+    },
+    "severity": "Info"
+  },
+  "SCRIPT-009": {
+    "layer": "L1",
+    "pattern": {
+      "family": "multi_substring",
+      "needles": [
+        "$",
+        "\\(",
+        "\\[",
+        "\\begin{equation",
+        "\\begin{align",
+        "\\begin{gather",
+        "\\begin{multline",
+        "\\begin{eqnarray",
+        "\\begin{math}",
+        "\\begin{displaymath}"
+      ]
+    },
+    "severity": "Info"
+  },
+  "SCRIPT-011": {
+    "layer": "L1",
+    "pattern": {
+      "family": "multi_substring",
+      "needles": [
+        "$",
+        "\\(",
+        "\\[",
+        "\\begin{equation",
+        "\\begin{align",
+        "\\begin{gather",
+        "\\begin{multline",
+        "\\begin{eqnarray",
+        "\\begin{math}",
+        "\\begin{displaymath}"
+      ]
+    },
+    "severity": "Info"
+  },
+  "SCRIPT-012": {
+    "layer": "L1",
+    "pattern": {
+      "family": "multi_substring",
+      "needles": [
+        "$",
+        "\\(",
+        "\\[",
+        "\\begin{equation",
+        "\\begin{align",
+        "\\begin{gather",
+        "\\begin{multline",
+        "\\begin{eqnarray",
+        "\\begin{math}",
+        "\\begin{displaymath}"
+      ]
+    },
+    "severity": "Info"
+  },
+  "SCRIPT-013": {
+    "layer": "L1",
+    "pattern": {
+      "family": "multi_substring",
+      "needles": [
+        "$",
+        "\\(",
+        "\\[",
+        "\\begin{equation",
+        "\\begin{align",
+        "\\begin{gather",
+        "\\begin{multline",
+        "\\begin{eqnarray",
+        "\\begin{math}",
+        "\\begin{displaymath}"
+      ]
+    },
+    "severity": "Info"
+  },
+  "SCRIPT-014": {
+    "layer": "L1",
+    "pattern": {
+      "family": "multi_substring",
+      "needles": [
+        "$",
+        "\\(",
+        "\\[",
+        "\\begin{equation",
+        "\\begin{align",
+        "\\begin{gather",
+        "\\begin{multline",
+        "\\begin{eqnarray",
+        "\\begin{math}",
+        "\\begin{displaymath}"
+      ]
+    },
+    "severity": "Info"
+  },
+  "SCRIPT-015": {
+    "layer": "L1",
+    "pattern": {
+      "family": "multi_substring",
+      "needles": [
+        "$",
+        "\\(",
+        "\\[",
+        "\\begin{equation",
+        "\\begin{align",
+        "\\begin{gather",
+        "\\begin{multline",
+        "\\begin{eqnarray",
+        "\\begin{math}",
+        "\\begin{displaymath}"
+      ]
+    },
+    "severity": "Info"
+  },
+  "SCRIPT-016": {
+    "layer": "L1",
+    "pattern": {
+      "family": "multi_substring",
+      "needles": [
+        "$",
+        "\\(",
+        "\\[",
+        "\\begin{equation",
+        "\\begin{align",
+        "\\begin{gather",
+        "\\begin{multline",
+        "\\begin{eqnarray",
+        "\\begin{math}",
+        "\\begin{displaymath}"
+      ]
+    },
+    "severity": "Info"
+  },
+  "SCRIPT-017": {
+    "layer": "L1",
+    "pattern": {
+      "family": "multi_substring",
+      "needles": [
+        "$",
+        "\\(",
+        "\\[",
+        "\\begin{equation",
+        "\\begin{align",
+        "\\begin{gather",
+        "\\begin{multline",
+        "\\begin{eqnarray",
+        "\\begin{math}",
+        "\\begin{displaymath}"
+      ]
+    },
+    "severity": "Info"
+  },
+  "SCRIPT-018": {
+    "layer": "L1",
+    "pattern": {
+      "family": "multi_substring",
+      "needles": [
+        "$",
+        "\\(",
+        "\\[",
+        "\\begin{equation",
+        "\\begin{align",
+        "\\begin{gather",
+        "\\begin{multline",
+        "\\begin{eqnarray",
+        "\\begin{math}",
+        "\\begin{displaymath}"
+      ]
+    },
+    "severity": "Info"
+  },
+  "SCRIPT-019": {
+    "layer": "L1",
+    "pattern": {
+      "family": "multi_substring",
+      "needles": [
+        "$",
+        "\\(",
+        "\\[",
+        "\\begin{equation",
+        "\\begin{align",
+        "\\begin{gather",
+        "\\begin{multline",
+        "\\begin{eqnarray",
+        "\\begin{math}",
+        "\\begin{displaymath}"
+      ]
+    },
+    "severity": "Info"
+  },
+  "SCRIPT-021": {
+    "layer": "L1",
+    "pattern": {
+      "family": "multi_substring",
+      "needles": [
+        "$",
+        "\\(",
+        "\\[",
+        "\\begin{equation",
+        "\\begin{align",
+        "\\begin{gather",
+        "\\begin{multline",
+        "\\begin{eqnarray",
+        "\\begin{math}",
+        "\\begin{displaymath}"
+      ]
+    },
+    "severity": "Info"
+  },
+  "SCRIPT-022": {
+    "layer": "L1",
+    "pattern": {
+      "family": "multi_substring",
+      "needles": [
+        "$",
+        "\\(",
+        "\\[",
+        "\\begin{equation",
+        "\\begin{align",
+        "\\begin{gather",
+        "\\begin{multline",
+        "\\begin{eqnarray",
+        "\\begin{math}",
+        "\\begin{displaymath}"
+      ]
+    },
+    "severity": "Info"
+  },
+  "CHEM-002": {
+    "layer": "L1",
+    "pattern": {
+      "family": "multi_substring",
+      "needles": [
+        "$",
+        "\\(",
+        "\\[",
+        "\\begin{equation",
+        "\\begin{align",
+        "\\begin{gather",
+        "\\begin{multline",
+        "\\begin{eqnarray",
+        "\\begin{math}",
+        "\\begin{displaymath}"
+      ]
+    },
+    "severity": "Info"
+  },
+  "CHEM-004": {
+    "layer": "L1",
+    "pattern": {
+      "family": "multi_substring",
+      "needles": [
+        "$",
+        "\\(",
+        "\\[",
+        "\\begin{equation",
+        "\\begin{align",
+        "\\begin{gather",
+        "\\begin{multline",
+        "\\begin{eqnarray",
+        "\\begin{math}",
+        "\\begin{displaymath}"
+      ]
+    },
+    "severity": "Info"
+  },
+  "CHEM-008": {
+    "layer": "L1",
+    "pattern": {
+      "family": "multi_substring",
+      "needles": [
+        "$",
+        "\\(",
+        "\\[",
+        "\\begin{equation",
+        "\\begin{align",
+        "\\begin{gather",
+        "\\begin{multline",
+        "\\begin{eqnarray",
+        "\\begin{math}",
+        "\\begin{displaymath}"
+      ]
+    },
+    "severity": "Info"
+  },
+  "DELIM-008": {
+    "layer": "L1",
+    "pattern": {
+      "family": "multi_substring",
+      "needles": [
+        "$",
+        "\\(",
+        "\\[",
+        "\\begin{equation",
+        "\\begin{align",
+        "\\begin{gather",
+        "\\begin{multline",
+        "\\begin{eqnarray",
+        "\\begin{math}",
+        "\\begin{displaymath}"
+      ]
+    },
+    "severity": "Info"
+  },
+  "DELIM-009": {
+    "layer": "L1",
+    "pattern": {
+      "family": "multi_substring",
+      "needles": [
+        "$",
+        "\\(",
+        "\\[",
+        "\\begin{equation",
+        "\\begin{align",
+        "\\begin{gather",
+        "\\begin{multline",
+        "\\begin{eqnarray",
+        "\\begin{math}",
+        "\\begin{displaymath}"
+      ]
+    },
+    "severity": "Info"
+  },
+  "CJK-008": {
+    "layer": "L1",
+    "pattern": {
+      "family": "multi_substring",
+      "needles": [
+        "$",
+        "\\(",
+        "\\[",
+        "\\begin{equation",
+        "\\begin{align",
+        "\\begin{gather",
+        "\\begin{multline",
+        "\\begin{eqnarray",
+        "\\begin{math}",
+        "\\begin{displaymath}"
+      ]
+    },
+    "severity": "Info"
+  },
+  "CJK-015": {
+    "layer": "L1",
+    "pattern": {
+      "family": "multi_substring",
+      "needles": [
+        "$",
+        "\\(",
+        "\\[",
+        "\\begin{equation",
+        "\\begin{align",
+        "\\begin{gather",
+        "\\begin{multline",
+        "\\begin{eqnarray",
+        "\\begin{math}",
+        "\\begin{displaymath}"
+      ]
+    },
+    "severity": "Info"
+  },
+  "FONT-004": {
+    "layer": "L1",
+    "pattern": {
+      "family": "multi_substring",
+      "needles": [
+        "$",
+        "\\(",
+        "\\[",
+        "\\begin{equation",
+        "\\begin{align",
+        "\\begin{gather",
+        "\\begin{multline",
+        "\\begin{eqnarray",
+        "\\begin{math}",
+        "\\begin{displaymath}"
+      ]
+    },
+    "severity": "Info"
+  },
+  "RTL-004": {
+    "layer": "L1",
+    "pattern": {
+      "family": "multi_substring",
+      "needles": [
+        "$",
+        "\\(",
+        "\\[",
+        "\\begin{equation",
+        "\\begin{align",
+        "\\begin{gather",
+        "\\begin{multline",
+        "\\begin{eqnarray",
+        "\\begin{math}",
+        "\\begin{displaymath}"
+      ]
+    },
+    "severity": "Info"
+  },
+  "TYPO-059": {
+    "layer": "L1",
+    "pattern": {
+      "family": "multi_substring",
+      "needles": [
+        "$",
+        "\\(",
+        "\\[",
+        "\\begin{equation",
+        "\\begin{align",
+        "\\begin{gather",
+        "\\begin{multline",
+        "\\begin{eqnarray",
+        "\\begin{math}",
+        "\\begin{displaymath}"
+      ]
+    },
+    "severity": "Info"
+  },
+  "PT-002": {
+    "layer": "L1",
+    "pattern": {
+      "family": "multi_substring",
+      "needles": [
+        "$",
+        "\\(",
+        "\\[",
+        "\\begin{equation",
+        "\\begin{align",
+        "\\begin{gather",
+        "\\begin{multline",
+        "\\begin{eqnarray",
+        "\\begin{math}",
+        "\\begin{displaymath}"
+      ]
+    },
+    "severity": "Info"
   }
 }


### PR DESCRIPTION
## Summary
- **Key insight:** All L1 rules using `extract_math_segments` require at least one math delimiter to exist. If none of `$`, `\(`, `\[`, `\begin{equation}`, `\begin{align}`, etc. appear, extraction returns `[]` and no rule can fire.
- Add 62 VPD entries: MATH (34), SCRIPT (17), CHEM (3), DELIM (2), CJK (2), FONT/RTL/TYPO/PT (4)
- **Faithful proofs: 197 → 259** (+62), conservative: 410 → 348

## Test plan
- [x] `gen_coq_proofs.py --check` → 259 faithful, 348 conservative
- [x] `dune clean && dune build` — 0 admits
- [x] `dune runtest` — all tests pass