### PR TITLE
fix(v26): wire WS4 invalidation + WS5 partial context into validators.ml

### DIFF
--- a/latex-parse/src/test_partial_cst.ml
+++ b/latex-parse/src/test_partial_cst.ml
@@ -135,38 +135,20 @@ let () =
       expect has (tag ^ ": set");
       expect no (tag ^ ": cleared"));
 
-  (* ── PRT validator tests ───────────────────────────────────────── *)
-  run "PRT-001 fires on Broken document" (fun tag ->
-      let pd =
-        Partial_cst.classify "broken {{" [ ("Unclosed brace", mk_loc 7) ]
+  (* ── PRT validator tests (run_all now auto-sets partial context) ── *)
+  run "PRT-001 fires on source with mismatched env" (fun tag ->
+      let src =
+        "\\begin{itemize}\n\\end{enumerate}\n"
+        ^ string_of_int (Random.int 999999)
       in
-      Partial_context.set pd;
-      Fun.protect ~finally:Partial_context.clear (fun () ->
-          let src = "broken {{ " ^ string_of_int (Random.int 999999) in
-          let results = Validators.run_all src in
-          let has_prt =
-            List.exists
-              (fun (r : Validators.result) -> r.id = "PRT-001")
-              results
-          in
-          expect has_prt (tag ^ ": PRT-001 fires")));
+      let results = Validators.run_all src in
+      let has_prt =
+        List.exists (fun (r : Validators.result) -> r.id = "PRT-001") results
+      in
+      expect has_prt (tag ^ ": PRT-001 fires"));
 
-  run "PRT-001 silent on Complete document" (fun tag ->
-      let pd = Partial_cst.classify "good document" [] in
-      Partial_context.set pd;
-      Fun.protect ~finally:Partial_context.clear (fun () ->
-          let src = "good document " ^ string_of_int (Random.int 999999) in
-          let results = Validators.run_all src in
-          let has_prt =
-            List.exists
-              (fun (r : Validators.result) -> r.id = "PRT-001")
-              results
-          in
-          expect (not has_prt) (tag ^ ": PRT-001 silent")));
-
-  run "PRT-001 silent without context" (fun tag ->
-      Partial_context.clear ();
-      let src = "no context " ^ string_of_int (Random.int 999999) in
+  run "PRT-001 silent on clean source" (fun tag ->
+      let src = "Hello world. " ^ string_of_int (Random.int 999999) in
       let results = Validators.run_all src in
       let has_prt =
         List.exists (fun (r : Validators.result) -> r.id = "PRT-001") results

--- a/latex-parse/src/validators.ml
+++ b/latex-parse/src/validators.ml
@@ -233,6 +233,10 @@ let run_all (src : string) : result list =
         (* Build semantic state for L3 validators (spec W53-57) *)
         let sem = Semantic_state.analyze src in
         Semantic_state.set_state sem;
+        (* Build partial document state for PRT validators (WS5) *)
+        let _parse_nodes, parse_errors = Parser_l2.parse_located src in
+        let pdoc = Partial_cst.classify src parse_errors in
+        Partial_context.set pdoc;
         (* Publish events to bus (spec W62) — subscribers consume deltas *)
         let bus = Event_bus.global () in
         (* Register one-shot subscribers for this run *)
@@ -275,6 +279,7 @@ let run_all (src : string) : result list =
               go acc rs
         in
         let results = go [] rules in
+        Partial_context.clear ();
         Cache_key.store cache cache_key results;
         results
 
@@ -748,7 +753,7 @@ let run_all_incremental ?(prev_src : string option) (src : string) : result list
   let dirty_indices =
     match _resolve_old_snap prev_src with
     | None -> List.init (Array.length new_snap.chunks) Fun.id
-    | Some os -> Chunk_store.diff_snapshots os new_snap
+    | Some os -> Invalidation.compute ~old_snap:os ~new_snap
   in
   _prev_snapshot := Some new_snap;
   (* Per-chunk rules: only re-run dirty chunks *)
@@ -799,7 +804,7 @@ let run_all_scheduled ?(edit_pos = 0) ?(prev_src : string option) (src : string)
   let dirty_indices =
     match _resolve_old_snap prev_src with
     | None -> List.init (Array.length new_snap.chunks) Fun.id
-    | Some os -> Chunk_store.diff_snapshots os new_snap
+    | Some os -> Invalidation.compute ~old_snap:os ~new_snap
   in
   _prev_snapshot := Some new_snap;
   let rules = get_rules () in


### PR DESCRIPTION
## Summary

Fixes two integration gaps found during deep audit:

**WS4**: `Invalidation.compute` was never called from production code — `run_all_incremental` and `run_all_scheduled` still used `Chunk_store.diff_snapshots` directly. Now both use `Invalidation.compute` which combines syntactic diff + semantic edge propagation.

**WS5**: `Partial_cst.classify` and `Partial_context.set` were never called from `run_all` — PRT-001/002 validators always returned None in production. Now `run_all` parses the source via `Parser_l2.parse_located`, classifies errors into trust zones, and sets partial context automatically.

## Test plan

- [x] `[partial-cst] PASS 25 cases` (updated to test auto-wiring)
- [x] `[incremental-integration] PASS 9 cases`
- [x] `[invalidation] PASS 17 cases`
- [x] Full suite exit 0, zero regressions
- [ ] CI green