### PR TITLE
fix(release.sh): handle no-op version-bump commit gracefully

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -95,14 +95,23 @@ if [[ "$DRY_RUN" != "--dry-run" ]]; then
   echo "[release] Pre-release gates ✓"
 fi
 
-# 7. Commit version bump
+# 7. Commit version bump (if anything actually changed)
+# If dune-project + governance + contracts are already at ${VERSION} (e.g.
+# a prior release.sh run completed the bump but failed before tagging, OR
+# someone pre-bumped), `git add` stages nothing and `git commit` fails
+# with "nothing to commit". Under `set -euo pipefail` the script would
+# abort BEFORE the tag step, leaving the repo un-tagged. Guard against it.
 echo "[release] Committing version bump..."
 git add dune-project latex-perfectionist.opam latex-parse/latex_parse.opam \
   governance/project_facts.yaml specs/rules/rule_contracts.yaml \
   specs/rules/rule_contracts.json
-git commit -m "chore: bump version to ${VERSION}"
+if git diff --cached --quiet; then
+  echo "[release] No staged changes (already at ${VERSION}); skipping commit."
+else
+  git commit -m "chore: bump version to ${VERSION}"
+fi
 
-# 8. Tag
+# 8. Tag (unconditional — works whether #7 committed or skipped)
 echo "[release] Tagging ${TAG}..."
 git tag -a "${TAG}" -m "Release ${TAG}"
 


### PR DESCRIPTION
## Problem

During v26.1.0 release, \`release.sh\` failed silently because \`dune-project\` already had version \`26.1.0\` from prior work. The sequence:

1. \`git add dune-project ...\` — stages nothing new.
2. \`git commit -m "..."\` — fails with \"nothing to commit\".
3. \`set -euo pipefail\` aborts the script.
4. **Tag step never runs.** v26.1.0 had to be tagged manually.

## Fix

Guard the commit with \`git diff --cached --quiet\`. If nothing is staged, skip the commit and proceed to the tag step. Idempotent.

## Test plan
- [x] Verified locally: running \`release.sh\` on an already-bumped tree skips commit, creates tag.
- [x] No change in behaviour when there's a real bump to commit.