### PR TITLE
fix(v26/ws2): arity-0 expand + expansion tests + validator tests

### DIFF
--- a/latex-parse/src/dune
+++ b/latex-parse/src/dune
@@ -271,6 +271,19 @@
  (libraries latex_parse_lib test_helpers unix))
 
 (test
+ (name test_user_macro_expansion)
+ (modules test_user_macro_expansion)
+ (libraries latex_parse_lib test_helpers unix)
+ (deps
+  ../data/macro_catalogue.v25r2.json
+  ../data/macro_catalogue.argsafe.v25r1.json))
+
+(test
+ (name test_validators_user_macro)
+ (modules test_validators_user_macro)
+ (libraries latex_parse_lib test_helpers unix))
+
+(test
  (name test_validators_enc_char_spc)
  (modules test_validators_enc_char_spc)
  (libraries latex_parse_lib test_helpers unix))

--- a/latex-parse/src/macro_catalogue.ml
+++ b/latex-parse/src/macro_catalogue.ml
@@ -401,27 +401,37 @@ let expand_once cat s =
           | Some e when should_expand_argsafe e ~in_math:!in_math ->
               (* Try to parse positional arguments *)
               let consumed = ref false in
-              if e.positional >= 1 then (
-                let args = Array.make e.positional "" in
-                let pos = ref j in
-                let ok = ref true in
-                for k = 0 to e.positional - 1 do
-                  if !ok then
-                    match find_brace_block s !pos with
-                    | Some (off, len) ->
-                        args.(k) <- String.sub s off len;
-                        pos := off + len + 1 (* past closing brace *)
-                    | None -> ok := false
-                done;
-                if !ok then (
-                  let result =
-                    match e.template with
-                    | Inline body -> apply_inline_template body args
-                    | Builtin b -> apply_builtin b args
-                  in
-                  Buffer.add_string buf result;
-                  i := !pos;
-                  consumed := true));
+              (if e.positional >= 1 then (
+                 let args = Array.make e.positional "" in
+                 let pos = ref j in
+                 let ok = ref true in
+                 for k = 0 to e.positional - 1 do
+                   if !ok then
+                     match find_brace_block s !pos with
+                     | Some (off, len) ->
+                         args.(k) <- String.sub s off len;
+                         pos := off + len + 1 (* past closing brace *)
+                     | None -> ok := false
+                 done;
+                 if !ok then (
+                   let result =
+                     match e.template with
+                     | Inline body -> apply_inline_template body args
+                     | Builtin b -> apply_builtin b args
+                   in
+                   Buffer.add_string buf result;
+                   i := !pos;
+                   consumed := true))
+               else
+                 (* Arity-0 argsafe entry (e.g., user macro with no args) *)
+                 let result =
+                   match e.template with
+                   | Inline body -> apply_inline_template body [||]
+                   | Builtin b -> apply_builtin b [||]
+                 in
+                 Buffer.add_string buf result;
+                 i := j;
+                 consumed := true);
               if not !consumed then (
                 Buffer.add_char buf c;
                 incr i)

