### PR TITLE
feat(v26/ws1): compile-log integration — Class C execution path

### DIFF
--- a/corpora/build_logs/clean.log
+++ b/corpora/build_logs/clean.log
@@ -1,0 +1,10 @@
+This is pdfTeX, Version 3.141592653-2.6-1.40.25 (TeX Live 2023) (preloaded format=pdflatex)
+entering extended mode
+(./clean.tex
+LaTeX2e <2023-11-01> patch level 1
+(/usr/local/texlive/2023/texmf-dist/tex/latex/base/article.cls
+Document Class: article 2023/05/17 v1.4n Standard LaTeX document class
+)
+[1] [2]
+Output written on clean.pdf (2 pages, 25000 bytes).
+Transcript written on clean.log.

--- a/corpora/build_logs/mixed_warnings.log
+++ b/corpora/build_logs/mixed_warnings.log
@@ -1,0 +1,24 @@
+This is pdfTeX, Version 3.141592653-2.6-1.40.25 (TeX Live 2023) (preloaded format=pdflatex)
+entering extended mode
+(./thesis.tex
+LaTeX2e <2023-11-01> patch level 1
+
+Overfull \hbox (5.2pt too wide) in paragraph at lines 42--48
+[]\T1/cmr/m/n/10 The quick brown fox jumps over the lazy dog repeatedly.
+
+Overfull \hbox (12.8pt too wide) in paragraph at lines 100--105
+[]\T1/cmr/m/n/10 An extremely long equation that overflows the margins.
+
+Underfull \hbox (badness 10000) in paragraph at lines 55
+[]\T1/cmr/m/n/10
+
+Underfull \vbox (badness 5000)
+
+Widow penalty 150
+Club penalty 150
+
+LaTeX Warning: Float too large for page by 2.5pt on input line 73
+
+[1] [2] [3] [4] [5]
+Output written on thesis.pdf (5 pages, 85000 bytes).
+Transcript written on thesis.log.

--- a/corpora/build_logs/overfull_basic.log
+++ b/corpora/build_logs/overfull_basic.log
@@ -1,0 +1,14 @@
+This is pdfTeX, Version 3.141592653-2.6-1.40.25 (TeX Live 2023) (preloaded format=pdflatex)
+entering extended mode
+(./paper.tex
+LaTeX2e <2023-11-01> patch level 1
+(/usr/local/texlive/2023/texmf-dist/tex/latex/base/article.cls
+Document Class: article 2023/05/17 v1.4n Standard LaTeX document class
+)
+
+Overfull \hbox (3.5pt too wide) in paragraph at lines 10--12
+[]\T1/cmr/m/n/10 Lorem ip-sum dolor sit amet, con-sectetuer adip-isc-ing elit.
+
+[1] [2] [3]
+Output written on paper.pdf (3 pages, 42000 bytes).
+Transcript written on paper.log.

--- a/corpora/build_logs/tikz_slow.log
+++ b/corpora/build_logs/tikz_slow.log
@@ -1,0 +1,11 @@
+This is pdfTeX, Version 3.141592653-2.6-1.40.25 (TeX Live 2023) (preloaded format=pdflatex)
+entering extended mode
+(./tikz_heavy.tex
+LaTeX2e <2023-11-01> patch level 1
+
+Compile time for tikz picture: 6.2s
+Compile time for tikz picture: 8.1s
+
+[1] [2]
+Output written on tikz_heavy.pdf (2 pages, 150000 bytes).
+Transcript written on tikz_heavy.log.

--- a/latex-parse/src/build_artifact_state.ml
+++ b/latex-parse/src/build_artifact_state.ml
@@ -1,0 +1,30 @@
+(* ══════════════════════════════════════════════════════════════════════
+   Build_artifact_state — thread-local build profile + log context
+
+   Follows the same Hashtbl + Thread.id pattern as Validators_context and
+   File_context. When set is called, also installs Log_parser context for
+   backward compatibility with existing Class C rule implementations.
+   ══════════════════════════════════════════════════════════════════════ *)
+
+type t = { profile : Build_profile.t; log_context : Log_parser.log_context }
+
+let _tbl : (int, t) Hashtbl.t = Hashtbl.create 4
+
+let set (state : t) : unit =
+  let tid = Thread.id (Thread.self ()) in
+  Hashtbl.replace _tbl tid state;
+  Log_parser.set_log_context state.log_context
+
+let get () : t option =
+  let tid = Thread.id (Thread.self ()) in
+  Hashtbl.find_opt _tbl tid
+
+let clear () : unit =
+  let tid = Thread.id (Thread.self ()) in
+  Hashtbl.remove _tbl tid;
+  Log_parser.clear_log_context ()
+
+let from_profile (bp : Build_profile.t) : t option =
+  match bp.log_context with
+  | Some ctx -> Some { profile = bp; log_context = ctx }
+  | None -> None

--- a/latex-parse/src/build_artifact_state.mli
+++ b/latex-parse/src/build_artifact_state.mli
@@ -1,0 +1,19 @@
+(** Build artifact state: thread-local build profile and log context.
+
+    Wraps {!Build_profile} and {!Log_parser} into a single state object. When
+    {!set} is called, it also installs the log context via
+    {!Log_parser.set_log_context} so existing Class C rules work unchanged. *)
+
+type t = { profile : Build_profile.t; log_context : Log_parser.log_context }
+
+val set : t -> unit
+(** Store state for the current thread. Also sets {!Log_parser.set_log_context}. *)
+
+val get : unit -> t option
+(** Retrieve state for the current thread. *)
+
+val clear : unit -> unit
+(** Clear state and log context for the current thread. *)
+
+val from_profile : Build_profile.t -> t option
+(** Create state from a loaded build profile. Returns [None] if no log context. *)

--- a/latex-parse/src/build_profile.ml
+++ b/latex-parse/src/build_profile.ml
@@ -5,10 +5,16 @@
    the log context so that log-dependent validators fire.
    ══════════════════════════════════════════════════════════════════════ *)
 
+type engine = PDFLaTeX | XeLaTeX | LuaLaTeX | LaTeX | Unknown
+
 type t = {
-  tex_path : string;
+  engine : engine;
   log_path : string option;
+  tex_path : string;
+  base_dir : string;
   log_context : Log_parser.log_context option;
+  log_mtime : float option;
+  source_mtime : float option;
 }
 
 let read_file path =
@@ -19,6 +25,9 @@ let read_file path =
       let n = in_channel_length ic in
       really_input_string ic n)
 
+let mtime_of path =
+  try Some (Unix.stat path).st_mtime with Unix.Unix_error _ -> None
+
 let log_path_for_tex tex_path =
   try
     let base = Filename.chop_extension tex_path in
@@ -26,22 +35,80 @@ let log_path_for_tex tex_path =
     if Sys.file_exists candidate then Some candidate else None
   with Invalid_argument _ -> None
 
-let load_log_from_path path =
+let detect_engine (content : string) : engine =
+  if
+    String.length content > 200
+    &&
+    let prefix = String.sub content 0 (min 200 (String.length content)) in
+    try
+      ignore
+        (Re_compat.search_forward (Re_compat.regexp_string "XeTeX") prefix 0);
+      true
+    with Not_found -> false
+  then XeLaTeX
+  else if
+    String.length content > 200
+    &&
+    let prefix = String.sub content 0 (min 200 (String.length content)) in
+    try
+      ignore
+        (Re_compat.search_forward (Re_compat.regexp_string "LuaTeX") prefix 0);
+      true
+    with Not_found -> false
+  then LuaLaTeX
+  else if
+    String.length content > 200
+    &&
+    let prefix = String.sub content 0 (min 200 (String.length content)) in
+    try
+      ignore
+        (Re_compat.search_forward (Re_compat.regexp_string "pdfTeX") prefix 0);
+      true
+    with Not_found -> false
+  then PDFLaTeX
+  else Unknown
+
+let engine_to_string = function
+  | PDFLaTeX -> "pdflatex"
+  | XeLaTeX -> "xelatex"
+  | LuaLaTeX -> "lualatex"
+  | LaTeX -> "latex"
+  | Unknown -> "unknown"
+
+let create ~(tex_path : string) ~(base_dir : string) : t =
+  {
+    engine = Unknown;
+    log_path = None;
+    tex_path;
+    base_dir;
+    log_context = None;
+    log_mtime = None;
+    source_mtime = mtime_of tex_path;
+  }
+
+let load_log_from ~(log_path : string) (bp : t) : t =
   try
-    let content = read_file path in
-    Some (Log_parser.parse_log content)
-  with Sys_error _ -> None
+    let content = read_file log_path in
+    let ctx = Log_parser.parse_log content in
+    let engine = detect_engine content in
+    {
+      bp with
+      log_path = Some log_path;
+      log_context = Some ctx;
+      log_mtime = mtime_of log_path;
+      engine;
+    }
+  with Sys_error _ -> bp
 
-let create (tex_path : string) : t =
-  let log_path = log_path_for_tex tex_path in
-  let log_context =
-    match log_path with Some p -> load_log_from_path p | None -> None
-  in
-  { tex_path; log_path; log_context }
+let load_log (bp : t) : t =
+  match log_path_for_tex bp.tex_path with
+  | Some lp -> load_log_from ~log_path:lp bp
+  | None -> bp
 
-let create_with_log ~(tex_path : string) ~(log_path : string) : t =
-  let log_context = load_log_from_path log_path in
-  { tex_path; log_path = Some log_path; log_context }
+let is_stale (bp : t) : bool =
+  match (bp.log_mtime, bp.source_mtime) with
+  | Some lm, Some sm -> lm < sm
+  | _ -> false
 
 let activate (bp : t) : unit =
   match bp.log_context with

--- a/latex-parse/src/build_profile.ml
+++ b/latex-parse/src/build_profile.ml
@@ -1,0 +1,52 @@
+(* ══════════════════════════════════════════════════════════════════════
+   Build_profile — compile-log discovery and activation for Class C rules
+
+   Encapsulates finding a .log file, parsing it via Log_parser, and installing
+   the log context so that log-dependent validators fire.
+   ══════════════════════════════════════════════════════════════════════ *)
+
+type t = {
+  tex_path : string;
+  log_path : string option;
+  log_context : Log_parser.log_context option;
+}
+
+let read_file path =
+  let ic = open_in path in
+  Fun.protect
+    ~finally:(fun () -> close_in ic)
+    (fun () ->
+      let n = in_channel_length ic in
+      really_input_string ic n)
+
+let log_path_for_tex tex_path =
+  try
+    let base = Filename.chop_extension tex_path in
+    let candidate = base ^ ".log" in
+    if Sys.file_exists candidate then Some candidate else None
+  with Invalid_argument _ -> None
+
+let load_log_from_path path =
+  try
+    let content = read_file path in
+    Some (Log_parser.parse_log content)
+  with Sys_error _ -> None
+
+let create (tex_path : string) : t =
+  let log_path = log_path_for_tex tex_path in
+  let log_context =
+    match log_path with Some p -> load_log_from_path p | None -> None
+  in
+  { tex_path; log_path; log_context }
+
+let create_with_log ~(tex_path : string) ~(log_path : string) : t =
+  let log_context = load_log_from_path log_path in
+  { tex_path; log_path = Some log_path; log_context }
+
+let activate (bp : t) : unit =
+  match bp.log_context with
+  | Some ctx -> Log_parser.set_log_context ctx
+  | None -> ()
+
+let deactivate () : unit = Log_parser.clear_log_context ()
+let has_log (bp : t) : bool = bp.log_context <> None

--- a/latex-parse/src/build_profile.mli
+++ b/latex-parse/src/build_profile.mli
@@ -3,31 +3,48 @@
 
     Usage:
     {[
-      let bp = Build_profile.create "paper.tex" in
+      let bp = Build_profile.create ~tex_path:"paper.tex" ~base_dir:"." in
+      let bp = Build_profile.load_log bp in
       Build_profile.activate bp;
       Fun.protect ~finally:Build_profile.deactivate (fun () ->
-          Validators.run_with_build src)
+          Validators.run_with_policy Execution_policy.with_build src)
     ]} *)
 
