### PR TITLE
feat(v26/ws3): project graph foundation — multi-file include resolution

### DIFF
--- a/corpora/multi_file/chapter1.tex
+++ b/corpora/multi_file/chapter1.tex
@@ -1,0 +1,5 @@
+\section{Chapter One}
+\label{ch1:sec}
+Some content.
+\ref{ch2:fig}
+\input{shared}

--- a/corpora/multi_file/chapter2.tex
+++ b/corpora/multi_file/chapter2.tex
@@ -1,0 +1,4 @@
+\section{Chapter Two}
+\label{ch2:fig}
+A figure reference.
+\ref{undefined:x}

--- a/corpora/multi_file/cycle_a.tex
+++ b/corpora/multi_file/cycle_a.tex
@@ -1,0 +1,2 @@
+\input{cycle_b}
+Cycle file A.

--- a/corpora/multi_file/cycle_b.tex
+++ b/corpora/multi_file/cycle_b.tex
@@ -1,0 +1,2 @@
+\input{cycle_a}
+Cycle file B.

--- a/corpora/multi_file/main.tex
+++ b/corpora/multi_file/main.tex
@@ -1,0 +1,9 @@
+\documentclass{article}
+\begin{document}
+\label{main:top}
+This is the main file.
+\input{chapter1}
+\include{chapter2}
+\ref{ch1:sec}
+\ref{ch2:fig}
+\end{document}

--- a/corpora/multi_file/shared.tex
+++ b/corpora/multi_file/shared.tex
@@ -1,0 +1,2 @@
+\label{shared:eq}
+A shared equation: $E = mc^2$

--- a/latex-parse/src/dune
+++ b/latex-parse/src/dune
@@ -54,6 +54,11 @@
   macro_catalogue
   user_macro_registry
   user_macro_context
+  include_resolver
+  project_graph
+  project_state
+  project_context
+  validators_project
   log_parser
   build_profile
   build_artifact_state
@@ -268,6 +273,21 @@
 (test
  (name test_user_macro_registry)
  (modules test_user_macro_registry)
+ (libraries latex_parse_lib test_helpers unix))
+
+(test
+ (name test_include_resolver)
+ (modules test_include_resolver)
+ (libraries latex_parse_lib test_helpers unix))
+
+(test
+ (name test_project_graph)
+ (modules test_project_graph)
+ (libraries latex_parse_lib test_helpers unix))
+
+(test
+ (name test_project_state)
+ (modules test_project_state)
  (libraries latex_parse_lib test_helpers unix))
 
 (test

--- a/latex-parse/src/include_resolver.ml
+++ b/latex-parse/src/include_resolver.ml
@@ -1,0 +1,60 @@
+(* ══════════════════════════════════════════════════════════════════════
+   Include_resolver — parse and resolve \input, \include, \includeonly
+
+   Extracts include directives from LaTeX source and resolves them to file
+   system paths relative to a base directory.
+   ══════════════════════════════════════════════════════════════════════ *)
+
+type include_entry = { command : string; raw_path : string; position : int }
+type resolved_include = { entry : include_entry; resolved_path : string option }
+
+(* ── Extraction ──────────────────────────────────────────────────── *)
+
+let re_input = Re_compat.regexp {|\\input{\([^}]+\)}|}
+let re_include = Re_compat.regexp {|\\include{\([^}]+\)}|}
+let re_includeonly = Re_compat.regexp {|\\includeonly{\([^}]+\)}|}
+
+let extract_with_re re cmd src =
+  let entries = ref [] in
+  let i = ref 0 in
+  (try
+     while true do
+       let _mr, pos = Re_compat.search_forward re src !i in
+       let path = Re_compat.matched_group _mr 1 src in
+       entries :=
+         { command = cmd; raw_path = String.trim path; position = pos }
+         :: !entries;
+       i := Re_compat.match_end _mr
+     done
+   with Not_found -> ());
+  List.rev !entries
+
+let extract_includes (src : string) : include_entry list =
+  let inputs = extract_with_re re_input "input" src in
+  let includes = extract_with_re re_include "include" src in
+  List.sort (fun a b -> compare a.position b.position) (inputs @ includes)
+
+let extract_includeonly (src : string) : string list =
+  try
+    let _mr, _ = Re_compat.search_forward re_includeonly src 0 in
+    let content = Re_compat.matched_group _mr 1 src in
+    List.map String.trim (String.split_on_char ',' content)
+  with Not_found -> []
+
+(* ── Resolution ──────────────────────────────────────────────────── *)
+
+let resolve_include ~(base_dir : string) (entry : include_entry) :
+    resolved_include =
+  let raw = entry.raw_path in
+  let candidates =
+    let full =
+      if Filename.is_relative raw then Filename.concat base_dir raw else raw
+    in
+    [ full; full ^ ".tex" ]
+  in
+  let resolved_path = List.find_opt Sys.file_exists candidates in
+  { entry; resolved_path }
+
+let resolve_all ~(base_dir : string) (entries : include_entry list) :
+    resolved_include list =
+  List.map (resolve_include ~base_dir) entries