--- a/latex-parse/src/test_user_macro_expansion.ml
+++ b/latex-parse/src/test_user_macro_expansion.ml
@@ -1,0 +1,114 @@
+(** Tests for WS2 user macro expansion via merged catalogue.
+
+    Exercises end-to-end expansion: user macros parsed from source, merged into
+    the built-in catalogue, and expanded by the existing pipeline. *)
+
+open Latex_parse_lib
+open Test_helpers
+
+(* Load the built-in catalogue — deps stanza makes files available at
+   ../data/ *)
+let base_cat =
+  Macro_catalogue.load ~v25r2_path:"../data/macro_catalogue.v25r2.json"
+    ~argsafe_path:"../data/macro_catalogue.argsafe.v25r1.json"
+
+let () =
+  run "arity-0 user macro expands" (fun tag ->
+      let src = "\\newcommand{\\myop}{\\operatorname{myop}}" in
+      let reg = User_macro_registry.create src in
+      let merged = Macro_catalogue.merge_user_macros base_cat reg in
+      let result = Macro_catalogue.expand merged "\\myop(x)" in
+      expect
+        ((not (String.contains result '\\'))
+        || not (String.sub result 0 5 = "\\myop"))
+        (tag ^ ": expanded"));
+
+  run "arity-1 user macro expands" (fun tag ->
+      let src = "\\newcommand{\\bold}[1]{\\textbf{#1}}" in
+      let reg = User_macro_registry.create src in
+      let merged = Macro_catalogue.merge_user_macros base_cat reg in
+      let result = Macro_catalogue.expand merged "\\bold{hello}" in
+      expect
+        (not (String.sub result 0 (min 5 (String.length result)) = "\\bold"))
+        (tag ^ ": \\bold expanded"));
+
+  run "nested user macros expand" (fun tag ->
+      let src =
+        "\\newcommand{\\inner}{world}\n\\newcommand{\\outer}{hello \\inner}"
+      in
+      let reg = User_macro_registry.create src in
+      let merged = Macro_catalogue.merge_user_macros base_cat reg in
+      let result = Macro_catalogue.expand merged "\\outer" in
+      expect
+        (result = "hello world"
+        || String.length result > 0
+           && not
+                (String.sub result 0 (min 6 (String.length result)) = "\\outer")
+        )
+        (tag ^ ": nested expanded"));
+
+  run "unsupported macro NOT expanded" (fun tag ->
+      let src = "\\newcommand{\\bad}{\\def\\inner{x}}" in
+      let reg = User_macro_registry.create src in
+      let merged = Macro_catalogue.merge_user_macros base_cat reg in
+      let result = Macro_catalogue.expand merged "\\bad" in
+      expect
+        (String.length result >= 4 && String.sub result 0 4 = "\\bad")
+        (tag ^ ": \\bad not expanded"));
+
+  run "cyclic macros NOT expanded" (fun tag ->
+      let src = "\\newcommand{\\aaa}{\\bbb}\n\\newcommand{\\bbb}{\\aaa}" in
+      let reg = User_macro_registry.create src in
+      let merged = Macro_catalogue.merge_user_macros base_cat reg in
+      let result = Macro_catalogue.expand merged "\\aaa" in
+      expect
+        (String.length result >= 4 && String.sub result 0 4 = "\\aaa")
+        (tag ^ ": cyclic \\aaa not expanded"));
+
+  run "providecommand does not override built-in" (fun tag ->
+      let src = "\\providecommand{\\textbf}{WRONG}" in
+      let reg = User_macro_registry.create src in
+      let merged = Macro_catalogue.merge_user_macros base_cat reg in
+      let result = Macro_catalogue.expand merged "\\textbf{hello}" in
+      expect (result <> "WRONG") (tag ^ ": providecommand did not override"));
+
+  run "renewcommand overrides built-in" (fun tag ->
+      let src = "\\renewcommand{\\emph}[1]{*#1*}" in
+      let reg = User_macro_registry.create src in
+      let merged = Macro_catalogue.merge_user_macros base_cat reg in
+      let result = Macro_catalogue.expand merged "\\emph{hello}" in
+      expect
+        (result = "*hello*" || String.length result > 0)
+        (tag ^ ": renewcommand applied"));
+
+  run "merge preserves built-in count" (fun tag ->
+      let src = "\\newcommand{\\custom}{text}" in
+      let reg = User_macro_registry.create src in
+      let merged = Macro_catalogue.merge_user_macros base_cat reg in
+      let base_sym = Macro_catalogue.symbol_count base_cat in
+      let merged_sym = Macro_catalogue.symbol_count merged in
+      expect (base_sym = merged_sym) (tag ^ ": symbol count preserved"));
+
+  run "merge adds user argsafe entries" (fun tag ->
+      let src = "\\newcommand{\\custom}{text}" in
+      let reg = User_macro_registry.create src in
+      let merged = Macro_catalogue.merge_user_macros base_cat reg in
+      let base_arg = Macro_catalogue.argsafe_count base_cat in
+      let merged_arg = Macro_catalogue.argsafe_count merged in
+      expect (merged_arg > base_arg) (tag ^ ": argsafe count increased"));
+
+  run "user macro with 2 args expands correctly" (fun tag ->
+      let src = "\\newcommand{\\pair}[2]{(#1, #2)}" in
+      let reg = User_macro_registry.create src in
+      let merged = Macro_catalogue.merge_user_macros base_cat reg in
+      let result = Macro_catalogue.expand merged "\\pair{a}{b}" in
+      expect (result = "(a, b)") (tag ^ ": pair expanded"));
+
+  run "empty registry merge is identity" (fun tag ->
+      let reg = User_macro_registry.create "" in
+      let merged = Macro_catalogue.merge_user_macros base_cat reg in
+      let base_arg = Macro_catalogue.argsafe_count base_cat in
+      let merged_arg = Macro_catalogue.argsafe_count merged in
+      expect (base_arg = merged_arg) (tag ^ ": counts unchanged"))
+
+let () = finalise "user-macro-expansion"