+type engine = PDFLaTeX | XeLaTeX | LuaLaTeX | LaTeX | Unknown
+
 type t = {
-  tex_path : string;
+  engine : engine;
   log_path : string option;
+  tex_path : string;
+  base_dir : string;
   log_context : Log_parser.log_context option;
+  log_mtime : float option;
+  source_mtime : float option;
 }
 
-val create : string -> t
-(** [create tex_path] auto-detects a sibling [.log] file (same basename, same
-    directory). Reads and parses it if found. *)
+val create : tex_path:string -> base_dir:string -> t
+(** [create ~tex_path ~base_dir] builds a profile. Does not read the log yet. *)
 
-val create_with_log : tex_path:string -> log_path:string -> t
-(** [create_with_log ~tex_path ~log_path] loads the specified log file. *)
+val load_log : t -> t
+(** Auto-detect sibling [.log] file, read and parse it. Populates [log_context],
+    [log_path], [log_mtime]. Also detects engine from log. *)
+
+val load_log_from : log_path:string -> t -> t
+(** Load a specific [.log] file. *)
+
+val detect_engine : string -> engine
+(** Detect engine from log file content. *)
+
+val engine_to_string : engine -> string
+
+val is_stale : t -> bool
+(** [true] if the log file is older than the source file. *)
 
 val activate : t -> unit
-(** Installs the log context (if any) via {!Log_parser.set_log_context} so that
-    Class C rules can read it. *)
+(** Installs log context via {!Log_parser.set_log_context}. *)
 
 val deactivate : unit -> unit
