### PR TITLE
chore: gitignore local artefacts + release.sh argument fix (unblocks v26.1.0 tag)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,12 @@ site/
 # ML checkpoints (reproducible from pipeline; too large for git)
 ml/checkpoints_v2/*.pt
 ml/checkpoints/*.pt
+
+# Claude Code local state (conversation transcripts, worktrees, etc.)
+.claude/
+
+# Ad-hoc local working notes (never committed)
+PROJECT_BRIEFING_FOR_EXPERT.md
+
+# Reference archive of earlier v25/v26 planning (local only)
+specs/latex_perf_v25_repo_with_v26_v27_planning.zip

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -38,7 +38,7 @@ python3 scripts/tools/generate_project_facts.py > /dev/null
 echo "[release] Regenerating specs/rules/rule_contracts.{yaml,json}..."
 python3 scripts/tools/generate_rule_contracts.py 2>&1 | tail -3
 echo "[release] Running drift gates..."
-python3 scripts/tools/check_repo_facts.py > /dev/null
+python3 scripts/tools/check_repo_facts.py --facts governance/project_facts.yaml --repo . > /dev/null
 python3 scripts/tools/check_rule_contracts.py > /dev/null
 python3 scripts/validate_catalogue.py > /dev/null
 echo "[release] Governance + contracts in sync ✓"


### PR DESCRIPTION
## Summary

Two small blockers for v26.1.0 tag discovered during \`release.sh 26.1.0 --dry-run\`:

### Blocker 1 — clean-tree check rejects untracked local files
release.sh's P1.3 clean-tree pre-flight uses \`git status --porcelain\` which includes \`??\` untracked lines. Three recurring local artefacts show up on dev machines:
- \`.claude/\` — Claude Code's local state (285MB)
- \`PROJECT_BRIEFING_FOR_EXPERT.md\` — personal working note
- \`specs/latex_perf_v25_repo_with_v26_v27_planning.zip\` — reference archive

Added to \`.gitignore\`. Additive, harmless.

### Blocker 2 — \`check_repo_facts.py\` called without required args
release.sh invoked \`python3 scripts/tools/check_repo_facts.py > /dev/null\` but the script requires \`--facts <path> --repo <dir>\`. Dry-run failed at the governance-regen step. Fixed to pass \`--facts governance/project_facts.yaml --repo .\`.

## Test plan
- [x] \`git status --porcelain\` clean on local dev machine
- [x] \`bash scripts/release.sh 26.1.0 --dry-run\` — end-to-end PASS
  - Working tree clean ✓
  - Governance regen + drift gates ✓
  - dune build + runtest ✓
  - Zero admits ✓
  - "All checks passed ✓"

Once merged, v26.1.0 can be tagged cleanly.