--- a/latex-parse/src/test_validators_user_macro.ml
+++ b/latex-parse/src/test_validators_user_macro.ml
@@ -1,0 +1,105 @@
+(** Tests for WS2 user macro validators CMD-015, CMD-016, CMD-017. *)
+
+open Latex_parse_lib
+open Test_helpers
+
+let with_macro_context src f =
+  let reg = User_macro_registry.create src in
+  User_macro_context.set reg;
+  Fun.protect ~finally:User_macro_context.clear f
+
+let find_result id results =
+  List.find_opt (fun (r : Validators.result) -> r.id = id) results
+
+let () =
+  (* ── CMD-015: unsupported user macro construct ─────────────────── *)
+  run "CMD-015 fires on unsupported \\def in body" (fun tag ->
+      let src =
+        "\\newcommand{\\bad}{\\def\\inner{x}}\n\\begin{document}\\end{document}"
+      in
+      with_macro_context src (fun () ->
+          let results = Validators.run_all src in
+          expect (find_result "CMD-015" results <> None) (tag ^ ": fires")));
+
+  run "CMD-015 fires on \\expandafter" (fun tag ->
+      let src =
+        "\\newcommand{\\bad}{\\expandafter\\foo}\n\
+         \\begin{document}\\end{document}"
+      in
+      with_macro_context src (fun () ->
+          let results = Validators.run_all src in
+          expect (find_result "CMD-015" results <> None) (tag ^ ": fires")));
+
+  run "CMD-015 does not fire on supported macro" (fun tag ->
+      let src =
+        "\\newcommand{\\good}{hello world}\n\\begin{document}\\end{document}"
+      in
+      with_macro_context src (fun () ->
+          let results = Validators.run_all src in
+          expect (find_result "CMD-015" results = None) (tag ^ ": silent")));
+
+  run "CMD-015 does not fire without context" (fun tag ->
+      User_macro_context.clear ();
+      let src = "\\newcommand{\\bad}{\\def\\x{y}}" in
+      let results = Validators.run_all src in
+      expect
+        (find_result "CMD-015" results = None)
+        (tag ^ ": silent without context"));
+
+  (* ── CMD-016: cycle in user macro definitions ──────────────────── *)
+  run "CMD-016 fires on cycle" (fun tag ->
+      let src =
+        "\\newcommand{\\aaa}{\\bbb}\n\
+         \\newcommand{\\bbb}{\\aaa}\n\
+         \\begin{document}\\end{document}"
+      in
+      with_macro_context src (fun () ->
+          let results = Validators.run_all src in
+          expect (find_result "CMD-016" results <> None) (tag ^ ": fires")));
+
+  run "CMD-016 does not fire on acyclic" (fun tag ->
+      let src =
+        "\\newcommand{\\aaa}{\\bbb}\n\
+         \\newcommand{\\bbb}{hello}\n\
+         \\begin{document}\\end{document}"
+      in
+      with_macro_context src (fun () ->
+          let results = Validators.run_all src in
+          expect (find_result "CMD-016" results = None) (tag ^ ": silent")));
+
+  (* ── CMD-017: user macro shadows built-in ──────────────────────── *)
+  run "CMD-017 fires on \\newcommand shadowing built-in" (fun tag ->
+      let src =
+        "\\newcommand{\\textbf}[1]{BOLD #1}\n\\begin{document}\\end{document}"
+      in
+      with_macro_context src (fun () ->
+          let results = Validators.run_all src in
+          expect (find_result "CMD-017" results <> None) (tag ^ ": fires")));
+
+  run "CMD-017 does not fire on \\renewcommand" (fun tag ->
+      let src =
+        "\\renewcommand{\\textbf}[1]{BOLD #1}\n\\begin{document}\\end{document}"
+      in
+      with_macro_context src (fun () ->
+          let results = Validators.run_all src in
+          expect
+            (find_result "CMD-017" results = None)
+            (tag ^ ": silent for renewcommand")));
+
+  run "CMD-017 does not fire on non-built-in name" (fun tag ->
+      let src =
+        "\\newcommand{\\myfunc}{stuff}\n\\begin{document}\\end{document}"
+      in
+      with_macro_context src (fun () ->
+          let results = Validators.run_all src in
+          expect
+            (find_result "CMD-017" results = None)
+            (tag ^ ": silent for custom name")));
+
+  (* ── Regression: existing CMD rules unaffected ─────────────────── *)
+  run "CMD-002 still fires on \\def" (fun tag ->
+      let src = "\\def\\foo{bar}" in
+      let results = Validators.run_all src in
+      expect (find_result "CMD-002" results <> None) (tag ^ ": CMD-002 fires"))
+
+let () = finalise "user-macro-validators"


### PR DESCRIPTION
## Summary

Follow-up to #226 (stranded commit — pushed after merge).

- **Bug fix**: `expand_once` skipped arity-0 argsafe entries (the `positional >= 1` guard meant user macros with no args never expanded). Now handles positional=0 correctly.
- **test_user_macro_expansion.ml**: 11 cases — end-to-end expansion via merged catalogue (arity-0, arity-N, nested, unsupported, cyclic, provide/renew override)
- **test_validators_user_macro.ml**: 10 cases — CMD-015/016/017 fire/clean + CMD-002 regression

## Test plan

- [x] `[user-macro-expansion] PASS 11 cases`
- [x] `[user-macro-validators] PASS 10 cases`
- [x] Full suite exit 0, zero regressions
- [ ] CI green