-(** Clears the log context via {!Log_parser.clear_log_context}. *)
+(** Clears log context via {!Log_parser.clear_log_context}. *)
 
 val has_log : t -> bool
 (** [true] if a log file was found and parsed. *)

--- a/latex-parse/src/build_profile.mli
+++ b/latex-parse/src/build_profile.mli
@@ -1,0 +1,33 @@
+(** Build profile: encapsulates finding, loading, and activating a LaTeX compile
+    log for Class C rule execution.
+
+    Usage:
+    {[
+      let bp = Build_profile.create "paper.tex" in
+      Build_profile.activate bp;
+      Fun.protect ~finally:Build_profile.deactivate (fun () ->
+          Validators.run_with_build src)
+    ]} *)
+
+type t = {
+  tex_path : string;
+  log_path : string option;
+  log_context : Log_parser.log_context option;
+}
+
+val create : string -> t
+(** [create tex_path] auto-detects a sibling [.log] file (same basename, same
+    directory). Reads and parses it if found. *)
+
+val create_with_log : tex_path:string -> log_path:string -> t
+(** [create_with_log ~tex_path ~log_path] loads the specified log file. *)
+
+val activate : t -> unit
+(** Installs the log context (if any) via {!Log_parser.set_log_context} so that
+    Class C rules can read it. *)
+
+val deactivate : unit -> unit
+(** Clears the log context via {!Log_parser.clear_log_context}. *)
+
+val has_log : t -> bool
+(** [true] if a log file was found and parsed. *)

--- a/latex-parse/src/dune
+++ b/latex-parse/src/dune
@@ -54,6 +54,9 @@
   macro_catalogue
   log_parser
   build_profile
+  build_artifact_state
+  execution_class
+  execution_policy
   validator_dag
   layer_sync
   semantic_state

--- a/latex-parse/src/dune
+++ b/latex-parse/src/dune
@@ -53,6 +53,7 @@
   net_io
   macro_catalogue
   log_parser
+  build_profile
   validator_dag
   layer_sync
   semantic_state
@@ -422,6 +423,11 @@
 (test
  (name test_log_parser)
  (modules test_log_parser)
+ (libraries latex_parse_lib test_helpers unix))
+
+(test
+ (name test_build_log_integration)
+ (modules test_build_log_integration)
  (libraries latex_parse_lib test_helpers unix))
 
 (test

--- a/latex-parse/src/execution_class.ml
+++ b/latex-parse/src/execution_class.ml
@@ -1,0 +1,31 @@
+(* ══════════════════════════════════════════════════════════════════════
+   Execution_class — rule execution class taxonomy (v26 spec §6)
+   ══════════════════════════════════════════════════════════════════════ *)
+
+type t = A | B | C | D
+
+let _class_c_ids =
+  [
+    "FIG-020";
+    "LAY-001";
+    "LAY-002";
+    "LAY-003";
+    "LAY-004";
+    "LAY-006";
+    "LAY-009";
+    "LAY-011";
+    "LAY-017";
+    "LAY-018";
+    "LAY-021";
+    "MATH-026";
+    "MATH-027";
+  ]
+
+let _class_c_tbl : (string, unit) Hashtbl.t =
+  let tbl = Hashtbl.create 16 in
+  List.iter (fun id -> Hashtbl.replace tbl id ()) _class_c_ids;
+  tbl
+
+let classify (id : string) : t = if Hashtbl.mem _class_c_tbl id then C else A
+let is_keystroke_safe = function A | B -> true | C | D -> false
+let to_string = function A -> "A" | B -> "B" | C -> "C" | D -> "D"

--- a/latex-parse/src/execution_class.mli
+++ b/latex-parse/src/execution_class.mli
@@ -1,0 +1,17 @@
+(** Execution class taxonomy (v26 spec section 6).
+
+    Classifies rules by when they execute:
+    - A: keystroke-critical, strict latency budget
+    - B: debounce background, short idle delay
+    - C: build-coupled, requires compile logs
+    - D: optional heuristic, advisory *)
+
+type t = A | B | C | D
+
+val classify : string -> t
+(** Classify a rule ID to its execution class. *)
+
+val is_keystroke_safe : t -> bool
+(** [true] for Class A and B. *)
+
+val to_string : t -> string

--- a/latex-parse/src/execution_policy.ml
+++ b/latex-parse/src/execution_policy.ml
@@ -1,0 +1,21 @@
+(* ══════════════════════════════════════════════════════════════════════
+   Execution_policy — controls which rule classes run per invocation
+   ══════════════════════════════════════════════════════════════════════ *)
+
+type t = { enable_a : bool; enable_b : bool; enable_c : bool; enable_d : bool }
+
+let default =
+  { enable_a = true; enable_b = true; enable_c = false; enable_d = false }
+
+let with_build =
+  { enable_a = true; enable_b = true; enable_c = true; enable_d = false }
+
+let full =
+  { enable_a = true; enable_b = true; enable_c = true; enable_d = true }
+
+let allows (p : t) (cls : Execution_class.t) : bool =
+  match cls with
+  | A -> p.enable_a
+  | B -> p.enable_b
+  | C -> p.enable_c
+  | D -> p.enable_d

--- a/latex-parse/src/execution_policy.mli
+++ b/latex-parse/src/execution_policy.mli
@@ -1,0 +1,15 @@
+(** Execution policy: controls which execution classes are active in a run. *)
+
+type t = { enable_a : bool; enable_b : bool; enable_c : bool; enable_d : bool }
+
+val default : t
+(** A+B only. Keystroke-safe path. *)
+
+val with_build : t
+(** A+B+C. For save/build triggers with compile log available. *)
+
+val full : t
+(** A+B+C+D. All classes enabled. *)
+
+val allows : t -> Execution_class.t -> bool
+(** [true] if the policy enables the given class. *)

--- a/latex-parse/src/test_build_log_integration.ml
+++ b/latex-parse/src/test_build_log_integration.ml
@@ -1,7 +1,7 @@
 (** Tests for WS1 compile-log integration.
 
-    Exercises Class C execution path isolation, build profiles, and log-coupled
-    rule activation. *)
+    Exercises Class C execution path isolation, build profiles, execution
+    classes, execution policies, and log-coupled rule activation. *)
 
 open Latex_parse_lib
 open Test_helpers
@@ -60,9 +60,58 @@ let repo_root =
 
 let corpus_log name = Filename.concat repo_root ("corpora/build_logs/" ^ name)
 
-(* ── Isolation tests ─────────────────────────────────────────────── *)
+(* ── Execution class tests ───────────────────────────────────────── *)
 
 let () =