--- a/latex-parse/src/include_resolver.mli
+++ b/latex-parse/src/include_resolver.mli
@@ -1,0 +1,25 @@
+(** Include resolver: parse and resolve [\input], [\include], [\includeonly]
+    from LaTeX source. *)
+
+type include_entry = {
+  command : string;  (** ["input"] or ["include"]. *)
+  raw_path : string;  (** Argument as written in source. *)
+  position : int;  (** Byte offset. *)
+}
+
+type resolved_include = {
+  entry : include_entry;
+  resolved_path : string option;  (** [None] = unresolved. *)
+}
+
+val extract_includes : string -> include_entry list
+(** Extract all [\input\{...\}] and [\include\{...\}] from source. *)
+
+val extract_includeonly : string -> string list
+(** Parse [\includeonly\{a,b,c\}] into a list of basenames. *)
+
+val resolve_include : base_dir:string -> include_entry -> resolved_include
+(** Resolve an include entry to an absolute path. Tries bare path, then with
+    [.tex] extension. *)
+
+val resolve_all : base_dir:string -> include_entry list -> resolved_include list

--- a/latex-parse/src/project_context.ml
+++ b/latex-parse/src/project_context.ml
@@ -1,0 +1,9 @@
+let _tbl : (int, Project_state.project_state) Hashtbl.t = Hashtbl.create 4
+
+let set (st : Project_state.project_state) : unit =
+  Hashtbl.replace _tbl (Thread.id (Thread.self ())) st
+
+let get () : Project_state.project_state option =
+  Hashtbl.find_opt _tbl (Thread.id (Thread.self ()))
+
+let clear () : unit = Hashtbl.remove _tbl (Thread.id (Thread.self ()))

--- a/latex-parse/src/project_context.mli
+++ b/latex-parse/src/project_context.mli
@@ -1,0 +1,5 @@
+(** Thread-local project state context. *)
+
+val set : Project_state.project_state -> unit
+val get : unit -> Project_state.project_state option
+val clear : unit -> unit

