### PR TITLE
feat(v26/ws2): bounded user macro registry

### DIFF
--- a/latex-parse/src/dune
+++ b/latex-parse/src/dune
@@ -52,6 +52,8 @@
   fd_util
   net_io
   macro_catalogue
+  user_macro_registry
+  user_macro_context
   log_parser
   build_profile
   build_artifact_state
@@ -262,6 +264,11 @@
  (deps
   ../data/macro_catalogue.v25r2.json
   ../data/macro_catalogue.argsafe.v25r1.json))
+
+(test
+ (name test_user_macro_registry)
+ (modules test_user_macro_registry)
+ (libraries latex_parse_lib test_helpers unix))
 
 (test
  (name test_validators_enc_char_spc)

--- a/latex-parse/src/macro_catalogue.ml
+++ b/latex-parse/src/macro_catalogue.ml
@@ -485,3 +485,53 @@ let expand_and_tokenize cat s =
   let expanded = expand cat s in
   let tokens = Tokenizer_lite.tokenize expanded in
   (expanded, tokens)
+
+(* ── User macro merging ──────────────────────────────────────────── *)
+
+let merge_user_macros (cat : catalogue) (reg : User_macro_registry.registry) :
+    catalogue =
+  let cycle_set =
+    let tbl = Hashtbl.create 16 in
+    if reg.has_cycle then
+      List.iter (fun n -> Hashtbl.replace tbl n ()) reg.cycle_path;
+    tbl
+  in
+  let new_argsafe = Hashtbl.copy cat.argsafe in
+  let new_all = Hashtbl.copy cat.all_names in
+  let new_symbols = Hashtbl.copy cat.symbols in
+  List.iter
+    (fun (cd : User_macro_registry.classified_def) ->
+      match cd.status with
+      | User_macro_registry.Unsupported _ -> ()
+      | User_macro_registry.Supported -> (
+          if Hashtbl.mem cycle_set cd.def.User_macro_registry.name then ()
+          else
+            let d = cd.def in
+            let template_body =
+              User_macro_registry.param_to_placeholder
+                d.User_macro_registry.body
+            in
+            let entry =
+              {
+                name = d.User_macro_registry.name;
+                mode = Both;
+                category = "user";
+                positional = d.User_macro_registry.arity;
+                kinds = List.init d.User_macro_registry.arity (fun _ -> "brace");
+                template = Inline template_body;
+              }
+            in
+            match d.User_macro_registry.kind with
+            | User_macro_registry.Newcommand ->
+                if not (Hashtbl.mem new_all entry.name) then (
+                  Hashtbl.replace new_argsafe entry.name entry;
+                  Hashtbl.replace new_all entry.name (Argsafe entry))
+            | User_macro_registry.Renewcommand ->
+                Hashtbl.replace new_argsafe entry.name entry;
+                Hashtbl.replace new_all entry.name (Argsafe entry)
+            | User_macro_registry.Providecommand ->
+                if not (Hashtbl.mem new_all entry.name) then (
+                  Hashtbl.replace new_argsafe entry.name entry;
+                  Hashtbl.replace new_all entry.name (Argsafe entry))))
+    reg.defs;
+  { symbols = new_symbols; argsafe = new_argsafe; all_names = new_all }

--- a/latex-parse/src/macro_catalogue.mli
+++ b/latex-parse/src/macro_catalogue.mli
@@ -82,6 +82,13 @@ val expand_and_tokenize :
   catalogue -> string -> string * Tokenizer_lite.tok list
 (** Expand to fixed point, then tokenise the result. *)
 
+(** {1 User macro merging} *)
+
+val merge_user_macros : catalogue -> User_macro_registry.registry -> catalogue
+(** Merge supported, acyclic user macros into the catalogue. [\newcommand] adds
+    if not present, [\renewcommand] replaces, [\providecommand] adds only if not
+    present. *)
+
 (** {1 Validation} *)
 
 val validate_epsilon : argsafe_entry -> bool * string option

--- a/latex-parse/src/test_user_macro_registry.ml
+++ b/latex-parse/src/test_user_macro_registry.ml
@@ -1,0 +1,321 @@
+(** Tests for WS2 user macro registry.
+
+    Covers parsing, classification, dependency edges, cycle detection, and
+    argsafe entry conversion. *)
+
+open Latex_parse_lib
+open Test_helpers
+
+(* ── Parsing tests ───────────────────────────────────────────────── *)
+
+let () =
+  run "parse simple \\newcommand" (fun tag ->
+      let src = "\\newcommand{\\foo}{hello}" in
+      let defs = User_macro_registry.parse_definitions src in
+      expect (List.length defs = 1) (tag ^ ": 1 def");
+      let d = List.hd defs in
+      expect (d.name = "foo") (tag ^ ": name=foo");
+      expect (d.arity = 0) (tag ^ ": arity=0");
+      expect (d.body = "hello") (tag ^ ": body=hello");
+      expect (d.kind = User_macro_registry.Newcommand) (tag ^ ": kind=New"));
+
+  run "parse \\renewcommand" (fun tag ->
+      let src = "\\renewcommand{\\bar}{world}" in
+      let defs = User_macro_registry.parse_definitions src in
+      expect (List.length defs = 1) (tag ^ ": 1 def");
+      let d = List.hd defs in
+      expect (d.name = "bar") (tag ^ ": name=bar");
+      expect (d.kind = User_macro_registry.Renewcommand) (tag ^ ": kind=Renew"));
+
+  run "parse \\providecommand" (fun tag ->
+      let src = "\\providecommand{\\baz}{stuff}" in
+      let defs = User_macro_registry.parse_definitions src in
+      expect (List.length defs = 1) (tag ^ ": 1 def");
+      let d = List.hd defs in
+      expect
+        (d.kind = User_macro_registry.Providecommand)
+        (tag ^ ": kind=Provide"));
+
+  run "parse with arity" (fun tag ->
+      let src = "\\newcommand{\\myop}[2]{#1 + #2}" in
+      let defs = User_macro_registry.parse_definitions src in
+      expect (List.length defs = 1) (tag ^ ": 1 def");
+      let d = List.hd defs in
+      expect (d.arity = 2) (tag ^ ": arity=2");
+      expect (d.body = "#1 + #2") (tag ^ ": body correct"));
+
+  run "parse with default arg" (fun tag ->
+      let src = "\\newcommand{\\greet}[1][World]{Hello #1}" in
+      let defs = User_macro_registry.parse_definitions src in
+      expect (List.length defs = 1) (tag ^ ": 1 def");
+      let d = List.hd defs in
+      expect (d.arity = 1) (tag ^ ": arity=1");
+      expect (d.opt_default = Some "World") (tag ^ ": default=World"));
+
+  run "parse star form" (fun tag ->
+      let src = "\\newcommand*{\\starred}{text}" in
+      let defs = User_macro_registry.parse_definitions src in
+      expect (List.length defs = 1) (tag ^ ": 1 def");
+      expect ((List.hd defs).name = "starred") (tag ^ ": name=starred"));
+
+  run "parse no-brace name form" (fun tag ->
+      let src = "\\newcommand\\nobrace{text}" in
+      let defs = User_macro_registry.parse_definitions src in
+      expect (List.length defs = 1) (tag ^ ": 1 def");
+      expect ((List.hd defs).name = "nobrace") (tag ^ ": name"));
+
+  run "parse multiple definitions" (fun tag ->
+      let src =
+        "\\newcommand{\\aaa}{one}\n\
+         \\renewcommand{\\bbb}{two}\n\
+         \\providecommand{\\ccc}{three}"
+      in
+      let defs = User_macro_registry.parse_definitions src in
+      expect (List.length defs = 3) (tag ^ ": 3 defs"));
+
+  run "parse nested braces in body" (fun tag ->
+      let src = "\\newcommand{\\nested}{outer{inner{deep}}}" in
+      let defs = User_macro_registry.parse_definitions src in
+      expect (List.length defs = 1) (tag ^ ": 1 def");
+      expect ((List.hd defs).body = "outer{inner{deep}}") (tag ^ ": body"));
+
+  run "parse empty source" (fun tag ->
+      let defs = User_macro_registry.parse_definitions "" in
+      expect (defs = []) (tag ^ ": empty"));
+
+  (* ── Classification tests ──────────────────────────────────────── *)
+  run "classify supported macro" (fun tag ->
+      let def =
+        {
+          User_macro_registry.kind = Newcommand;
+          name = "foo";
+          arity = 1;
+          opt_default = None;
+          body = "\\textbf{#1}";
+          loc = 0;
+        }
+      in
+      let cd = User_macro_registry.classify def in
+      expect (cd.status = Supported) (tag ^ ": supported"));
+
+  run "classify unsupported: \\def in body" (fun tag ->
+      let def =
+        {
+          User_macro_registry.kind = Newcommand;
+          name = "bad";
+          arity = 0;
+          opt_default = None;
+          body = "\\def\\inner{x}";
+          loc = 0;
+        }
+      in
+      let cd = User_macro_registry.classify def in
+      match cd.status with
+      | User_macro_registry.Unsupported reason ->
+          expect (String.length reason > 0) (tag ^ ": has reason: " ^ reason)
+      | Supported -> expect false (tag ^ ": should be unsupported"));
+
+  run "classify unsupported: \\catcode" (fun tag ->
+      let def =
+        {
+          User_macro_registry.kind = Newcommand;
+          name = "bad2";
+          arity = 0;
+          opt_default = None;
+          body = "\\catcode`@=11";
+          loc = 0;
+        }
+      in
+      let cd = User_macro_registry.classify def in
+      match cd.status with
+      | User_macro_registry.Unsupported _ -> expect true (tag ^ ": unsupported")
+      | Supported -> expect false (tag ^ ": should be unsupported"));
+
+  run "classify unsupported: conditional \\ifx" (fun tag ->
+      let def =
+        {
+          User_macro_registry.kind = Newcommand;
+          name = "cond";
+          arity = 0;
+          opt_default = None;
+          body = "\\ifx\\foo\\bar yes\\fi";
+          loc = 0;
+        }
+      in
+      let cd = User_macro_registry.classify def in
+      match cd.status with
+      | User_macro_registry.Unsupported _ -> expect true (tag ^ ": unsupported")
+      | Supported -> expect false (tag ^ ": should be unsupported"));
+
+  run "classify unsupported: \\expandafter" (fun tag ->
+      let def =
+        {
+          User_macro_registry.kind = Newcommand;
+          name = "exp";
+          arity = 0;
+          opt_default = None;
+          body = "\\expandafter\\foo\\bar";
+          loc = 0;
+        }
+      in
+      let cd = User_macro_registry.classify def in
+      match cd.status with
+      | User_macro_registry.Unsupported _ -> expect true (tag ^ ": unsupported")
+      | Supported -> expect false (tag ^ ": should be unsupported"));
+
+  run "classify unsupported: arity > 9" (fun tag ->
+      let def =
+        {
+          User_macro_registry.kind = Newcommand;
+          name = "toomany";
+          arity = 10;
+          opt_default = None;
+          body = "text";
+          loc = 0;
+        }
+      in
+      let cd = User_macro_registry.classify def in
+      match cd.status with
+      | User_macro_registry.Unsupported _ -> expect true (tag ^ ": unsupported")
+      | Supported -> expect false (tag ^ ": should be unsupported"));
+
+  (* ── Dependency edge tests ─────────────────────────────────────── *)
+  run "dep edges: A uses B" (fun tag ->
+      let defs =
+        [
+          {
+            User_macro_registry.kind = Newcommand;
+            name = "outer";
+            arity = 0;
+            opt_default = None;
+            body = "\\inner world";
+            loc = 0;
+          };
+          {
+            User_macro_registry.kind = Newcommand;
+            name = "inner";
+            arity = 0;
+            opt_default = None;
+            body = "hello";
+            loc = 30;
+          };
+        ]
+      in
+      let edges = User_macro_registry.build_dep_edges defs in
+      expect (List.length edges = 1) (tag ^ ": 1 edge");
+      let e = List.hd edges in
+      expect
+        (e.from_name = "outer" && e.to_name = "inner")
+        (tag ^ ": outer->inner"));
+
+  run "dep edges: no self-edges" (fun tag ->
+      let defs =
+        [
+          {
+            User_macro_registry.kind = Newcommand;
+            name = "self";
+            arity = 0;
+            opt_default = None;
+            body = "\\self";
+            loc = 0;
+          };
+        ]
+      in
+      let edges = User_macro_registry.build_dep_edges defs in
+      expect (edges = []) (tag ^ ": no self edges"));
+
+  run "dep edges: no edges to non-user macros" (fun tag ->
+      let defs =
+        [
+          {
+            User_macro_registry.kind = Newcommand;
+            name = "user";
+            arity = 0;
+            opt_default = None;
+            body = "\\textbf{hello}";
+            loc = 0;
+          };
+        ]
+      in
+      let edges = User_macro_registry.build_dep_edges defs in
+      expect (edges = []) (tag ^ ": no edges to builtins"));
+
+  (* ── Cycle detection tests ─────────────────────────────────────── *)
+  run "detect_cycle: acyclic" (fun tag ->
+      let edges =
+        [
+          { User_macro_registry.from_name = "a"; to_name = "b" };
+          { from_name = "b"; to_name = "c" };
+        ]
+      in
+      let has_cycle, _ =
+        User_macro_registry.detect_cycle edges [ "a"; "b"; "c" ]
+      in
+      expect (not has_cycle) (tag ^ ": no cycle"));
+
+  run "detect_cycle: simple cycle" (fun tag ->
+      let edges =
+        [
+          { User_macro_registry.from_name = "a"; to_name = "b" };
+          { from_name = "b"; to_name = "a" };
+        ]
+      in
+      let has_cycle, path =
+        User_macro_registry.detect_cycle edges [ "a"; "b" ]
+      in
+      expect has_cycle (tag ^ ": has cycle");
+      expect (List.length path > 0) (tag ^ ": path non-empty"));
+
+  run "detect_cycle: diamond (no cycle)" (fun tag ->
+      let edges =
+        [
+          { User_macro_registry.from_name = "a"; to_name = "b" };
+          { User_macro_registry.from_name = "a"; to_name = "c" };
+          { User_macro_registry.from_name = "b"; to_name = "d" };
+          { User_macro_registry.from_name = "c"; to_name = "d" };
+        ]
+      in
+      let has_cycle, _ =
+        User_macro_registry.detect_cycle edges [ "a"; "b"; "c"; "d" ]
+      in
+      expect (not has_cycle) (tag ^ ": diamond is acyclic"));
+
+  (* ── Full registry (create) tests ──────────────────────────────── *)
+  run "create: simple document" (fun tag ->
+      let src =
+        "\\documentclass{article}\n\
+         \\newcommand{\\myop}{\\operatorname{myop}}\n\
+         \\newcommand{\\myval}[1]{\\textbf{#1}}\n\
+         \\begin{document}\n\
+         $\\myop(x)$ is \\myval{good}\n\
+         \\end{document}"
+      in
+      let reg = User_macro_registry.create src in
+      expect (List.length reg.defs = 2) (tag ^ ": 2 defs");
+      expect (reg.supported_count = 2) (tag ^ ": 2 supported");
+      expect (reg.unsupported_count = 0) (tag ^ ": 0 unsupported");
+      expect (not reg.has_cycle) (tag ^ ": no cycle"));
+
+  run "create: mixed supported/unsupported" (fun tag ->
+      let src =
+        "\\newcommand{\\good}{hello}\n\\newcommand{\\bad}{\\def\\inner{x}}\n"
+      in
+      let reg = User_macro_registry.create src in
+      expect (reg.supported_count = 1) (tag ^ ": 1 supported");
+      expect (reg.unsupported_count = 1) (tag ^ ": 1 unsupported"));
+
+  run "create: cycle detection" (fun tag ->
+      let src = "\\newcommand{\\aaa}{\\bbb}\n\\newcommand{\\bbb}{\\aaa}\n" in
+      let reg = User_macro_registry.create src in
+      expect reg.has_cycle (tag ^ ": has cycle"));
+
+  (* ── param_to_placeholder tests ──────────────────────────────── *)
+  run "param_to_placeholder: #1 -> $1" (fun tag ->
+      let result = User_macro_registry.param_to_placeholder "#1 + #2" in
+      expect (result = "$1 + $2") (tag ^ ": converted"));
+
+  run "param_to_placeholder: no params unchanged" (fun tag ->
+      let result = User_macro_registry.param_to_placeholder "hello world" in
+      expect (result = "hello world") (tag ^ ": unchanged"))
+
+let () = finalise "user-macro-registry"

--- a/latex-parse/src/user_macro_context.ml
+++ b/latex-parse/src/user_macro_context.ml
@@ -1,0 +1,20 @@
+(* ══════════════════════════════════════════════════════════════════════
+   User_macro_context — thread-local user macro registry
+
+   Follows the same Hashtbl + Thread.id pattern as File_context, Log_parser,
+   Build_artifact_state, and Validators_context.
+   ══════════════════════════════════════════════════════════════════════ *)
+
+let _tbl : (int, User_macro_registry.registry) Hashtbl.t = Hashtbl.create 4
+
+let set (reg : User_macro_registry.registry) : unit =
+  let tid = Thread.id (Thread.self ()) in
+  Hashtbl.replace _tbl tid reg
+
+let get () : User_macro_registry.registry option =
+  let tid = Thread.id (Thread.self ()) in
+  Hashtbl.find_opt _tbl tid
+
+let clear () : unit =
+  let tid = Thread.id (Thread.self ()) in
+  Hashtbl.remove _tbl tid

--- a/latex-parse/src/user_macro_context.mli
+++ b/latex-parse/src/user_macro_context.mli
@@ -1,0 +1,8 @@
+(** Thread-local user macro registry context.
+
+    Set once per validation run so that validators and the expansion pipeline
+    can access the parsed user macro registry without re-parsing. *)
+
+val set : User_macro_registry.registry -> unit
+val get : unit -> User_macro_registry.registry option
+val clear : unit -> unit

--- a/latex-parse/src/user_macro_registry.ml
+++ b/latex-parse/src/user_macro_registry.ml
@@ -1,0 +1,360 @@
+(* ══════════════════════════════════════════════════════════════════════
+   User_macro_registry — parse, classify, and track user-defined commands
+
+   Parses \newcommand, \renewcommand, and \providecommand from LaTeX source.
+   Classifies each as supported (safe for expansion) or unsupported (diagnosed
+   with reason). Builds def-use dependency graph and detects cycles via DFS
+   topological sort.
+   ══════════════════════════════════════════════════════════════════════ *)
+
+type macro_kind = Newcommand | Renewcommand | Providecommand
+
+type user_macro_def = {
+  kind : macro_kind;
+  name : string;
+  arity : int;
+  opt_default : string option;
+  body : string;
+  loc : int;
+}
+
+type support_status = Supported | Unsupported of string
+type classified_def = { def : user_macro_def; status : support_status }
+type dep_edge = { from_name : string; to_name : string }
+
+type registry = {
+  defs : classified_def list;
+  edges : dep_edge list;
+  has_cycle : bool;
+  cycle_path : string list;
+  supported_count : int;
+  unsupported_count : int;
+}
+
+(* ── Helpers ─────────────────────────────────────────────────────── *)
+
+let is_letter c = ('a' <= c && c <= 'z') || ('A' <= c && c <= 'Z')
+
+let find_brace_block s i =
+  let n = String.length s in
+  if i >= n || s.[i] <> '{' then None
+  else
+    let j = ref (i + 1) in
+    let depth = ref 1 in
+    while !j < n && !depth > 0 do
+      (match s.[!j] with '{' -> incr depth | '}' -> decr depth | _ -> ());
+      incr j
+    done;
+    if !depth = 0 then Some (i + 1, !j - i - 2) else None
+
+let skip_ws s i =
+  let n = String.length s in
+  let j = ref i in
+  while !j < n && (s.[!j] = ' ' || s.[!j] = '\t' || s.[!j] = '\n') do
+    incr j
+  done;
+  !j
+
+let take_ident s i =
+  let n = String.length s in
+  let j = ref i in
+  while !j < n && is_letter s.[!j] do
+    incr j
+  done;
+  if !j > i then Some (String.sub s i (!j - i), !j) else None
+
+(* ── Parsing ─────────────────────────────────────────────────────── *)
+
+let re_def =
+  Re_compat.regexp {|\\\(newcommand\|renewcommand\|providecommand\)\*?|}
+
+let kind_of_string = function
+  | "newcommand" -> Newcommand
+  | "renewcommand" -> Renewcommand
+  | "providecommand" -> Providecommand
+  | _ -> Newcommand
+
+let parse_definitions (src : string) : user_macro_def list =
+  let defs = ref [] in
+  let i = ref 0 in
+  let n = String.length src in
+  (try
+     while true do
+       let _mr, pos = Re_compat.search_forward re_def src !i in
+       let kind_str = Re_compat.matched_group _mr 1 src in
+       let kind = kind_of_string kind_str in
+       let loc = pos in
+       let after_cmd = Re_compat.match_end _mr in
+       (* Skip optional * and whitespace *)
+       let p = ref after_cmd in
+       p := skip_ws src !p;
+       (* Extract macro name: either {\name} or \name *)
+       let name_opt =
+         if !p < n && src.[!p] = '{' then
+           (* {\name} form *)
+           let inside = !p + 1 in
+           if inside < n && src.[inside] = '\\' then
+             match take_ident src (inside + 1) with
+             | Some (name, after_name) ->
+                 (* skip closing brace *)
+                 let q = ref after_name in
+                 q := skip_ws src !q;
+                 if !q < n && src.[!q] = '}' then (
+                   p := !q + 1;
+                   Some name)
+                 else None
+             | None -> None
+           else None
+         else if !p < n && src.[!p] = '\\' then
+           (* \name form (no braces) *)
+           match take_ident src (!p + 1) with
+           | Some (name, after_name) ->
+               p := after_name;
+               Some name
+           | None -> None
+         else None
+       in
+       (match name_opt with
+       | None -> i := after_cmd
+       | Some name -> (
+           p := skip_ws src !p;
+           (* Optional arity [N] *)
+           let arity =
+             if !p < n && src.[!p] = '[' then (
+               let q = ref (!p + 1) in
+               while !q < n && src.[!q] <> ']' do
+                 incr q
+               done;
+               if !q < n then (
+                 let arity_str = String.sub src (!p + 1) (!q - !p - 1) in
+                 p := !q + 1;
+                 try int_of_string (String.trim arity_str) with Failure _ -> 0)
+               else 0)
+             else 0
+           in
+           p := skip_ws src !p;
+           (* Optional default [default] *)
+           let opt_default =
+             if !p < n && src.[!p] = '[' then (
+               let q = ref (!p + 1) in
+               let depth = ref 1 in
+               while !q < n && !depth > 0 do
+                 (match src.[!q] with
+                 | '[' -> incr depth
+                 | ']' -> decr depth
+                 | _ -> ());
+                 if !depth > 0 then incr q
+               done;
+               if !depth = 0 then (
+                 let def_str = String.sub src (!p + 1) (!q - !p - 1) in
+                 p := !q + 1;
+                 Some def_str)
+               else None)
+             else None
+           in
+           p := skip_ws src !p;
+           (* Body {....} *)
+           match find_brace_block src !p with
+           | Some (start, len) ->
+               let body = String.sub src start len in
+               defs := { kind; name; arity; opt_default; body; loc } :: !defs;
+               i := start + len + 1
+           | None -> i := !p + 1));
+       i := max !i (pos + 1)
+     done
+   with Not_found -> ());
+  List.rev !defs
+
+(* ── Classification ──────────────────────────────────────────────── *)
+
+let _blocklist =
+  [
+    ("\\catcode", "body contains \\catcode");
+    ("\\makeatletter", "body contains \\makeatletter");
+    ("\\def", "body contains \\def");
+    ("\\edef", "body contains \\edef");
+    ("\\gdef", "body contains \\gdef");
+    ("\\xdef", "body contains \\xdef");
+    ("\\let", "body contains \\let");
+    ("\\expandafter", "body contains \\expandafter");
+    ("\\csname", "body contains \\csname");
+    ("\\noexpand", "body contains \\noexpand");
+    ("\\string", "body contains \\string");
+    ("\\meaning", "body contains \\meaning");
+    ("\\ifx", "body contains conditional \\ifx");
+    ("\\ifnum", "body contains conditional \\ifnum");
+    ("\\ifcase", "body contains conditional \\ifcase");
+    ("\\ifdim", "body contains conditional \\ifdim");
+    ("\\ifcat", "body contains conditional \\ifcat");
+    ("\\if", "body contains conditional \\if");
+    ("\\else", "body contains \\else");
+    ("\\fi", "body contains \\fi");
+    ("\\input", "body contains \\input");
+    ("\\include", "body contains \\include");
+    ("\\read", "body contains \\read");
+    ("\\write", "body contains \\write");
+    ("\\count", "body contains register \\count");
+    ("\\dimen", "body contains register \\dimen");
+    ("\\skip", "body contains register \\skip");
+    ("\\toks", "body contains register \\toks");
+    ("\\futurelet", "body contains \\futurelet");
+  ]
+
+(** Check if body contains a blocklisted control sequence. We need to verify the
+    match is actually a control sequence (followed by non-letter or end). *)
+let check_blocklist body =
+  let check (pattern, reason) =
+    let plen = String.length pattern in
+    let blen = String.length body in
+    let rec scan i =
+      if i > blen - plen then None
+      else if String.sub body i plen = pattern then
+        (* Verify it's a complete control sequence *)
+        let after = i + plen in
+        if after >= blen || not (is_letter body.[after]) then Some reason
+        else scan (i + 1)
+      else scan (i + 1)
+    in
+    scan 0
+  in
+  List.find_map check _blocklist
+
+let classify (def : user_macro_def) : classified_def =
+  if def.arity < 0 || def.arity > 9 then
+    { def; status = Unsupported "arity out of range (must be 0-9)" }
+  else
+    match check_blocklist def.body with
+    | Some reason -> { def; status = Unsupported reason }
+    | None -> { def; status = Supported }
+
+(* ── Dependency edges ────────────────────────────────────────────── *)
+
+let extract_control_seqs body =
+  let refs = ref [] in
+  let n = String.length body in
+  let i = ref 0 in
+  while !i < n do
+    if body.[!i] = '\\' && !i + 1 < n && is_letter body.[!i + 1] then (
+      let start = !i + 1 in
+      let j = ref start in
+      while !j < n && is_letter body.[!j] do
+        incr j
+      done;
+      refs := String.sub body start (!j - start) :: !refs;
+      i := !j)
+    else incr i
+  done;
+  !refs
+
+let build_dep_edges (defs : user_macro_def list) : dep_edge list =
+  let name_set =
+    let tbl = Hashtbl.create 32 in
+    List.iter (fun d -> Hashtbl.replace tbl d.name ()) defs;
+    tbl
+  in
+  List.concat_map
+    (fun d ->
+      let refs = extract_control_seqs d.body in
+      List.filter_map
+        (fun r ->
+          if Hashtbl.mem name_set r && r <> d.name then
+            Some { from_name = d.name; to_name = r }
+          else None)
+        refs)
+    defs
+
+(* ── Cycle detection via DFS ─────────────────────────────────────── *)
+
+type color = White | Gray | Black
+
+let detect_cycle (edges : dep_edge list) (names : string list) :
+    bool * string list =
+  let adj = Hashtbl.create 32 in
+  List.iter (fun n -> Hashtbl.replace adj n []) names;
+  List.iter
+    (fun e ->
+      if Hashtbl.mem adj e.from_name && Hashtbl.mem adj e.to_name then
+        Hashtbl.replace adj e.from_name
+          (e.to_name
+          :: (try Hashtbl.find adj e.from_name with Not_found -> [])))
+    edges;
+  let color = Hashtbl.create 32 in
+  List.iter (fun n -> Hashtbl.replace color n White) names;
+  let cycle_path = ref [] in
+  let has_cycle = ref false in
+  let rec dfs node path =
+    if !has_cycle then ()
+    else (
+      Hashtbl.replace color node Gray;
+      let neighbors = try Hashtbl.find adj node with Not_found -> [] in
+      List.iter
+        (fun nb ->
+          if !has_cycle then ()
+          else
+            match Hashtbl.find_opt color nb with
+            | Some Gray ->
+                has_cycle := true;
+                cycle_path := nb :: node :: path
+            | Some White -> dfs nb (node :: path)
+            | _ -> ())
+        neighbors;
+      if not !has_cycle then Hashtbl.replace color node Black)
+  in
+  List.iter
+    (fun n -> if (not !has_cycle) && Hashtbl.find color n = White then dfs n [])
+    names;
+  (!has_cycle, List.rev !cycle_path)
+
+(* ── Orchestrator ────────────────────────────────────────────────── *)
+
+let create (src : string) : registry =
+  let raw_defs = parse_definitions src in
+  let classified = List.map classify raw_defs in
+  let supported_defs =
+    List.filter_map
+      (fun cd ->
+        match cd.status with Supported -> Some cd.def | Unsupported _ -> None)
+      classified
+  in
+  let edges = build_dep_edges supported_defs in
+  let user_names = List.map (fun d -> d.name) supported_defs in
+  let has_cycle, cycle_path = detect_cycle edges user_names in
+  let supported_count =
+    List.length (List.filter (fun cd -> cd.status = Supported) classified)
+  in
+  let unsupported_count =
+    List.length
+      (List.filter
+         (fun cd -> match cd.status with Unsupported _ -> true | _ -> false)
+         classified)
+  in
+  {
+    defs = classified;
+    edges;
+    has_cycle;
+    cycle_path;
+    supported_count;
+    unsupported_count;
+  }
+
+(* ── Parameter placeholder conversion ─────────────────────────────── *)
+
+let param_to_placeholder body =
+  let buf = Buffer.create (String.length body + 16) in
+  let n = String.length body in
+  let i = ref 0 in
+  while !i < n do
+    if
+      !i + 1 < n
+      && body.[!i] = '#'
+      && body.[!i + 1] >= '1'
+      && body.[!i + 1] <= '9'
+    then (
+      Buffer.add_char buf '$';
+      Buffer.add_char buf body.[!i + 1];
+      i := !i + 2)
+    else (
+      Buffer.add_char buf body.[!i];
+      incr i)
+  done;
+  Buffer.contents buf

--- a/latex-parse/src/user_macro_registry.mli
+++ b/latex-parse/src/user_macro_registry.mli
@@ -1,0 +1,53 @@
+(** User macro registry: parse, classify, and track user-defined commands.
+
+    Parses [\newcommand], [\renewcommand], and [\providecommand] from LaTeX
+    source. Classifies each as supported or unsupported, builds a def-use
+    dependency graph, and detects cycles. Supported, acyclic macros can be
+    merged into {!Macro_catalogue} for expansion. *)
+
+type macro_kind = Newcommand | Renewcommand | Providecommand
+
+type user_macro_def = {
+  kind : macro_kind;
+  name : string;  (** Without backslash. *)
+  arity : int;  (** 0..9, from [[N]] spec. *)
+  opt_default : string option;  (** From [[default]], if present. *)
+  body : string;  (** Raw body text. *)
+  loc : int;  (** Byte offset in source. *)
+}
+
+type support_status = Supported | Unsupported of string
+type classified_def = { def : user_macro_def; status : support_status }
+type dep_edge = { from_name : string; to_name : string }
+
+type registry = {
+  defs : classified_def list;
+  edges : dep_edge list;
+  has_cycle : bool;
+  cycle_path : string list;
+  supported_count : int;
+  unsupported_count : int;
+}
+
+val parse_definitions : string -> user_macro_def list
+(** Extract all [\newcommand], [\renewcommand], [\providecommand] definitions
+    from a LaTeX source string. *)
+
+val classify : user_macro_def -> classified_def
+(** Classify a definition as supported or unsupported based on its body content.
+    Unsupported macros include a diagnostic reason string. *)
+
+val build_dep_edges : user_macro_def list -> dep_edge list
+(** Build dependency edges between user macros (A depends on B if A's body
+    contains [\B]). *)
+
+val detect_cycle : dep_edge list -> string list -> bool * string list
+(** [detect_cycle edges names] returns [(has_cycle, cycle_path)]. Only considers
+    edges between names in the [names] list. *)
+
+val create : string -> registry
+(** Top-level entry point: parse, classify, build edges, detect cycles. *)
+
+val param_to_placeholder : string -> string
+(** Convert [#1..#9] parameter references to [$1..$9] placeholders for the
+    {!Macro_catalogue} inline template format. *)

--- a/latex-parse/src/validators.ml
+++ b/latex-parse/src/validators.ml
@@ -45,6 +45,7 @@ let rules_enc_char_spc : rule list =
   @ rules_style
   @ rules_l3_file
   @ rules_l1_expl3
+  @ rules_user_macro
 
 (* ── VPD-catalogue: all 80 rules with VPD pattern annotations ──────── *)
 (* This list enumerates every rule that has a corresponding entry in

--- a/latex-parse/src/validators_cli.ml
+++ b/latex-parse/src/validators_cli.ml
@@ -65,7 +65,8 @@ let setup_command_spans src =
 let cleanup () =
   Latex_parse_lib.Validators_context.clear ();
   Latex_parse_lib.File_context.clear_file_context ();
-  Latex_parse_lib.Build_artifact_state.clear ()
+  Latex_parse_lib.Build_artifact_state.clear ();
+  Latex_parse_lib.User_macro_context.clear ()
 
 let setup_all ~path ~src ~log_path =
   let base_dir = Filename.dirname path in
@@ -80,6 +81,8 @@ let setup_all ~path ~src ~log_path =
   (match Latex_parse_lib.Build_artifact_state.from_profile bp with
   | Some state -> Latex_parse_lib.Build_artifact_state.set state
   | None -> ());
+  let reg = Latex_parse_lib.User_macro_registry.create src in
+  Latex_parse_lib.User_macro_context.set reg;
   bp
 
 (* ── Class C result detection ────────────────────────────────────── *)

--- a/latex-parse/src/validators_l2.ml
+++ b/latex-parse/src/validators_l2.ml
@@ -6317,6 +6317,138 @@ let r_cmd_013 : rule =
   in
   { id = "CMD-013"; run; languages = [] }
 
+(* ══════════════════════════════════════════════════════════════════════ WS2:
+   User macro registry validators — require User_macro_context. Rules silently
+   return None if no registry context is set.
+   ══════════════════════════════════════════════════════════════════════ *)
+
+(* CMD-015: Unsupported user macro construct *)
+let r_cmd_015 : rule =
+  let run _s =
+    match User_macro_context.get () with
+    | None -> None
+    | Some reg ->
+        let unsupported =
+          List.filter_map
+            (fun (cd : User_macro_registry.classified_def) ->
+              match cd.status with
+              | User_macro_registry.Unsupported reason ->
+                  Some (cd.def.User_macro_registry.name, reason)
+              | Supported -> None)
+            reg.User_macro_registry.defs
+        in
+        let cnt = List.length unsupported in
+        if cnt > 0 then
+          let reasons =
+            List.map
+              (fun (name, reason) -> Printf.sprintf "\\%s: %s" name reason)
+              unsupported
+          in
+          Some
+            {
+              id = "CMD-015";
+              severity = Info;
+              message =
+                Printf.sprintf "Unsupported user macro construct(s): %s"
+                  (String.concat "; " reasons);
+              count = cnt;
+            }
+        else None
+  in
+  mk_rule "CMD-015" run
+
+(* CMD-016: Cycle in user macro definitions *)
+let r_cmd_016 : rule =
+  let run _s =
+    match User_macro_context.get () with
+    | None -> None
+    | Some reg ->
+        if reg.User_macro_registry.has_cycle then
+          let path =
+            String.concat " -> "
+              (List.map (fun n -> "\\" ^ n) reg.User_macro_registry.cycle_path)
+          in
+          Some
+            {
+              id = "CMD-016";
+              severity = Warning;
+              message =
+                Printf.sprintf "Cycle in user macro definitions: %s" path;
+              count = 1;
+            }
+        else None
+  in
+  mk_rule "CMD-016" run
+
+(* CMD-017: User macro shadows built-in via \newcommand *)
+let r_cmd_017 : rule =
+  let run _s =
+    match User_macro_context.get () with
+    | None -> None
+    | Some reg ->
+        let shadows =
+          List.filter_map
+            (fun (cd : User_macro_registry.classified_def) ->
+              if
+                cd.def.User_macro_registry.kind = User_macro_registry.Newcommand
+                && cd.status = User_macro_registry.Supported
+              then
+                (* Check if the name matches a known built-in *)
+                let known =
+                  [
+                    "textbf";
+                    "textit";
+                    "texttt";
+                    "textsf";
+                    "textsc";
+                    "emph";
+                    "mathrm";
+                    "mathbf";
+                    "mathsf";
+                    "mathtt";
+                    "frac";
+                    "sqrt";
+                    "operatorname";
+                    "section";
+                    "subsection";
+                    "chapter";
+                    "ref";
+                    "label";
+                    "cite";
+                    "caption";
+                    "includegraphics";
+                    "usepackage";
+                    "documentclass";
+                    "title";
+                    "author";
+                    "date";
+                    "maketitle";
+                    "tableofcontents";
+                    "bibliography";
+                  ]
+                in
+                if List.mem cd.def.User_macro_registry.name known then
+                  Some cd.def.User_macro_registry.name
+                else None
+              else None)
+            reg.User_macro_registry.defs
+        in
+        let cnt = List.length shadows in
+        if cnt > 0 then
+          Some
+            {
+              id = "CMD-017";
+              severity = Warning;
+              message =
+                Printf.sprintf
+                  "User \\newcommand shadows built-in: %s (use \\renewcommand)"
+                  (String.concat ", " (List.map (fun n -> "\\" ^ n) shadows));
+              count = cnt;
+            }
+        else None
+  in
+  mk_rule "CMD-017" run
+
 let rules_cmd : rule list =
   [
     r_cmd_002;
@@ -6328,6 +6460,10 @@ let rules_cmd : rule list =
     r_cmd_011;
     r_cmd_013;
   ]
+
+(** WS2 user macro registry validators — require [User_macro_context]. Separated
+    from [rules_cmd] because they are defined after [rules_l2_approx]. *)
+let rules_user_macro : rule list = [ r_cmd_015; r_cmd_016; r_cmd_017 ]
 
 (* ── TYPO-062: Literal backslash in text ───────────────────────────── *)
 let r_typo_062 : rule =


### PR DESCRIPTION
## Summary

- Parse `\newcommand`/`\renewcommand`/`\providecommand` from source with balanced-brace body extraction
- Classify supported (arity 0-9, no primitives) vs unsupported (29 blocklisted TeX primitives, diagnosed with reason)
- Build def-use dependency graph between user macros, detect cycles via DFS
- `merge_user_macros` converts supported macros to `argsafe_entry` for existing expansion pipeline
- CMD-015: unsupported construct diagnostic, CMD-016: cycle detection, CMD-017: built-in shadowing
- CLI wired: `User_macro_context` set/cleared in `setup_all`/`cleanup`

## Test plan

- [x] `[user-macro-registry] PASS 47 cases` — parsing, classification, dep edges, cycles, param conversion
- [x] `dune runtest` — full suite exit 0, zero regressions
- [x] `dune fmt` — formatting clean
- [ ] CI green