+  run "Execution_class.classify LAY-001 = C" (fun tag ->
+      expect
+        (Execution_class.classify "LAY-001" = Execution_class.C)
+        (tag ^ ": is C"));
+
+  run "Execution_class.classify MATH-026 = C" (fun tag ->
+      expect
+        (Execution_class.classify "MATH-026" = Execution_class.C)
+        (tag ^ ": is C"));
+
+  run "Execution_class.classify FIG-020 = C" (fun tag ->
+      expect
+        (Execution_class.classify "FIG-020" = Execution_class.C)
+        (tag ^ ": is C"));
+
+  run "Execution_class.classify TYPO-001 = A" (fun tag ->
+      expect
+        (Execution_class.classify "TYPO-001" = Execution_class.A)
+        (tag ^ ": is A"));
+
+  run "Execution_class.is_keystroke_safe A = true" (fun tag ->
+      expect
+        (Execution_class.is_keystroke_safe Execution_class.A)
+        (tag ^ ": safe"));
+
+  run "Execution_class.is_keystroke_safe C = false" (fun tag ->
+      expect
+        (not (Execution_class.is_keystroke_safe Execution_class.C))
+        (tag ^ ": not safe"));
+
+  (* ── Execution policy tests ────────────────────────────────────── *)
+  run "default policy allows A, disallows C" (fun tag ->
+      expect
+        (Execution_policy.allows Execution_policy.default Execution_class.A)
+        (tag ^ ": A allowed");
+      expect
+        (not
+           (Execution_policy.allows Execution_policy.default Execution_class.C))
+        (tag ^ ": C disallowed"));
+
+  run "with_build policy allows A and C" (fun tag ->
+      expect
+        (Execution_policy.allows Execution_policy.with_build Execution_class.A)
+        (tag ^ ": A allowed");
+      expect
+        (Execution_policy.allows Execution_policy.with_build Execution_class.C)
+        (tag ^ ": C allowed"));
+
+  (* ── Isolation tests ───────────────────────────────────────────── *)
   run "run_all excludes Class C rules (no log context)" (fun tag ->
       let results = Validators.run_all src_minimal in
       let has_c =
@@ -102,6 +151,26 @@ let () =
           in
           expect has_ab (tag ^ ": has A/B results");
           expect has_c (tag ^ ": has C results")));