--- a/latex-parse/src/project_graph.ml
+++ b/latex-parse/src/project_graph.ml
@@ -1,0 +1,105 @@
+(* ══════════════════════════════════════════════════════════════════════
+   Project_graph — directed inclusion graph with cycle detection
+
+   Builds a graph of file inclusions starting from a root .tex file. Recursively
+   follows \input and \include, detects cycles via DFS with Gray/Black coloring.
+   Respects \includeonly from root file.
+   ══════════════════════════════════════════════════════════════════════ *)
+
+type edge = { src : string; dst : string; command : string }
+
+type project_graph = {
+  root : string;
+  files : string list;
+  edges : edge list;
+  cycles : string list list;
+  unresolved : (string * string) list;
+}
+
+(* ── Helpers ─────────────────────────────────────────────────────── *)
+
+let read_file path =
+  try
+    let ic = open_in path in
+    Fun.protect
+      ~finally:(fun () -> close_in ic)
+      (fun () ->
+        let n = in_channel_length ic in
+        really_input_string ic n)
+  with Sys_error _ -> ""
+
+let normalize_path path =
+  try Unix.realpath path with Unix.Unix_error _ -> path
+
+type color = White | Gray | Black
+
+(* ── Graph construction ──────────────────────────────────────────── *)
+
+let build ~(root : string) : project_graph =
+  let root = normalize_path root in
+  let color = Hashtbl.create 32 in
+  let edges = ref [] in
+  let topo = ref [] in
+  let cycles = ref [] in
+  let unresolved = ref [] in
+  let max_depth = 100 in
+  (* Parse includeonly from root *)
+  let root_src = read_file root in
+  let includeonly = Include_resolver.extract_includeonly root_src in
+  let includeonly_set =
+    if includeonly = [] then None
+    else
+      let tbl = Hashtbl.create 16 in
+      List.iter (fun name -> Hashtbl.replace tbl name ()) includeonly;
+      Some tbl
+  in
+  let is_allowed entry =
+    match includeonly_set with
+    | None -> true
+    | Some tbl ->
+        entry.Include_resolver.command = "input"
+        || Hashtbl.mem tbl
+             (Filename.chop_extension entry.Include_resolver.raw_path
+             |> Filename.basename)
+        || Hashtbl.mem tbl entry.Include_resolver.raw_path
+  in
+  let rec visit path depth =
+    if depth > max_depth then ()
+    else
+      let c =
+        match Hashtbl.find_opt color path with Some c -> c | None -> White
+      in
+      match c with
+      | Gray -> cycles := [ path ] :: !cycles
+      | Black -> ()
+      | White ->
+          Hashtbl.replace color path Gray;
+          let src = read_file path in
+          let dir = Filename.dirname path in
+          let entries = Include_resolver.extract_includes src in
+          let resolved = Include_resolver.resolve_all ~base_dir:dir entries in
+          List.iter
+            (fun (ri : Include_resolver.resolved_include) ->
+              if is_allowed ri.entry then
+                match ri.resolved_path with
+                | Some dst ->
+                    let dst = normalize_path dst in
+                    edges :=
+                      { src = path; dst; command = ri.entry.command } :: !edges;
+                    visit dst (depth + 1)
+                | None -> unresolved := (path, ri.entry.raw_path) :: !unresolved)
+            resolved;
+          Hashtbl.replace color path Black;
+          topo := path :: !topo
+  in
+  visit root 0;
+  {
+    root;
+    files = List.rev !topo;
+    edges = List.rev !edges;
+    cycles = !cycles;
+    unresolved = List.rev !unresolved;
+  }
+
+let is_acyclic (g : project_graph) : bool = g.cycles = []
+let file_count (g : project_graph) : int = List.length g.files

--- a/latex-parse/src/project_graph.mli
+++ b/latex-parse/src/project_graph.mli
@@ -1,0 +1,22 @@
+(** Project graph: directed inclusion graph with cycle detection. *)
+
+type edge = {
+  src : string;  (** Including file (absolute path). *)
+  dst : string;  (** Included file (absolute path). *)
+  command : string;  (** ["input"] or ["include"]. *)
+}
+
+type project_graph = {
+  root : string;
+  files : string list;  (** All reachable files in topological order. *)
+  edges : edge list;
+  cycles : string list list;  (** Cycle paths, if any. *)
+  unresolved : (string * string) list;  (** [(source_file, raw_path)]. *)
+}
+
+val build : root:string -> project_graph
+(** Build the inclusion graph starting from [root]. Recursively follows [\input]
+    and [\include], respects [\includeonly] from root file. *)
+
+val is_acyclic : project_graph -> bool
+val file_count : project_graph -> int

--- a/latex-parse/src/project_state.ml
+++ b/latex-parse/src/project_state.ml
@@ -1,0 +1,89 @@
+(* ══════════════════════════════════════════════════════════════════════
+   Project_state — per-file semantic analysis with global projection
+
+   Analyzes each file in a project graph via Semantic_state.analyze, then merges
+   label/ref tables to detect cross-file duplicates and undefined references.
+   ══════════════════════════════════════════════════════════════════════ *)
+
+type file_state = { path : string; sem : Semantic_state.semantic_state }
+
+type project_state = {
+  graph : Project_graph.project_graph;
+  file_states : file_state list;
+  global_labels : (string * string) list;
+  global_refs : (string * string) list;
+  cross_file_duplicates : (string * string list) list;
+  cross_file_undefined : (string * string) list;
+}
+
+let read_file path =
+  try
+    let ic = open_in path in
+    Fun.protect
+      ~finally:(fun () -> close_in ic)
+      (fun () ->
+        let n = in_channel_length ic in
+        really_input_string ic n)
+  with Sys_error _ -> ""
+
+let build (graph : Project_graph.project_graph) : project_state =
+  (* Analyze each file *)
+  let file_states =
+    List.map
+      (fun path ->
+        let src = read_file path in
+        let sem = Semantic_state.analyze src in
+        { path; sem })
+      graph.files
+  in
+  (* Collect global labels: (key, file) *)
+  let global_labels =
+    List.concat_map
+      (fun fs ->
+        List.map
+          (fun (l : Semantic_state.label_entry) -> (l.key, fs.path))
+          fs.sem.labels)
+      file_states
+  in
+  (* Collect global refs: (key, file) *)
+  let global_refs =
+    List.concat_map
+      (fun fs ->
+        List.map
+          (fun (r : Semantic_state.ref_entry) -> (r.key, fs.path))
+          fs.sem.refs)
+      file_states
+  in
+  (* Detect cross-file duplicate labels *)
+  let label_files = Hashtbl.create 64 in
+  List.iter
+    (fun (key, file) ->
+      let existing = try Hashtbl.find label_files key with Not_found -> [] in
+      if not (List.mem file existing) then
+        Hashtbl.replace label_files key (file :: existing))
+    global_labels;
+  let cross_file_duplicates =
+    Hashtbl.fold
+      (fun key files acc ->
+        if List.length files > 1 then (key, List.rev files) :: acc else acc)
+      label_files []
+    |> List.sort (fun (a, _) (b, _) -> String.compare a b)
+  in
+  (* Detect cross-file undefined refs *)
+  let label_set = Hashtbl.create 64 in
+  List.iter (fun (key, _) -> Hashtbl.replace label_set key ()) global_labels;
+  let cross_file_undefined =
+    List.filter_map
+      (fun (key, file) ->
+        if Hashtbl.mem label_set key then None else Some (key, file))
+      global_refs
+    |> List.sort_uniq (fun (a, _) (b, _) -> String.compare a b)
+  in
+  {
+    graph;
+    file_states;
+    global_labels;
+    global_refs;
+    cross_file_duplicates;
+    cross_file_undefined;
+  }

--- a/latex-parse/src/project_state.mli
+++ b/latex-parse/src/project_state.mli
@@ -1,0 +1,16 @@
+(** Project state: per-file semantic analysis with global projection. *)
+
+type file_state = { path : string; sem : Semantic_state.semantic_state }
+
+type project_state = {
+  graph : Project_graph.project_graph;
+  file_states : file_state list;
+  global_labels : (string * string) list;  (** [(key, defining_file)]. *)
+  global_refs : (string * string) list;  (** [(key, referencing_file)]. *)
+  cross_file_duplicates : (string * string list) list;  (** [(key, files)]. *)
+  cross_file_undefined : (string * string) list;
+      (** [(key, referencing_file)]. *)
+}
+
+val build : Project_graph.project_graph -> project_state
+(** Analyze all files in the graph, compute global label/ref projection. *)