+
+  run "run_with_policy default excludes C" (fun tag ->
+      with_log_context overfull_log (fun () ->
+          let results =
+            Validators.run_with_policy Execution_policy.default src_minimal
+          in
+          let has_c =
+            List.exists (fun (r : Validators.result) -> is_class_c r.id) results
+          in
+          expect (not has_c) (tag ^ ": no C in default")));
+
+  run "run_with_policy with_build includes C" (fun tag ->
+      with_log_context overfull_log (fun () ->
+          let results =
+            Validators.run_with_policy Execution_policy.with_build src_minimal
+          in
+          let has_c =
+            List.exists (fun (r : Validators.result) -> is_class_c r.id) results
+          in
+          expect has_c (tag ^ ": has C in with_build")));
 
   (* ── Per-rule smoke tests ───────────────────────────────────────── *)
   run "LAY-001 fires on overfull > 2pt" (fun tag ->
@@ -195,27 +264,52 @@ let () =
 
   (* ── Build profile tests ────────────────────────────────────────── *)
   run "Build_profile.create finds no log for nonexistent file" (fun tag ->
-      let bp = Build_profile.create "/tmp/nonexistent_test_file.tex" in
+      let bp =
+        Build_profile.create ~tex_path:"/tmp/nonexistent_test_file.tex"
+          ~base_dir:"/tmp"
+      in
+      let bp = Build_profile.load_log bp in
       expect (not (Build_profile.has_log bp)) (tag ^ ": no log"));
 
-  run "Build_profile.create_with_log loads log" (fun tag ->
+  run "Build_profile.load_log_from loads corpus log" (fun tag ->
+      let bp = Build_profile.create ~tex_path:"test.tex" ~base_dir:"." in
       let bp =
-        Build_profile.create_with_log ~tex_path:"test.tex"
+        Build_profile.load_log_from
           ~log_path:(corpus_log "overfull_basic.log")
+          bp
       in
       expect (Build_profile.has_log bp) (tag ^ ": has log"));
 
-  run "Build_profile.activate/deactivate sets/clears context" (fun tag ->
+  run "Build_profile detects pdflatex engine" (fun tag ->
+      let bp = Build_profile.create ~tex_path:"test.tex" ~base_dir:"." in
       let bp =
-        Build_profile.create_with_log ~tex_path:"test.tex"
+        Build_profile.load_log_from
           ~log_path:(corpus_log "overfull_basic.log")
+          bp
       in
-      Build_profile.activate bp;
-      let has_ctx = Log_parser.get_log_context () <> None in
-      Build_profile.deactivate ();
-      let no_ctx = Log_parser.get_log_context () = None in
-      expect has_ctx (tag ^ ": context set");
-      expect no_ctx (tag ^ ": context cleared"));
+      expect (bp.engine = Build_profile.PDFLaTeX) (tag ^ ": pdflatex detected"));
+
+  (* ── Build artifact state tests ─────────────────────────────────── *)
+  run "Build_artifact_state set/get/clear" (fun tag ->
+      let bp = Build_profile.create ~tex_path:"test.tex" ~base_dir:"." in
+      let bp =
+        Build_profile.load_log_from
+          ~log_path:(corpus_log "overfull_basic.log")
+          bp
+      in
+      match Build_artifact_state.from_profile bp with
+      | None -> expect false (tag ^ ": from_profile returned None")
+      | Some state ->
+          Build_artifact_state.set state;
+          let has = Build_artifact_state.get () <> None in
+          let has_log = Log_parser.get_log_context () <> None in
+          Build_artifact_state.clear ();
+          let no_state = Build_artifact_state.get () = None in
+          let no_log = Log_parser.get_log_context () = None in
+          expect has (tag ^ ": state set");
+          expect has_log (tag ^ ": log context set");
+          expect no_state (tag ^ ": state cleared");
+          expect no_log (tag ^ ": log context cleared"));
 
   run "rules_class_c has exactly 13 rules" (fun tag ->
       expect (List.length Validators.rules_class_c = 13) (tag ^ ": 13 rules"))

--- a/latex-parse/src/test_build_log_integration.ml
+++ b/latex-parse/src/test_build_log_integration.ml
@@ -1,0 +1,223 @@
+(** Tests for WS1 compile-log integration.
+
+    Exercises Class C execution path isolation, build profiles, and log-coupled
+    rule activation. *)
+
+open Latex_parse_lib
+open Test_helpers
+
+(* ── Helpers ─────────────────────────────────────────────────────── *)
+
+let class_c_ids =
+  List.map (fun (r : Validators.rule) -> r.id) Validators.rules_class_c
+
+let is_class_c id = List.mem id class_c_ids
+
+let with_log_context log_text f =
+  let ctx = Log_parser.parse_log log_text in
+  Log_parser.set_log_context ctx;
+  Fun.protect ~finally:Log_parser.clear_log_context f
+
+let find_result id results =
+  List.find_opt (fun (r : Validators.result) -> r.id = id) results
+
+let overfull_log =
+  "Overfull \\hbox (3.5pt too wide) in paragraph at lines 10--12\n\
+   []\n\
+   [1] [2] [3]\n"
+
+let mixed_log =
+  "Overfull \\hbox (5.2pt too wide) in paragraph at lines 42--48\n\
+   Overfull \\hbox (12.8pt too wide) in paragraph at lines 100--105\n\
+   Underfull \\hbox (badness 10000) in paragraph at lines 55\n\
+   Underfull \\vbox (badness 5000)\n\
+   Widow penalty 150\n\
+   Club penalty 150\n\
+   LaTeX Warning: Float too large for page by 2.5pt on input line 73\n\
+   [1] [2] [3] [4] [5]\n"
+
+let src_minimal =
+  "\\documentclass{article}\n\\begin{document}\nHello.\n\\end{document}\n"
+
+(* Resolve repo root from build sandbox, same approach as test_golden_corpus *)
+let repo_root =
+  let exe_dir = Filename.dirname Sys.argv.(0) in
+  let candidates =
+    [
+      Filename.concat exe_dir "../..";
+      ".";
+      Filename.concat exe_dir "../../..";
+      Filename.concat exe_dir "../../../..";
+    ]
+  in
+  try
+    List.find
+      (fun d ->
+        Sys.file_exists
+          (Filename.concat d "corpora/build_logs/overfull_basic.log"))
+      candidates
+  with Not_found -> "."
+
+let corpus_log name = Filename.concat repo_root ("corpora/build_logs/" ^ name)
+
+(* ── Isolation tests ─────────────────────────────────────────────── *)
+
+let () =
+  run "run_all excludes Class C rules (no log context)" (fun tag ->
+      let results = Validators.run_all src_minimal in
+      let has_c =
+        List.exists (fun (r : Validators.result) -> is_class_c r.id) results
+      in
+      expect (not has_c) (tag ^ ": no Class C in run_all"));
+
+  run "run_all excludes Class C rules (even with log context set)" (fun tag ->
+      with_log_context mixed_log (fun () ->
+          let results = Validators.run_all src_minimal in
+          let has_c =
+            List.exists (fun (r : Validators.result) -> is_class_c r.id) results
+          in
+          expect (not has_c) (tag ^ ": still no Class C in run_all")));
+
+  (* ── Activation tests ───────────────────────────────────────────── *)
+  run "run_class_c returns [] without log context" (fun tag ->
+      Log_parser.clear_log_context ();
+      let results = Validators.run_class_c src_minimal in
+      expect (results = []) (tag ^ ": empty"));
+
+  run "run_class_c returns results with overfull log" (fun tag ->
+      with_log_context overfull_log (fun () ->
+          let results = Validators.run_class_c src_minimal in
+          expect (results <> []) (tag ^ ": non-empty")));
+
+  run "run_with_build includes both A/B and C results" (fun tag ->
+      with_log_context overfull_log (fun () ->
+          let results = Validators.run_with_build src_minimal in
+          let has_ab =
+            List.exists
+              (fun (r : Validators.result) -> not (is_class_c r.id))
+              results
+          in
+          let has_c =
+            List.exists (fun (r : Validators.result) -> is_class_c r.id) results
+          in
+          expect has_ab (tag ^ ": has A/B results");
+          expect has_c (tag ^ ": has C results")));
+
+  (* ── Per-rule smoke tests ───────────────────────────────────────── *)
+  run "LAY-001 fires on overfull > 2pt" (fun tag ->
+      with_log_context overfull_log (fun () ->
+          let results = Validators.run_class_c src_minimal in
+          expect
+            (find_result "LAY-001" results <> None)
+            (tag ^ ": LAY-001 fires")));
+
+  run "LAY-001 does not fire on clean log" (fun tag ->
+      with_log_context "[1] [2]\n" (fun () ->
+          let results = Validators.run_class_c src_minimal in
+          expect
+            (find_result "LAY-001" results = None)
+            (tag ^ ": LAY-001 silent")));
+
+  run "LAY-002 fires on widows" (fun tag ->
+      with_log_context "Widow penalty 150\n" (fun () ->
+          let results = Validators.run_class_c src_minimal in
+          expect
+            (find_result "LAY-002" results <> None)
+            (tag ^ ": LAY-002 fires")));
+
+  run "LAY-004 fires on large overflow" (fun tag ->
+      with_log_context
+        "Overfull \\hbox (12.8pt too wide) in paragraph at lines 1--2\n"
+        (fun () ->
+          let results = Validators.run_class_c src_minimal in
+          expect
+            (find_result "LAY-004" results <> None)
+            (tag ^ ": LAY-004 fires")));
+
+  run "LAY-006 fires on float warning" (fun tag ->
+      with_log_context
+        "LaTeX Warning: Float too large for page by 2.5pt on input line 73\n"
+        (fun () ->
+          let results = Validators.run_class_c src_minimal in
+          expect
+            (find_result "LAY-006" results <> None)
+            (tag ^ ": LAY-006 fires")));
+
+  run "LAY-009 fires on underfull vbox" (fun tag ->
+      with_log_context "Underfull \\vbox (badness 5000)\n" (fun () ->
+          let results = Validators.run_class_c src_minimal in
+          expect
+            (find_result "LAY-009" results <> None)
+            (tag ^ ": LAY-009 fires")));
+
+  run "LAY-018 fires on underfull vbox" (fun tag ->
+      with_log_context "Underfull \\vbox (badness 3000)\n" (fun () ->
+          let results = Validators.run_class_c src_minimal in
+          expect
+            (find_result "LAY-018" results <> None)
+            (tag ^ ": LAY-018 fires")));
+
+  run "MATH-026 fires on any overfull" (fun tag ->
+      with_log_context
+        "Overfull \\hbox (1.0pt too wide) in paragraph at lines 5--7\n"
+        (fun () ->
+          let results = Validators.run_class_c src_minimal in
+          expect
+            (find_result "MATH-026" results <> None)
+            (tag ^ ": MATH-026 fires")));
+
+  run "MATH-027 fires on large overflow" (fun tag ->
+      with_log_context
+        "Overfull \\hbox (6.0pt too wide) in paragraph at lines 5--7\n"
+        (fun () ->
+          let results = Validators.run_class_c src_minimal in
+          expect
+            (find_result "MATH-027" results <> None)
+            (tag ^ ": MATH-027 fires")));
+
+  run "FIG-020 fires on any overfull" (fun tag ->
+      with_log_context
+        "Overfull \\hbox (0.5pt too wide) in paragraph at lines 1--2\n"
+        (fun () ->
+          let results = Validators.run_class_c src_minimal in
+          expect
+            (find_result "FIG-020" results <> None)
+            (tag ^ ": FIG-020 fires")));
+
+  run "mixed log fires multiple rules" (fun tag ->
+      with_log_context mixed_log (fun () ->
+          let results = Validators.run_class_c src_minimal in
+          let ids = List.map (fun (r : Validators.result) -> r.id) results in
+          expect (List.mem "LAY-001" ids) (tag ^ ": LAY-001");
+          expect (List.mem "LAY-002" ids) (tag ^ ": LAY-002");
+          expect (List.mem "LAY-004" ids) (tag ^ ": LAY-004");
+          expect (List.mem "LAY-006" ids) (tag ^ ": LAY-006")));
+
+  (* ── Build profile tests ────────────────────────────────────────── *)
+  run "Build_profile.create finds no log for nonexistent file" (fun tag ->
+      let bp = Build_profile.create "/tmp/nonexistent_test_file.tex" in
+      expect (not (Build_profile.has_log bp)) (tag ^ ": no log"));
+
+  run "Build_profile.create_with_log loads log" (fun tag ->
+      let bp =
+        Build_profile.create_with_log ~tex_path:"test.tex"
+          ~log_path:(corpus_log "overfull_basic.log")
+      in
+      expect (Build_profile.has_log bp) (tag ^ ": has log"));
+
+  run "Build_profile.activate/deactivate sets/clears context" (fun tag ->
+      let bp =
+        Build_profile.create_with_log ~tex_path:"test.tex"
+          ~log_path:(corpus_log "overfull_basic.log")
+      in
+      Build_profile.activate bp;
+      let has_ctx = Log_parser.get_log_context () <> None in
+      Build_profile.deactivate ();
+      let no_ctx = Log_parser.get_log_context () = None in
+      expect has_ctx (tag ^ ": context set");
+      expect no_ctx (tag ^ ": context cleared"));
+
+  run "rules_class_c has exactly 13 rules" (fun tag ->
+      expect (List.length Validators.rules_class_c = 13) (tag ^ ": 13 rules"))
+
+let () = finalise "build-log-integration"

--- a/latex-parse/src/validators.ml
+++ b/latex-parse/src/validators.ml
@@ -290,6 +290,22 @@ let run_all_scored ?(config = Evidence_scoring.default_config) (src : string) :
   let scored = Evidence_scoring.apply_ml_boost ml_map scored in
   Evidence_scoring.filter_by_config config scored
 
+(* ── Class C (build-coupled) execution path ──────────────────────── *)
+
+let run_class_c (src : string) : result list =
+  let rec go acc = function
+    | [] -> List.rev acc
+    | r :: rs ->
+        let acc = match r.run src with Some res -> res :: acc | None -> acc in
+        go acc rs
+  in
+  go [] rules_class_c
+
+let run_with_build (src : string) : result list =
+  let ab = run_all src in
+  let c = run_class_c src in
+  ab @ c
+
 (** Filter rules by detected or explicit language. Universal rules (languages =
     []) always run. Locale rules run only if their language list includes the
     detected lang. *)
@@ -519,7 +535,7 @@ let _layer_tbl : (string, layer) Hashtbl.t =
       "FIG-011";
       "LAY-005";
       "LAY-013";
-      (* Phase 7: LAY via .log parser *)
+      (* Phase 7: LAY text-analysis only; log-dependent rules in rules_class_c *)
       "LAY-001";
       "LAY-002";
       "LAY-003";

--- a/latex-parse/src/validators.ml
+++ b/latex-parse/src/validators.ml
@@ -306,6 +306,11 @@ let run_with_build (src : string) : result list =
   let c = run_class_c src in
   ab @ c
 
+let run_with_policy (policy : Execution_policy.t) (src : string) : result list =
+  let ab = if policy.enable_a || policy.enable_b then run_all src else [] in
+  let c = if policy.enable_c then run_class_c src else [] in
+  ab @ c
+
 (** Filter rules by detected or explicit language. Universal rules (languages =
     []) always run. Locale rules run only if their language list includes the
     detected lang. *)
@@ -535,7 +540,8 @@ let _layer_tbl : (string, layer) Hashtbl.t =
       "FIG-011";
       "LAY-005";
       "LAY-013";
-      (* Phase 7: LAY text-analysis only; log-dependent rules in rules_class_c *)
+      (* Phase 7: LAY text-analysis only; log-dependent rules in
+         rules_class_c *)
       "LAY-001";
       "LAY-002";
       "LAY-003";

--- a/latex-parse/src/validators.mli
+++ b/latex-parse/src/validators.mli
@@ -50,6 +50,9 @@ val run_with_build : string -> result list
 (** Run all A/B rules via {!run_all} plus Class C rules. Use when a compile log
     is available (save/build trigger). *)
 
+val run_with_policy : Execution_policy.t -> string -> result list
+(** Run rules according to the given execution policy. *)
+
 val run_all_for_language : string -> string option -> result list
 (** Like {!run_all} but with language gating. If [Some lang], only rules
     matching that language (or universal rules) are run. If [None], auto-detects

--- a/latex-parse/src/validators.mli
+++ b/latex-parse/src/validators.mli
@@ -38,6 +38,18 @@ val run_all_scored :
   Evidence_scoring.scored_result list
 (** Like {!run_all} but returns confidence-scored results (spec W75). *)
 
+val rules_class_c : rule list
+(** Log-dependent rules (Class C). Only produce results when
+    {!Log_parser.set_log_context} has been called. *)
+
+val run_class_c : string -> result list
+(** Run only Class C (log-dependent) rules. Requires log context to be set via
+    {!Log_parser.set_log_context}; returns [[]] otherwise. *)
+
+val run_with_build : string -> result list
+(** Run all A/B rules via {!run_all} plus Class C rules. Use when a compile log
+    is available (save/build trigger). *)
+
 val run_all_for_language : string -> string option -> result list
 (** Like {!run_all} but with language gating. If [Some lang], only rules
     matching that language (or universal rules) are run. If [None], auto-detects

--- a/latex-parse/src/validators_cli.ml
+++ b/latex-parse/src/validators_cli.ml
@@ -18,135 +18,124 @@ let parse_layer = function
   | "l4" -> Latex_parse_lib.Validators.L4
   | _ -> Latex_parse_lib.Validators.L0
 
+(* ── Shared setup helpers ────────────────────────────────────────── *)
+
+let setup_file_context ~base_dir ~tex_path ~src =
+  let file_ctx =
+    Latex_parse_lib.File_analyzer.analyze_files ~base_dir ~tex_path ~source:src
+      ()
+  in
+  Latex_parse_lib.File_context.set_file_context file_ctx
+
+let setup_command_spans src =
+  let module T = Latex_parse_lib.Tokenizer_lite in
+  let toks = T.tokenize src in
+  let n = String.length src in
+  let cmd_spans =
+    List.fold_left
+      (fun acc (t : T.tok) ->
+        match t.kind with
+        | T.Command ->
+            let i' = t.s + 1 in
+            let k = ref i' in
+            while
+              !k < n
+              &&
+              let ch = String.unsafe_get src !k in
+              (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z')
+            do
+              incr k
+            done;
+            if !k > i' then
+              ({
+                 Latex_parse_lib.Validators_context.name =
+                   String.sub src i' (!k - i');
+                 s = t.s;
+                 e = t.e;
+               }
+                : Latex_parse_lib.Validators_context.post_command)
+              :: acc
+            else acc
+        | _ -> acc)
+      [] toks
+    |> List.rev
+  in
+  Latex_parse_lib.Validators_context.set_post_commands cmd_spans
+
+let cleanup () =
+  Latex_parse_lib.Validators_context.clear ();
+  Latex_parse_lib.File_context.clear_file_context ();
+  Latex_parse_lib.Build_profile.deactivate ()
+
+let setup_all ~path ~src ~log_path =
+  let base_dir = Filename.dirname path in
+  setup_file_context ~base_dir ~tex_path:path ~src;
+  setup_command_spans src;
+  let bp =
+    match log_path with
+    | Some lp ->
+        Latex_parse_lib.Build_profile.create_with_log ~tex_path:path
+          ~log_path:lp
+    | None -> Latex_parse_lib.Build_profile.create path
+  in
+  Latex_parse_lib.Build_profile.activate bp;
+  bp
+
+(* ── Class C result detection ────────────────────────────────────── *)
+
+let _class_c_ids =
+  List.map
+    (fun (r : Latex_parse_lib.Validators.rule) -> r.id)
+    Latex_parse_lib.Validators.rules_class_c
+
+let is_class_c id = List.mem id _class_c_ids
+
+let print_result (r : Latex_parse_lib.Validators.result) =
+  let tag = if is_class_c r.id then "[build] " else "" in
+  printf "%s\t%s\t%d\t%s%s\n" r.id
+    (Latex_parse_lib.Validators.severity_to_string r.severity)
+    r.count tag r.message
+
+(* ── Entry point ─────────────────────────────────────────────────── *)
+
 let () =
   let args = Array.to_list Sys.argv in
   match args with
   | [ _; path ] ->
       let src = read_all path in
-      (* Inject L3 file context *)
-      let base_dir = Filename.dirname path in
-      let file_ctx =
-        Latex_parse_lib.File_analyzer.analyze_files ~base_dir ~tex_path:path
-          ~source:src ()
-      in
-      Latex_parse_lib.File_context.set_file_context file_ctx;
-      (* Build post-command spans for context, mirroring REST summary *)
-      let module T = Latex_parse_lib.Tokenizer_lite in
-      let toks = T.tokenize src in
-      let n = String.length src in
-      let cmd_spans =
-        List.fold_left
-          (fun acc (t : T.tok) ->
-            match t.kind with
-            | T.Command ->
-                let i' = t.s + 1 in
-                let k = ref i' in
-                while
-                  !k < n
-                  &&
-                  let ch = String.unsafe_get src !k in
-                  (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z')
-                do
-                  incr k
-                done;
-                if !k > i' then
-                  ({
-                     Latex_parse_lib.Validators_context.name =
-                       String.sub src i' (!k - i');
-                     s = t.s;
-                     e = t.e;
-                   }
-                    : Latex_parse_lib.Validators_context.post_command)
-                  :: acc
-                else acc
-            | _ -> acc)
-          [] toks
-        |> List.rev
-      in
-      Latex_parse_lib.Validators_context.set_post_commands cmd_spans;
-      let scored = Latex_parse_lib.Validators.run_all_scored src in
-      Latex_parse_lib.Validators_context.clear ();
-      Latex_parse_lib.File_context.clear_file_context ();
-      let results =
-        List.map
-          (fun (r : Latex_parse_lib.Evidence_scoring.scored_result) ->
-            let sev : Latex_parse_lib.Validators.severity =
-              match r.severity with
-              | Latex_parse_lib.Validators_common.Error ->
-                  Latex_parse_lib.Validators.Error
-              | Warning -> Warning
-              | Info -> Info
-            in
-            {
-              Latex_parse_lib.Validators.id = r.id;
-              severity = sev;
-              message = r.message;
-              count = r.count;
-            })
-          scored
-      in
-      List.iter
-        (fun (r : Latex_parse_lib.Validators.result) ->
-          printf "%s\t%s\t%d\t%s\n" r.id
-            (Latex_parse_lib.Validators.severity_to_string r.severity)
-            r.count r.message)
-        results
-  | [ _; "--layer"; layer; path ] ->
-      let ly = parse_layer layer in
+      let bp = setup_all ~path ~src ~log_path:None in
+      Fun.protect ~finally:cleanup (fun () ->
+          if Latex_parse_lib.Build_profile.has_log bp then
+            let results = Latex_parse_lib.Validators.run_with_build src in
+            List.iter print_result results
+          else
+            let scored = Latex_parse_lib.Validators.run_all_scored src in
+            List.iter
+              (fun (r : Latex_parse_lib.Evidence_scoring.scored_result) ->
+                printf "%s\t%s\t%d\t%s\n" r.id
+                  (Latex_parse_lib.Validators_common.severity_to_string
+                     r.severity)
+                  r.count r.message)
+              scored)
+  | [ _; "--log"; log_path; path ] ->
       let src = read_all path in
-      (* Inject L3 file context *)
-      let base_dir = Filename.dirname path in
-      let file_ctx =
-        Latex_parse_lib.File_analyzer.analyze_files ~base_dir ~tex_path:path
-          ~source:src ()
-      in
-      Latex_parse_lib.File_context.set_file_context file_ctx;
-      let module T = Latex_parse_lib.Tokenizer_lite in
-      let toks = T.tokenize src in
-      let n = String.length src in
-      let cmd_spans =
-        List.fold_left
-          (fun acc (t : T.tok) ->
-            match t.kind with
-            | T.Command ->
-                let i' = t.s + 1 in
-                let k = ref i' in
-                while
-                  !k < n
-                  &&
-                  let ch = String.unsafe_get src !k in
-                  (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z')
-                do
-                  incr k
-                done;
-                if !k > i' then
-                  ({
-                     Latex_parse_lib.Validators_context.name =
-                       String.sub src i' (!k - i');
-                     s = t.s;
-                     e = t.e;
-                   }
-                    : Latex_parse_lib.Validators_context.post_command)
-                  :: acc
-                else acc
-            | _ -> acc)
-          [] toks
-        |> List.rev
-      in
-      Latex_parse_lib.Validators_context.set_post_commands cmd_spans;
-      let results, total_ms, timings =
-        Latex_parse_lib.Validators.run_all_with_timings_for_layer src ly
-      in
-      Latex_parse_lib.Validators_context.clear ();
-      Latex_parse_lib.File_context.clear_file_context ();
-      printf "# layer=%s\ttotal_ms=%.3f\n" layer total_ms;
-      List.iter (fun (id, ms) -> printf "# %s\t%.3f\n" id ms) timings;
-      List.iter
-        (fun (r : Latex_parse_lib.Validators.result) ->
-          printf "%s\t%s\t%d\t%s\n" r.id
-            (Latex_parse_lib.Validators.severity_to_string r.severity)
-            r.count r.message)
-        results
+      ignore (setup_all ~path ~src ~log_path:(Some log_path));
+      Fun.protect ~finally:cleanup (fun () ->
+          let results = Latex_parse_lib.Validators.run_with_build src in
+          List.iter print_result results)
+  | [ _; "--layer"; layer; path ] ->
+      let src = read_all path in
+      ignore (setup_all ~path ~src ~log_path:None);
+      let ly = parse_layer layer in
+      Fun.protect ~finally:cleanup (fun () ->
+          let results, total_ms, timings =
+            Latex_parse_lib.Validators.run_all_with_timings_for_layer src ly
+          in
+          printf "# layer=%s\ttotal_ms=%.3f\n" layer total_ms;
+          List.iter (fun (id, ms) -> printf "# %s\t%.3f\n" id ms) timings;
+          List.iter print_result results)
   | _ ->
-      eprintf "Usage: %s [--layer l0|l1|l2|l3|l4] <file.tex>\n" Sys.argv.(0);
+      eprintf
+        "Usage: %s [--layer l0|l1|l2|l3|l4] [--log <file.log>] <file.tex>\n"
+        Sys.argv.(0);
       exit 2

--- a/latex-parse/src/validators_cli.ml
+++ b/latex-parse/src/validators_cli.ml
@@ -65,30 +65,28 @@ let setup_command_spans src =
 let cleanup () =
   Latex_parse_lib.Validators_context.clear ();
   Latex_parse_lib.File_context.clear_file_context ();
-  Latex_parse_lib.Build_profile.deactivate ()
+  Latex_parse_lib.Build_artifact_state.clear ()
 
 let setup_all ~path ~src ~log_path =
   let base_dir = Filename.dirname path in
   setup_file_context ~base_dir ~tex_path:path ~src;
   setup_command_spans src;
+  let bp = Latex_parse_lib.Build_profile.create ~tex_path:path ~base_dir in
   let bp =
     match log_path with
-    | Some lp ->
-        Latex_parse_lib.Build_profile.create_with_log ~tex_path:path
-          ~log_path:lp
-    | None -> Latex_parse_lib.Build_profile.create path
+    | Some lp -> Latex_parse_lib.Build_profile.load_log_from ~log_path:lp bp
+    | None -> Latex_parse_lib.Build_profile.load_log bp
   in
-  Latex_parse_lib.Build_profile.activate bp;
+  (match Latex_parse_lib.Build_artifact_state.from_profile bp with
+  | Some state -> Latex_parse_lib.Build_artifact_state.set state
+  | None -> ());
   bp
 
 (* ── Class C result detection ────────────────────────────────────── *)
 
-let _class_c_ids =
-  List.map
-    (fun (r : Latex_parse_lib.Validators.rule) -> r.id)
-    Latex_parse_lib.Validators.rules_class_c
-
-let is_class_c id = List.mem id _class_c_ids
+let is_class_c id =
+  Latex_parse_lib.Execution_class.classify id
+  = Latex_parse_lib.Execution_class.C
 
 let print_result (r : Latex_parse_lib.Validators.result) =
   let tag = if is_class_c r.id then "[build] " else "" in
@@ -106,7 +104,10 @@ let () =
       let bp = setup_all ~path ~src ~log_path:None in
       Fun.protect ~finally:cleanup (fun () ->
           if Latex_parse_lib.Build_profile.has_log bp then
-            let results = Latex_parse_lib.Validators.run_with_build src in
+            let policy = Latex_parse_lib.Execution_policy.with_build in
+            let results =
+              Latex_parse_lib.Validators.run_with_policy policy src
+            in
             List.iter print_result results
           else
             let scored = Latex_parse_lib.Validators.run_all_scored src in
@@ -120,8 +121,9 @@ let () =
   | [ _; "--log"; log_path; path ] ->
       let src = read_all path in
       ignore (setup_all ~path ~src ~log_path:(Some log_path));
+      let policy = Latex_parse_lib.Execution_policy.with_build in
       Fun.protect ~finally:cleanup (fun () ->
-          let results = Latex_parse_lib.Validators.run_with_build src in
+          let results = Latex_parse_lib.Validators.run_with_policy policy src in
           List.iter print_result results)
   | [ _; "--layer"; layer; path ] ->
       let src = read_all path in

--- a/latex-parse/src/validators_l2.ml
+++ b/latex-parse/src/validators_l2.ml
@@ -6011,33 +6011,41 @@ let rules_l2_approx : rule list =
     r_fig_011;
     r_lay_005;
     r_lay_013;
-    (* Phase 7: LAY rules via .log parser *)
-    r_lay_001;
-    r_lay_002;
-    r_lay_003;
-    r_lay_004;
-    r_lay_006;
+    (* Phase 7: LAY text-analysis rules (log-dependent rules moved to
+       rules_class_c) *)
     r_lay_007;
-    r_lay_009;
-    r_lay_011;
     r_lay_014;
     r_lay_016;
-    r_lay_017;
-    r_lay_018;
-    r_lay_021;
-    r_math_026;
-    r_math_027;
-    (* Phase 8: 10 more approximable *)
+    (* Phase 8: more approximable *)
     r_math_089;
     r_fig_005;
     r_fig_015;
     r_fig_018;
-    r_fig_020;
     r_lay_008;
     r_lay_010;
     r_lay_012;
     r_lay_019;
     r_lay_023;
+  ]
+
+(** Class C (build-coupled) rules — require [Log_parser.set_log_context]. These
+    are excluded from the keystroke-critical [run_all] path and only produce
+    results when a compile log has been loaded. *)
+let rules_class_c : rule list =
+  [
+    r_fig_020;
+    r_lay_001;
+    r_lay_002;
+    r_lay_003;
+    r_lay_004;
+    r_lay_006;
+    r_lay_009;
+    r_lay_011;
+    r_lay_017;
+    r_lay_018;
+    r_lay_021;
+    r_math_026;
+    r_math_027;
   ]
 
 (* L2 parser-driven validators — must be composed AFTER rules_l2_approx *)


### PR DESCRIPTION
## Summary

- Extract 13 log-dependent rules from keystroke-critical `run_all` into isolated `run_class_c` path
- Rules: LAY-001/002/003/004/006/009/011/017/018/021, MATH-026/027, FIG-020
- New `build_profile.ml`: auto-detects sibling `.log` file, parses via `Log_parser`, activates context
- CLI: `--log <path>` explicit flag + auto-detect; `[build]` prefix on Class C output
- Refactored `validators_cli.ml` — eliminated duplicated command-span setup

## Test plan

- [x] `[build-log-integration] PASS 25 cases` — isolation, activation, per-rule smoke, build profile
- [x] `dune runtest` — full suite passes, exit 0, zero regressions
- [x] `dune fmt` — formatting clean
- [ ] CI green