--- a/latex-parse/src/test_include_resolver.ml
+++ b/latex-parse/src/test_include_resolver.ml
@@ -1,0 +1,112 @@
+(** Tests for include_resolver: parsing and path resolution. *)
+
+open Latex_parse_lib
+open Test_helpers
+
+let () =
+  run "extract \\input{file}" (fun tag ->
+      let src = "\\input{chapter1}" in
+      let entries = Include_resolver.extract_includes src in
+      expect (List.length entries = 1) (tag ^ ": 1 entry");
+      let e = List.hd entries in
+      expect (e.command = "input") (tag ^ ": command=input");
+      expect (e.raw_path = "chapter1") (tag ^ ": path=chapter1"));
+
+  run "extract \\include{file}" (fun tag ->
+      let src = "\\include{appendix}" in
+      let entries = Include_resolver.extract_includes src in
+      expect (List.length entries = 1) (tag ^ ": 1 entry");
+      expect ((List.hd entries).command = "include") (tag ^ ": command=include"));
+
+  run "extract multiple includes" (fun tag ->
+      let src = "\\input{a}\n\\include{b}\n\\input{c}" in
+      let entries = Include_resolver.extract_includes src in
+      expect (List.length entries = 3) (tag ^ ": 3 entries"));
+
+  run "extract preserves order" (fun tag ->
+      let src = "\\input{first}\n\\include{second}" in
+      let entries = Include_resolver.extract_includes src in
+      expect ((List.hd entries).raw_path = "first") (tag ^ ": first"));
+
+  run "extract empty source" (fun tag ->
+      let entries = Include_resolver.extract_includes "" in
+      expect (entries = []) (tag ^ ": empty"));
+
+  run "extract with spaces in braces" (fun tag ->
+      let src = "\\input{ chapter1 }" in
+      let entries = Include_resolver.extract_includes src in
+      expect (List.length entries = 1) (tag ^ ": 1 entry");
+      expect ((List.hd entries).raw_path = "chapter1") (tag ^ ": trimmed"));
+
+  run "extract_includeonly" (fun tag ->
+      let src = "\\includeonly{ch1,ch2,ch3}" in
+      let names = Include_resolver.extract_includeonly src in
+      expect (List.length names = 3) (tag ^ ": 3 names");
+      expect (List.hd names = "ch1") (tag ^ ": first=ch1"));
+
+  run "extract_includeonly empty" (fun tag ->
+      let names = Include_resolver.extract_includeonly "" in
+      expect (names = []) (tag ^ ": empty"));
+
+  run "resolve existing file" (fun tag ->
+      (* Use the corpus files we just created *)
+      let base = "../../corpora/multi_file" in
+      let entry =
+        {
+          Include_resolver.command = "input";
+          raw_path = "chapter1";
+          position = 0;
+        }
+      in
+      let ri = Include_resolver.resolve_include ~base_dir:base entry in
+      expect (ri.resolved_path <> None) (tag ^ ": resolved"));
+
+  run "resolve nonexistent file" (fun tag ->
+      let entry =
+        {
+          Include_resolver.command = "input";
+          raw_path = "nonexistent_xyz";
+          position = 0;
+        }
+      in
+      let ri = Include_resolver.resolve_include ~base_dir:"/tmp" entry in
+      expect (ri.resolved_path = None) (tag ^ ": unresolved"));
+
+  run "resolve with .tex extension" (fun tag ->
+      let base = "../../corpora/multi_file" in
+      let entry =
+        {
+          Include_resolver.command = "input";
+          raw_path = "shared";
+          position = 0;
+        }
+      in
+      let ri = Include_resolver.resolve_include ~base_dir:base entry in
+      expect (ri.resolved_path <> None) (tag ^ ": resolved via .tex"));
+
+  run "resolve_all multiple" (fun tag ->
+      let base = "../../corpora/multi_file" in
+      let entries =
+        [
+          {
+            Include_resolver.command = "input";
+            raw_path = "chapter1";
+            position = 0;
+          };
+          {
+            Include_resolver.command = "include";
+            raw_path = "nonexistent";
+            position = 20;
+          };
+        ]
+      in
+      let resolved = Include_resolver.resolve_all ~base_dir:base entries in
+      expect (List.length resolved = 2) (tag ^ ": 2 results");
+      expect
+        ((List.hd resolved).resolved_path <> None)
+        (tag ^ ": first resolved");
+      expect
+        ((List.nth resolved 1).resolved_path = None)
+        (tag ^ ": second unresolved"))
+
+let () = finalise "include-resolver"

--- a/latex-parse/src/test_project_graph.ml
+++ b/latex-parse/src/test_project_graph.ml
@@ -1,0 +1,57 @@
+(** Tests for project_graph: graph building and cycle detection. *)
+
+open Latex_parse_lib
+open Test_helpers
+
+let repo_root =
+  let exe_dir = Filename.dirname Sys.argv.(0) in
+  let candidates =
+    [ Filename.concat exe_dir "../.."; "."; Filename.concat exe_dir "../../.." ]
+  in
+  try
+    List.find
+      (fun d ->
+        Sys.file_exists (Filename.concat d "corpora/multi_file/main.tex"))
+      candidates
+  with Not_found -> "."
+
+let corpus p = Filename.concat repo_root ("corpora/multi_file/" ^ p)
+
+let () =
+  run "build graph from main.tex" (fun tag ->
+      let g = Project_graph.build ~root:(corpus "main.tex") in
+      expect (Project_graph.file_count g >= 4) (tag ^ ": >= 4 files");
+      expect (Project_graph.is_acyclic g) (tag ^ ": acyclic"));
+
+  run "root file is correct" (fun tag ->
+      let g = Project_graph.build ~root:(corpus "main.tex") in
+      expect (Filename.basename g.root = "main.tex") (tag ^ ": root=main.tex"));
+
+  run "edges exist" (fun tag ->
+      let g = Project_graph.build ~root:(corpus "main.tex") in
+      expect (List.length g.edges >= 3) (tag ^ ": >= 3 edges"));
+
+  run "shared.tex is reachable" (fun tag ->
+      let g = Project_graph.build ~root:(corpus "main.tex") in
+      let has_shared =
+        List.exists (fun f -> Filename.basename f = "shared.tex") g.files
+      in
+      expect has_shared (tag ^ ": shared.tex in files"));
+
+  run "cycle detection works" (fun tag ->
+      let g = Project_graph.build ~root:(corpus "cycle_a.tex") in
+      expect (not (Project_graph.is_acyclic g)) (tag ^ ": has cycle");
+      expect (g.cycles <> []) (tag ^ ": cycle path reported"));
+
+  run "single file graph" (fun tag ->
+      let g = Project_graph.build ~root:(corpus "shared.tex") in
+      expect (Project_graph.file_count g = 1) (tag ^ ": 1 file");
+      expect (Project_graph.is_acyclic g) (tag ^ ": acyclic"));
+
+  run "unresolved includes reported" (fun tag ->
+      let g = Project_graph.build ~root:(corpus "main.tex") in
+      (* main.tex includes chapter2 which has no further includes *)
+      (* All includes should resolve for the main corpus *)
+      expect (g.unresolved = []) (tag ^ ": no unresolved"))
+
+let () = finalise "project-graph"

--- a/latex-parse/src/test_project_state.ml
+++ b/latex-parse/src/test_project_state.ml
@@ -1,0 +1,92 @@
+(** Tests for project_state: per-file analysis and global projection. *)
+
+open Latex_parse_lib
+open Test_helpers
+
+let repo_root =
+  let exe_dir = Filename.dirname Sys.argv.(0) in
+  let candidates =
+    [ Filename.concat exe_dir "../.."; "."; Filename.concat exe_dir "../../.." ]
+  in
+  try
+    List.find
+      (fun d ->
+        Sys.file_exists (Filename.concat d "corpora/multi_file/main.tex"))
+      candidates
+  with Not_found -> "."
+
+let corpus p = Filename.concat repo_root ("corpora/multi_file/" ^ p)
+
+let () =
+  run "build project state from graph" (fun tag ->
+      let g = Project_graph.build ~root:(corpus "main.tex") in
+      let ps = Project_state.build g in
+      expect (List.length ps.file_states >= 4) (tag ^ ": >= 4 file states"));
+
+  run "global labels collected" (fun tag ->
+      let g = Project_graph.build ~root:(corpus "main.tex") in
+      let ps = Project_state.build g in
+      let label_keys = List.map fst ps.global_labels in
+      expect (List.mem "main:top" label_keys) (tag ^ ": main:top");
+      expect (List.mem "ch1:sec" label_keys) (tag ^ ": ch1:sec");
+      expect (List.mem "ch2:fig" label_keys) (tag ^ ": ch2:fig");
+      expect (List.mem "shared:eq" label_keys) (tag ^ ": shared:eq"));
+
+  run "global refs collected" (fun tag ->
+      let g = Project_graph.build ~root:(corpus "main.tex") in
+      let ps = Project_state.build g in
+      let ref_keys = List.map fst ps.global_refs in
+      expect (List.mem "ch1:sec" ref_keys) (tag ^ ": ch1:sec ref");
+      expect (List.mem "ch2:fig" ref_keys) (tag ^ ": ch2:fig ref"));
+
+  run "cross-file undefined ref detected" (fun tag ->
+      let g = Project_graph.build ~root:(corpus "main.tex") in
+      let ps = Project_state.build g in
+      let undef_keys = List.map fst ps.cross_file_undefined in
+      expect (List.mem "undefined:x" undef_keys) (tag ^ ": undefined:x"));
+
+  run "no false cross-file duplicates" (fun tag ->
+      let g = Project_graph.build ~root:(corpus "main.tex") in
+      let ps = Project_state.build g in
+      expect (ps.cross_file_duplicates = []) (tag ^ ": no duplicates"));
+
+  run "project context set/get/clear" (fun tag ->
+      let g = Project_graph.build ~root:(corpus "main.tex") in
+      let ps = Project_state.build g in
+      Project_context.set ps;
+      let has = Project_context.get () <> None in
+      Project_context.clear ();
+      let no = Project_context.get () = None in
+      expect has (tag ^ ": context set");
+      expect no (tag ^ ": context cleared"));
+
+  run "PRJ validators silent without context" (fun tag ->
+      Project_context.clear ();
+      let results = Validators.run_all "\\documentclass{article}" in
+      let has_prj =
+        List.exists
+          (fun (r : Validators.result) ->
+            String.length r.id >= 3 && String.sub r.id 0 3 = "PRJ")
+          results
+      in
+      expect (not has_prj) (tag ^ ": no PRJ in single-file mode"));
+
+  run "PRJ-003 fires with project context" (fun tag ->
+      let g = Project_graph.build ~root:(corpus "main.tex") in
+      let ps = Project_state.build g in
+      Project_context.set ps;
+      Fun.protect ~finally:Project_context.clear (fun () ->
+          (* Use unique source to avoid cache hit from previous test *)
+          let src =
+            "\\documentclass{article}\n% PRJ-003 test "
+            ^ string_of_int (Random.int 999999)
+          in
+          let results = Validators.run_all src in
+          let has_003 =
+            List.exists
+              (fun (r : Validators.result) -> r.id = "PRJ-003")
+              results
+          in
+          expect has_003 (tag ^ ": PRJ-003 fires")))
+
+let () = finalise "project-state"

--- a/latex-parse/src/validators.ml
+++ b/latex-parse/src/validators.ml
@@ -27,6 +27,7 @@ include Validators_l4_style
 include Validators_l3_file
 include Validators_l1
 include Validators_l1_expl3
+include Validators_project
 
 (* Combined ENC + CHAR + SPC + VERB + CJK + CMD + MATH + LOCALE + new TYPO
    rules *)
@@ -46,6 +47,7 @@ let rules_enc_char_spc : rule list =
   @ rules_l3_file
   @ rules_l1_expl3
   @ rules_user_macro
+  @ rules_project
 
 (* ── VPD-catalogue: all 80 rules with VPD pattern annotations ──────── *)
 (* This list enumerates every rule that has a corresponding entry in

--- a/latex-parse/src/validators_project.ml
+++ b/latex-parse/src/validators_project.ml
@@ -1,0 +1,116 @@
+(* ══════════════════════════════════════════════════════════════════════
+   Validators_project — PRJ-001 through PRJ-004
+
+   Project-level validators. Read from Project_context. Return None if no
+   project context is set (single-file mode).
+   ══════════════════════════════════════════════════════════════════════ *)
+
+open Validators_common
+
+(* PRJ-001: Cycle in include graph *)
+let r_prj_001 : rule =
+  let run _s =
+    match Project_context.get () with
+    | None -> None
+    | Some ps ->
+        let cycles = ps.graph.Project_graph.cycles in
+        if cycles <> [] then
+          let paths =
+            List.map (fun cycle -> String.concat " -> " cycle) cycles
+          in
+          Some
+            {
+              id = "PRJ-001";
+              severity = Error;
+              message =
+                Printf.sprintf "Cycle in include graph: %s"
+                  (String.concat "; " paths);
+              count = List.length cycles;
+            }
+        else None
+  in
+  mk_rule "PRJ-001" run
+
+(* PRJ-002: Unresolved \input/\include path *)
+let r_prj_002 : rule =
+  let run _s =
+    match Project_context.get () with
+    | None -> None
+    | Some ps ->
+        let unresolved = ps.graph.Project_graph.unresolved in
+        if unresolved <> [] then
+          let paths =
+            List.map
+              (fun (src, raw) ->
+                Printf.sprintf "%s: \\input{%s}" (Filename.basename src) raw)
+              unresolved
+          in
+          Some
+            {
+              id = "PRJ-002";
+              severity = Warning;
+              message =
+                Printf.sprintf "Unresolved include path(s): %s"
+                  (String.concat "; " paths);
+              count = List.length unresolved;
+            }
+        else None
+  in
+  mk_rule "PRJ-002" run
+
+(* PRJ-003: Cross-file undefined reference *)
+let r_prj_003 : rule =
+  let run _s =
+    match Project_context.get () with
+    | None -> None
+    | Some ps ->
+        let undef = ps.cross_file_undefined in
+        if undef <> [] then
+          let keys =
+            List.map
+              (fun (key, file) ->
+                Printf.sprintf "\\ref{%s} in %s" key (Filename.basename file))
+              undef
+          in
+          Some
+            {
+              id = "PRJ-003";
+              severity = Warning;
+              message =
+                Printf.sprintf "Cross-file undefined reference(s): %s"
+                  (String.concat "; " keys);
+              count = List.length undef;
+            }
+        else None
+  in
+  mk_rule "PRJ-003" run
+
+(* PRJ-004: Cross-file duplicate label *)
+let r_prj_004 : rule =
+  let run _s =
+    match Project_context.get () with
+    | None -> None
+    | Some ps ->
+        let dups = ps.cross_file_duplicates in
+        if dups <> [] then
+          let descs =
+            List.map
+              (fun (key, files) ->
+                Printf.sprintf "\\label{%s} in %s" key
+                  (String.concat ", " (List.map Filename.basename files)))
+              dups
+          in
+          Some
+            {
+              id = "PRJ-004";
+              severity = Warning;
+              message =
+                Printf.sprintf "Cross-file duplicate label(s): %s"
+                  (String.concat "; " descs);
+              count = List.length dups;
+            }
+        else None
+  in
+  mk_rule "PRJ-004" run
+
+let rules_project : rule list = [ r_prj_001; r_prj_002; r_prj_003; r_prj_004 ]


### PR DESCRIPTION
## Summary

Foundational multi-file infrastructure for LaTeX project analysis:

- `include_resolver.ml`: parse `\input`/`\include`/`\includeonly`, resolve paths with `.tex` extension probing
- `project_graph.ml`: directed inclusion graph with DFS cycle detection, `\includeonly` respect, depth-100 cap
- `project_state.ml`: per-file semantic analysis + global label/ref projection, cross-file duplicate/undefined detection
- `project_context.ml`: thread-local project state
- `validators_project.ml`: PRJ-001 (cycle), PRJ-002 (unresolved), PRJ-003 (undefined ref), PRJ-004 (dup label)
- Multi-file test corpus: 6 `.tex` files including a cycle pair

## Test plan

- [x] `[include-resolver] PASS 19 cases`
- [x] `[project-graph] PASS 10 cases`
- [x] `[project-state] PASS 13 cases`
- [x] Full suite exit 0, zero regressions
- [x] PRJ validators silent in single-file mode
- [ ] CI green