### PR TITLE
docs(v26.2): PR A0 — plan + sub-docs + architectural decisions

### DIFF
--- a/docs/v26_2/COMMUNICATION_PLAN.md
+++ b/docs/v26_2/COMMUNICATION_PLAN.md
@@ -1,0 +1,106 @@
+# v26.2 communication plan
+
+## Audience channels
+
+- **GitHub Releases page** — primary announcement surface.
+- **GitHub Discussions** (if enabled) — ongoing Q&A.
+- **CHANGELOG.md** — authoritative record.
+- **Repo README** — version recommendation.
+
+No mailing list, no Discord, no Twitter — this is a library/CLI, not a
+product.
+
+## Release-stage template
+
+Each alpha or full tag publishes a Release page with the following
+structure:
+
+```markdown
+# v26.2.0-alpha1 — <YYYY-MM-DD>
+
+⚠️ **Pre-release.** For testing the compile-guarantee pipeline.
+Not for production use. Known incomplete: CST + rewrite engine
+(lands in alpha2).
+
+## Highlights
+- `latex-parse/src/compile_contract.ml` — pre-compile readiness predicate
+- T0–T5 theorem wrappers; T6/T7 hypothesis-parametric in CompileProgress.v
+
+## Breaking changes
+None (strictly additive per plan §8).
+
+## Try it
+```bash
+opam install latex_parse.26.2.0-alpha1
+latex_parse_cli --compile-check path/to/main.tex
+```
+
+## Known issues
+- [link to open issues tagged `v26.2.0-alpha1`]
+
+## Full changelog
+[see CHANGELOG.md for the [v26.2.0-alpha1] section]
+```
+
+## Template for v26.2.0 final
+
+```markdown
+# v26.2.0 — <YYYY-MM-DD>
+
+## Summary
+Ships partial-parsing substrate, lossless CST, rewrite engine v1, and
+the compilation-guarantee theorem stack T0–T7 (hypothesis-parametric).
+Strictly additive over v26.1 — no breaking changes.
+
+## For users of v26.1.0
+- Upgrade path: `opam update && opam upgrade latex_parse`. No code
+  changes required.
+- New CLI flags: `--apply-fixes`, `--compile-check`.
+- New library modules: see `docs/MIGRATION_v26.1_to_v26.2.md`.
+
+## For library consumers
+- `Validators.result` gains `fix : Cst_edit.edit option`. Existing
+  pattern matches keep working (field is optional).
+- New modules: `Cst`, `Cst_edit`, `Rewrite_engine`, `Project_model`,
+  `Build_graph`, `Aux_state`, `Compile_contract`, `Stable_spans`.
+
+## Verification
+- 13 CI gates green on tag commit.
+- Differential test vs v26.1.0 on corpus: 0 unexpected diffs.
+- All existing tests PASS.
+
+## Artefacts
+- Docker image: `ghcr.io/.../latex-perfectionist:26.2.0`
+- opam: `opam install latex_parse.26.2.0`
+- SBOM: attached to this release as sbom-cyclonedx.json
+- Cosign signature: `sigstore verify ...`
+
+## Credits
+[contributor list]
+```
+
+## Alpha user expectations
+
+Explicitly document:
+- **No SLA.** Alpha users accept the tool may break between alpha1 and
+  alpha2.
+- **Feedback welcomed** via GitHub Issues tagged `v26.2-alpha-feedback`.
+- **Bug reports** to the regular Issues tracker. High-severity alpha
+  bugs trigger Scenario 1 in ROLLBACK_DRILL.md.
+- **Upgrade path.** Alpha users should pin the alpha version until
+  the final v26.2.0 ships; then upgrade via `opam upgrade`.
+
+## Post-tag checks (for whoever publishes)
+
+Within 10 min of `git push origin v26.2.0`:
+1. `gh run watch` until `release.yml` completes.
+2. Visit the Releases page and confirm artefacts attached.
+3. Try `docker pull ghcr.io/.../latex-perfectionist:26.2.0` from a
+   clean machine. If it fails, Scenario 3 in ROLLBACK_DRILL.md.
+4. Post a Discussions thread (if enabled) linking the release.
+
+## Silence policy
+
+Between alphas and the final, no external communication is required.
+Internal development continues on `main`. Alpha testers read
+CHANGELOG.md working sections if they care.

--- a/docs/v26_2/CORPUS_LICENSING.md
+++ b/docs/v26_2/CORPUS_LICENSING.md
@@ -1,0 +1,72 @@
+# Corpus licensing + curation (v26.2)
+
+v26.2 introduces 3 new corpus directories; this doc governs their
+licensing and curation.
+
+## New corpora
+
+- `corpora/compile_contract/` — 5+ sample projects for PR A2 testing
+  (simple, multi-file, with-bib, with-missing-ref, with-cycle)
+- `corpora/roundtrip/` — 100+ files for CST round-trip testing (PR B2)
+- `corpora/regression/` — subset of existing corpus for v26.1 vs v26.2
+  differential testing (PR C)
+
+## Licensing policy
+
+All new corpus files MUST be one of:
+1. **Synthetic** — authored by us specifically for testing, no external
+   source. Commit with an `AUTHORS` comment at top identifying this.
+2. **Public-domain LaTeX examples** — classical distribution (e.g.
+   TeX sample documents, TUGboat articles pre-1990, anything marked
+   Public Domain). Credit the original author.
+3. **Permissively-licensed** (MIT, Apache, CC-BY, CC-BY-SA) — add
+   `.LICENSE` next to the file.
+4. **Author-donated** — explicit grant from a user/academic. Preserve
+   their email in the corpus file's header and an entry in
+   `corpora/AUTHORS.md`.
+
+**NEVER include:**
+- GPL'd LaTeX files (incompatible with our MIT licensing).
+- Third-party papers without the author's explicit permission.
+- Files scraped from arXiv / journal websites without verified license.
+
+## Curation process
+
+1. Author / identify source.
+2. Verify licensing.
+3. Scrub sensitive content (author names if donor requested, institution
+   details if flagged).
+4. Ensure file is in scope of current CST subset (§2.6 of plan). If
+   out of scope, file it under `corpora/out_of_scope/` with a note.
+5. Commit with a descriptive path (`corpora/roundtrip/math_heavy.tex`
+   not `corpora/roundtrip/file_042.tex`).
+6. Add to corresponding test's input list.
+
+## Corpus manifest
+
+`corpora/MANIFEST.md` lists every file with its licensing, source,
+and purpose. PR A2 / B2 / C each append relevant entries.
+
+Template row:
+```markdown
+## corpora/roundtrip/math_heavy.tex
+- License: CC-BY 4.0
+- Source: TUGboat 2012, issue 3, article by Jane Doe (donated 2026-04-15)
+- Purpose: exercises math environments (align, gather, matrix)
+- In subset: yes
+```
+
+## Fixture hygiene
+
+- Keep files under 100KB each (corpus test runtime budget).
+- Total corpus under 20MB (cloneable on slow connections).
+- UTF-8 encoding; no BOMs; no mixed encodings.
+- Normalize line endings to LF at commit time (`.gitattributes` enforces).
+
+## Auditing
+
+- PR A2: verify new files have MANIFEST entries.
+- PR B2: verify new files are in CST subset OR flagged out-of-scope.
+- PR C: verify differential-test corpus is a strict subset of
+  `corpora/regression/` (no new files between v26.1 and v26.2 corpora
+  for this specific comparison).

--- a/docs/v26_2/FIX_STYLE_GUIDE.md
+++ b/docs/v26_2/FIX_STYLE_GUIDE.md
@@ -1,0 +1,84 @@
+# Fix-suggestion style guide (v26.2)
+
+As rule authors add `fix : Cst_edit.edit option` suggestions, consistency
+matters: users see these in validator output and potentially `--apply-fixes`
+their source. Inconsistent style erodes trust.
+
+## Canonical patterns
+
+### Replacement fixes
+- Use minimum span: replace only the problem span, not surrounding context.
+- Preserve capitalization / punctuation outside the span.
+- Prefer Unicode characters that render correctly in both pdflatex + UTF-8
+  input mode (XeLaTeX) OR that have `\tex` escapes that work in both.
+
+### Insertion fixes
+- Insert at a semantically meaningful span boundary (start of env, after
+  `\documentclass`), not arbitrary offsets.
+- Include a trailing newline if inserting a line-shaped construct
+  (`\documentclass{article}\n`).
+
+### Deletion fixes
+- Delete minimal span. If the problem is `  ,` (space before comma),
+  delete the space, not the comma.
+
+## Examples (exemplar rules that ship in v26.2 B3)
+
+**STRUCT-001: Missing \documentclass**
+```ocaml
+fix = Some (Cst_edit.Insert {
+  at = top_of_source;
+  text = "\\documentclass{article}\n";
+})
+```
+
+**TYPO-002: `--` should be `–` (en dash)**
+```ocaml
+fix = Some (Cst_edit.Replace {
+  span = span_of_match;    (* the `--` itself *)
+  text = "–";
+})
+```
+
+**TYPO-003: `---` should be `—` (em dash)**
+```ocaml
+fix = Some (Cst_edit.Replace {
+  span = span_of_match;
+  text = "—";
+})
+```
+
+## Anti-patterns (reject in review)
+
+- **Overly aggressive span.** Don't replace a whole sentence to fix one
+  character.
+- **Ambiguous replacement text.** `text = "corrected"` without explanation
+  leaves the user confused.
+- **Multi-location fixes in one edit.** One `edit` per problem span;
+  composite rewrites use multiple `edits`.
+- **Fixes that change semantics subtly.** E.g., "--" vs "\," changes
+  math vs text interpretation. Don't automate ambiguous cases.
+- **Localized/translated fix text.** Always English in v26.2; future
+  versions may add locale.
+
+## Review checklist for new fix-suggesting rules
+
+- [ ] Fix has minimal span.
+- [ ] Replacement text renders correctly in pdflatex + xelatex + lualatex
+  (or comment lists which engines NOT supported).
+- [ ] `Cst_edit.edit` constructor matches the user's intent (Insert vs
+  Replace vs Delete).
+- [ ] Unit test verifies the fix applies without corrupting surrounding
+  context.
+- [ ] E2E test (`test_rule_fix_integration.ml`) includes this rule.
+- [ ] CHANGELOG mentions the new fix in the rule's row.
+
+## When NOT to provide a `fix`
+
+Not every rule should suggest a fix:
+- **Ambiguous cases** (user needs context): no fix.
+- **Style rules** (Class D) with taste-dependent outcomes: no fix.
+- **Rules that fire on multi-span patterns** where single-span edit
+  can't express the correction: no fix.
+
+Leaving `fix = None` is always acceptable.

--- a/docs/v26_2/ROLLBACK_DRILL.md
+++ b/docs/v26_2/ROLLBACK_DRILL.md
@@ -1,0 +1,124 @@
+# v26.2 rollback drill
+
+Concrete procedures for two failure modes: a bad v26.2.0 tag and
+`--apply-fixes` source corruption.
+
+## Scenario 1 — v26.2.0 tag reveals critical bug (post-publish)
+
+**Assumption:** a user reports that v26.2.0 breaks their document
+within 24h of tag.
+
+### Step 1 — triage (30 min)
+- Reproduce from a clean checkout of `v26.2.0`.
+- Classify: blocker (corruption, crash on valid input, severe perf) vs
+  non-blocker (edge case, documentation, minor UX).
+- Non-blocker → document, roll into v26.2.1 batch.
+- Blocker → Step 2.
+
+### Step 2 — hotfix branch (1 hour)
+```bash
+git checkout v26.2.0
+git checkout -b v26.2.1-hotfix
+# minimal fix, targeted at the reproducer
+```
+
+### Step 3 — validate (1 hour)
+- Run `pre_release_check.py` (must pass).
+- Run `test_l2_gate` (perf ratchet).
+- Add regression test that reproduces the user's failure and now passes.
+- Run differential test against v26.1.0 and v26.2.0 on corpus — expect
+  identical output except at the reproducer input.
+
+### Step 4 — ship v26.2.1 (30 min)
+```bash
+bash scripts/release.sh 26.2.1 --dry-run
+bash scripts/release.sh 26.2.1
+git push origin v26.2.1-hotfix:main   # or a hotfix PR merged
+git push origin v26.2.1
+```
+
+### Step 5 — announce
+- Release notes published.
+- If communication plan in effect, post alpha-channel notice.
+- Update `README.md` recommended version.
+
+**Total time budget:** 3 hours from reporter → published v26.2.1.
+
+**Gotcha:** `release.sh` requires clean tree. Commit the hotfix first.
+
+## Scenario 2 — `--apply-fixes` corrupts user source
+
+**Assumption:** user runs `validators_cli --apply-fixes doc.tex`, the
+tool writes a modified file, and later the user discovers the rewrite
+was wrong.
+
+### v26.2 must ship with these guards:
+
+1. **Backup before write.** Every `--apply-fixes` invocation writes
+   `doc.tex.bak-<timestamp>` before modifying `doc.tex`. CLI prints
+   the backup path.
+
+2. **Atomic per-file writes.** Write to `doc.tex.tmp`, fsync, rename
+   over `doc.tex`. No partial writes on crash.
+
+3. **Multi-file projects: all-or-nothing.** If `--project root.tex`
+   produces fixes for 5 files, either all 5 write successfully or zero
+   do. Use a staging directory + atomic rename pattern.
+
+4. **Refuse on conflict.** If two rules produce overlapping
+   `Cst_edit.edit` on the same span, `--apply-fixes` fails with a
+   clear message listing the conflict. User must `--apply-fixes` a
+   subset. No silent merge.
+
+5. **Refuse on parse failure.** After applying fixes, re-parse the
+   result. If it fails to parse where the original did, abort and
+   restore from backup. No corruption reaches disk.
+
+### Restore procedure (user-driven)
+
+```bash
+# User sees broken output, wants to revert:
+mv doc.tex.bak-<timestamp> doc.tex
+# Or for multi-file:
+for f in *.tex.bak-<timestamp>; do mv "$f" "${f%.bak-*}"; done
+```
+
+Document this in `docs/MIGRATION_v26.1_to_v26.2.md`.
+
+## Scenario 3 — release.yml fails silently
+
+**Assumption:** `scripts/release.sh 26.2.0` runs to completion locally,
+git tag pushed, but GitHub Actions `release.yml` fails to publish
+artefacts (SBOM, Cosign, Docker push).
+
+### Detection (MUST check within 10 min of push)
+```bash
+gh run watch --exit-status
+# If red: release workflow failed.
+```
+
+### Recovery
+
+Options in order of preference:
+1. **Rerun release.yml** (GitHub UI → rerun failed jobs). Usually
+   transient.
+2. **Manually publish artefacts** (via `scripts/manual_release.sh`, to
+   be created as part of A0 if not already in tree).
+3. **Abandon v26.2.0 and cut v26.2.1 immediately** (if the workflow
+   failure is structural, not infrastructure).
+
+### Prevention (PR A0 task)
+- Add a `.github/workflows/release.yml` dry-run step that catches
+  credential or config errors BEFORE tag push.
+- Add a smoke test: after release.yml success, try `docker pull
+  ghcr.io/.../latex-perfectionist:26.2.0` — fail the post-release
+  check if the image isn't pullable.
+
+## When to drill
+
+- Before v26.2.0 tag: execute Scenario 3 steps with a throwaway tag
+  `v26.2.0-drill` on a fork.
+- Before v26.2.0-alpha1 tag: execute Scenario 1 steps with a
+  hypothetical bug to time the 3-hour budget.
+
+**Drill is a prerequisite in PR C** acceptance criteria.

--- a/docs/v26_2/USER_PERSONAS.md
+++ b/docs/v26_2/USER_PERSONAS.md
@@ -1,0 +1,54 @@
+# v26.2 user personas
+
+Decisions about new features (`--apply-fixes`, CST API, compile_contract)
+hinge on who's using the tool. Three personas anchor scope:
+
+## P1 — Academic researcher
+
+- Writes ~20-page papers in LaTeX, re-runs latexmk on save.
+- Cares: compile errors caught early; pretty output.
+- Doesn't care: CLI flags beyond `--apply-fixes`; CST API; fix customisation.
+- Runs on: laptop; no CI.
+- **v26.2 wins:** `--apply-fixes` auto-fixes typography, compile_contract
+  tells them "missing reference, no rerun needed" before latexmk.
+- **Scope call:** UX priority for CLI output; no API-facing demands.
+
+## P2 — Industrial technical writer
+
+- Multi-file documentation trees; builds into CI pipeline.
+- Cares: reproducible builds; zero false positives; sensible exit codes.
+- Doesn't care: Coq proofs; formal guarantees.
+- Runs on: Docker CI runners; Jenkins or GitHub Actions.
+- **v26.2 wins:** compile_contract gives CI a pre-compile predicate
+  (fail-fast without running latexmk); differential-test gate prevents
+  silent regressions.
+- **Scope call:** CLI stability matters more than Coq; docker image
+  continuity required.
+
+## P3 — Compiler/linting researcher integrating our library
+
+- Embeds `latex_parse_lib` in their own tool.
+- Cares: API stability; typed public interface; CST for structural analysis.
+- Doesn't care: CLI UX.
+- Runs on: their own OCaml project.
+- **v26.2 wins:** CST with stable IDs makes structural analysis tractable;
+  rewrite engine is a building block for their own pass.
+- **Scope call:** strict API stability commitment (§8 of plan) matters most.
+
+## Non-personas (out of v26.2 scope)
+
+- Real-time editor plugins (v27 WS10 collaboration — IDE integration).
+- Cloud-hosted service with SLA (v27 WS11 platform).
+- Non-LaTeX ingesters (v27 WS12 extension plane).
+
+## What this implies for contested design decisions
+
+- `--apply-fixes-for RULE-ID` granularity: deferred (P1/P2 want all-or-nothing;
+  P3 will wrap the library directly).
+- CST streaming API: deferred (P3 use cases we've heard work fine with
+  whole-document CST; streaming is v27 if demanded).
+- Fix-suggestion localization: deferred (P1 academic writers are
+  English-speaking majority; v27 if international adoption grows).
+- Undo safety for `--apply-fixes`: **MUST ship in v26.2**. P2 CI users
+  cannot tolerate silent source corruption. See
+  [ROLLBACK_DRILL.md](ROLLBACK_DRILL.md).

--- a/docs/v26_2/adr/ADR-001-core-directory-alias.md
+++ b/docs/v26_2/adr/ADR-001-core-directory-alias.md
@@ -1,0 +1,40 @@
+# ADR-001: core/l2_parser/ alias pattern instead of directory migration
+
+- **Status:** Accepted (2026-04-22)
+- **Context owner:** v26.2 architectural decisions (plan §2.1)
+
+## Context
+
+Memo `REPO_EXACT_MISSING_ARCHITECTURE_MEMO_V26_V27.md` §§5.5, 16.3 prescribes
+new modules under `core/l2_parser/` (e.g. `core/l2_parser/cst.ml`,
+`core/l2_parser/partial_cst.ml`). The repo does not have a `core/`
+directory — every OCaml module lives under `latex-parse/src/`. We've
+already aliased three memo-prescribed paths (P1.6 `macro_subset.ml`,
+P1.7 `invalidation_engine.ml` and `log_context.ml`).
+
+## Decision
+
+**Ship v26.2 modules under `latex-parse/src/` with thin alias modules at
+memo-prescribed paths** (e.g. `core/l2_parser/cst.ml` re-exports
+`Latex_parse_lib.Cst`). Continue the pattern established in P1.6/P1.7.
+
+## Alternatives considered
+
+- **Option A: Migrate to `core/l2_parser/` as a real dune library.**
+  Would require splitting `latex_parse_lib` into multiple libraries,
+  editing every dune file, and likely breaking downstream consumers.
+  Estimated 1 full day of build-system work for zero user-visible gain.
+  Rejected.
+- **Option B: Ignore the memo path, don't alias.**
+  Leaves `check_memo_files.py` failing on memo-prescribed paths. Rejected
+  — drift is unacceptable per audit discipline.
+
+## Consequences
+
+- Memo paths remain "canonical prose, aliased runtime". Future readers
+  see both the memo ref and the real path side-by-side.
+- `check_memo_files.py` PATH_ALIASES grows by ~4 entries in v26.2.
+- Technical debt flag: if v27 decides to reorganize the source tree
+  (e.g. for `core/project/`, `core/l1_expander/`, etc.), this alias
+  pattern becomes part of the migration cleanup scope.
+- No impact on v26.2 user-facing API.

--- a/docs/v26_2/adr/ADR-002-aux-state-vs-build-artifact-state.md
+++ b/docs/v26_2/adr/ADR-002-aux-state-vs-build-artifact-state.md
@@ -1,0 +1,40 @@
+# ADR-002: aux_state and build_artifact_state are distinct modules
+
+- **Status:** Accepted (2026-04-22)
+- **Context owner:** v26.2 architectural decisions (plan §2.2)
+
+## Context
+
+Memo §5.5 prescribes a new `aux_state.{ml,mli}` for the compilation
+guarantee stack. The repo already has `build_artifact_state.{ml,mli}`
+shipped in v26.0. Superficially similar names — are they the same thing?
+
+## Decision
+
+**They are different. Both ship, with distinct responsibilities.**
+
+- `build_artifact_state.ml` (v26.0, ~30 LOC) — thread-local wrapper
+  around `Build_profile.t`; holds a *parsed compile-log context*
+  (produced by `Log_parser` and `Log_context`).
+- `aux_state.ml` (v26.2, NEW, ~300+ LOC estimated) — reads and parses
+  the `.aux` FILE on disk; builds a cross-reference table (`\newlabel`,
+  `\bibcite`, counters, `\@LN`, etc.). pdflatex-only for v26.2.
+
+## Alternatives considered
+
+- **Option A: Extend `build_artifact_state` to also parse .aux.**
+  Mixes two very different concerns (runtime wrapper vs. file parser)
+  and makes the module non-cohesive. Rejected.
+- **Option B: Rename `build_artifact_state` → `aux_state` and extend.**
+  Breaking change to a v26.0-shipped module; would violate API stability.
+  Rejected.
+
+## Consequences
+
+- Two similarly-named modules; doc `docs/FOUR_GRAPHS.md` (created in A1)
+  documents the distinction alongside the graph-module disambiguation.
+- `aux_state.ml` is multi-day work (~1.5 days in A2 estimate).
+  Explicit scope: pdflatex-only; `.toc` / `.lof` / `.lot` / `.idx` /
+  `.glg` out of scope for v26.2.
+- `Compile_contract.ml` (new in A2) uses BOTH modules: `aux_state`
+  for .aux content, `build_artifact_state` for log context.

--- a/docs/v26_2/adr/ADR-003-four-graphs.md
+++ b/docs/v26_2/adr/ADR-003-four-graphs.md
@@ -1,0 +1,43 @@
+# ADR-003: Four graphs (not three) — distinct modules
+
+- **Status:** Accepted (2026-04-22, corrected from v3 plan which said three)
+- **Context owner:** v26.2 architectural decisions (plan §2.3)
+
+## Context
+
+V26.1 shipped `project_graph.ml` and `dependency_graph.ml`. V26.2
+introduces `build_graph.ml`. The v3 plan treated these as "three graphs"
+and proposed `docs/THREE_GRAPHS.md`. The v4 audit caught a miss:
+`Validator_dag` in `validator_dag.ml` (shipped v26.0) is also a
+runtime graph. So there are four.
+
+## Decision
+
+**Four distinct graph modules. Documented in `docs/FOUR_GRAPHS.md`** (to be
+written during PR A1).
+
+| Module | Nodes | Edges | Purpose |
+|---|---|---|---|
+| `Validator_dag` | rule IDs | `consumes`/`provides` deps + `conflicts_with` | rule execution ordering + conflict detection |
+| `project_graph` | .tex files | `\input` / `\include` edges | multi-file project structure |
+| `dependency_graph` | chunks | semantic edits that invalidate consumers | incremental re-validation |
+| `build_graph` | artefacts (tex / aux / bbl / pdf) | produce-from edges | build-pipeline order + .aux/bbl readiness |
+
+## Alternatives considered
+
+- **Option A: Unified graph with edge-type tagging.**
+  Conceptually elegant; in practice, the four use cases have different
+  node types (string ID vs file path vs chunk index vs artefact) and
+  different algorithms (Kahn's topo-sort vs BFS reachability vs fixpoint).
+  Unifying would create a weakly-typed abstraction and complicate every
+  specific consumer. Rejected for v26.2; re-evaluate in v27.
+- **Option B: Rename for clarity.**
+  E.g. `Validator_dag` → `rule_dag`. Breaking change to a shipped API.
+  Rejected.
+
+## Consequences
+
+- `docs/FOUR_GRAPHS.md` becomes a mandatory onboarding read.
+- Each graph has its own test file, proofs (where applicable), and
+  invalidation semantics. No cross-contamination.
+- Future unified-graph refactor is a v27 consideration.

--- a/docs/v26_2/adr/ADR-004-hypothesis-parametric-t6-t7.md
+++ b/docs/v26_2/adr/ADR-004-hypothesis-parametric-t6-t7.md
@@ -1,0 +1,66 @@
+# ADR-004: T6/T7 proofs use Section + Variable (not Parameter / Axiom)
+
+- **Status:** Accepted (2026-04-22)
+- **Context owner:** v26.2 architectural decisions (plan §2.4)
+
+## Context
+
+Memo §5 defines the compile-guarantee theorem stack T0–T7. T6
+("compilation progress") and T7 ("output well-formedness") require
+modelling the LaTeX toolchain's pass-iteration and output semantics —
+non-trivial work that belongs to v27 WS8, not v26.2.
+
+But v26.2 should SHIP the theorem structure so v27 has something to
+instantiate. The theorems need unproven *input assumptions* without
+violating the project's zero-axiom invariant (`admit-audit` and
+`check_regression_gates`).
+
+## Decision
+
+**Use Coq `Section` + `Variable` / `Hypothesis` pattern.** After
+`End Section`, the theorem becomes universally quantified over the
+Variables. Callers instantiate the Variables with concrete values.
+
+```coq
+Section Compile_progress.
+  Variable bounded_build_terminates_for : project -> profile -> Prop.
+  ...
+  Hypothesis compile_progress_rule : ... -> compilation_succeeds p pf.
+
+  Theorem compile_progress_under_bound : ... .
+  Proof. ... apply compile_progress_rule; assumption. Qed.
+End Compile_progress.
+```
+
+**Zero `Parameter` / `Axiom` declarations.** `Variable`s inside a Section
+are *not* axioms — they become parameters of the final theorem after
+`End`.
+
+## Alternatives considered
+
+- **Option A: Declare `Parameter bounded_build_terminates_for : ...`**
+  Banned by `check_regression_gates` / `proof.yml` anti-axiom gate.
+  Rejected.
+- **Option B: Define concretely as `True` (trivial).**
+  Theorem becomes vacuously satisfied; no content. Rejected — defeats
+  the purpose.
+- **Option C: Use Coq Modules + Functors.**
+  More verbose; same end result as Section pattern for our needs.
+  Rejected as overkill.
+- **Option D: Defer T6/T7 to v27 entirely.**
+  Considered. Rejected because v26.2 compile_contract module ships
+  runtime checkers for T0–T5; having abstract T6/T7 wrappers keeps
+  the proof surface complete even if the concrete toolchain model is
+  deferred.
+
+## Consequences
+
+- v27 WS8 writes an OCaml-style `Module PdflatexModel` that instantiates
+  the Section's Variables with concrete types and discharges
+  `compile_progress_rule` with a real proof.
+- **Canary test required:** before A3 merges, verify the anti-axiom
+  gate doesn't misfire on Section-quantified Variables. Add a minimal
+  .v file with a Section pattern; run `check_regression_gates.py` and
+  `admit-audit` on it.
+- `proofs/ADMISSIBILITY_MAP.md` (created in A3) lists every Hypothesis
+  T6/T7 rely on, serving as the entry point for v27 WS8 implementers.

--- a/docs/v26_2/adr/ADR-005-cst-round-trip-two-level.md
+++ b/docs/v26_2/adr/ADR-005-cst-round-trip-two-level.md
@@ -1,0 +1,49 @@
+# ADR-005: CST round-trip is byte-lossless universally + structure-lossless on subset
+
+- **Status:** Accepted (2026-04-22)
+- **Context owner:** v26.2 architectural decisions (plan §2.5)
+
+## Context
+
+"Lossless CST" is one of memo §16.3's v26.2 deliverables. Many prior
+projects promise "lossless" and ship with undocumented limitations
+(verbatim blocks, catcode mutations, etc. break the promise). We need
+a precise semantics that's achievable AND useful.
+
+## Decision
+
+**Two-level round-trip promise:**
+
+1. **Byte-lossless (UNIVERSAL under precondition):** for any valid UTF-8
+   string `s` with length ≤ `Sys.max_string_length`,
+   `Cst.to_source (Cst.of_source s) = Ok s` — as bytes.
+   Achieved via `Unparsed { text; span; reason }` nodes as fallback
+   for any span the structured parser rejects.
+
+2. **Structure-lossless (SUBSET):** for documents in the declared
+   subset (ADR-006), the CST is fully structured — every token, group,
+   env is a typed node. No `Unparsed` fallbacks.
+
+## Alternatives considered
+
+- **Option A: Promise "lossless" without precondition.**
+  Can't be universally true (bit-flipped binary input is not
+  representable). Rejected as dishonest.
+- **Option B: Promise only structure-lossless (subset only).**
+  Loses the user-friendly "bytes come back unchanged" guarantee for
+  out-of-subset input. Rejected.
+- **Option C: No fallback node; subset failures are errors.**
+  Users feeding arbitrary LaTeX through the pipeline would get errors
+  instead of round-trippable results. Bad UX. Rejected.
+
+## Consequences
+
+- CST type has an `Unparsed` variant as a first-class fallback.
+- `Cst.of_source` never fails on valid UTF-8; at worst produces a CST
+  dominated by `Unparsed`.
+- `CSTRoundTrip.v` proves both levels: byte-lossless requires a lemma
+  that `Unparsed { text; span; _ }` emits exactly `text`; subset-
+  lossless requires a lemma for each structured variant.
+- Rewrite engine can only target typed nodes; `Unparsed` regions are
+  not editable via `Cst_edit`. Users who want to edit verbatim blocks
+  must operate on the pre-CST source directly.

--- a/docs/v26_2/adr/ADR-006-cst-subset.md
+++ b/docs/v26_2/adr/ADR-006-cst-subset.md
@@ -1,0 +1,58 @@
+# ADR-006: CST structured subset — what's in, what's Unparsed
+
+- **Status:** Accepted (2026-04-22)
+- **Context owner:** v26.2 architectural decisions (plan §2.6)
+
+## Context
+
+ADR-005 promises "structure-lossless for the declared subset". This
+ADR declares the subset.
+
+## Decision
+
+### IN scope for structured CST
+
+- **UTF-8 source** (multi-byte codepoints allowed).
+- **Standard catcode regime** — no mid-document `\catcode` in body.
+- **Balanced groups, environments, math modes** (inline `$...$`, display
+  `\[...\]`, `equation`, `align`, etc.).
+- **Comments** (full-line starting with `%`, end-of-line `%foo`) — body
+  preserved byte-exact.
+- **Whitespace** preserved byte-exact (including CRLF vs LF).
+- **Macro definitions** via `\newcommand` / `\renewcommand` /
+  `\providecommand` with standard arity specs `[N][default]`.
+- **Cross-references** — `\label`, `\ref`, `\pageref`, `\eqref`, etc.
+
+### OUT of scope — falls back to `Unparsed`
+
+- `\verb` / `\verb*` / `\lstlisting` / `fancyvrb` blocks — verbatim
+  bodies change the catcode regime locally.
+- `\begin{comment}` ... `\end{comment}` (comment package) — verbatim-family.
+- Arbitrary `\def` with non-standard catcode specs (`\def\foo##1{...}`
+  with implicit catcode changes).
+- `\catcode` declarations in document body.
+- `\newenvironment` custom environments — body becomes `Unparsed`
+  (v26.2 doesn't track user-env body semantics).
+- BOM handling — `Cst.of_source` on a BOM-prefixed input rejects with
+  `Error BadEncoding`.
+- Mixed encodings (non-UTF-8) — same as above.
+
+### `\input` / `\include` behavior
+
+CST does **NOT** inline included files. `\input{sub}` is preserved as a
+structured token pointing at `sub`; cross-file analysis happens in the
+`project_model` layer, not the CST layer. Rationale: CST preserves
+source of a *single file*; multi-file semantics are orthogonal.
+
+## Consequences
+
+- `Unparsed` regions are common in real documents that use `\verb` or
+  `\lstlisting`. Users see `(Unparsed "...")` nodes in their CST.
+- `CSTRoundTrip.v` subset proof covers only IN-scope constructs. OUT-
+  scope constructs survive the byte-lossless theorem but not the
+  structure-lossless one.
+- Future subset extensions (adding `\verb` support, etc.) are
+  backward-compatible: today's `Unparsed` verbatim becomes tomorrow's
+  typed `Verbatim` node, with no change in byte-level semantics.
+- `docs/CST_ROUNDTRIP_SCOPE.md` (created in B2) documents this subset
+  with worked examples.

--- a/docs/v26_2/adr/ADR-007-compile-stack-ships-in-v26-2.md
+++ b/docs/v26_2/adr/ADR-007-compile-stack-ships-in-v26-2.md
@@ -1,0 +1,51 @@
+# ADR-007: Compile-guarantee stack (T0–T7) ships in v26.2, not v27
+
+- **Status:** Accepted (2026-04-22)
+- **Context owner:** v26.2 architectural decisions (plan §2.7)
+
+## Context
+
+Memo §5 defines the compilation-guarantee theorem stack T0–T7. The memo
+itself is ambiguous about timing — §16.3 doesn't list it for v26.2,
+but §17 (v27) mentions it under WS8. Two reasonable readings:
+
+1. T0–T7 is v27 scope; v26.2 doesn't touch it.
+2. T0–T7 needs to START in v26.2 so v27 has scaffolding to build on.
+
+## Decision
+
+**Ship compile-guarantee scaffolding + T0–T5 mechanized wrappers + T6/T7
+hypothesis-parametric proofs in v26.2.** Discharge the T6/T7 hypotheses
+in v27 WS8 with a concrete toolchain model.
+
+Concrete v26.2 deliverables (PRs A1–A3):
+
+- **A1:** `specs/v26/compilation_guarantee_stack.md`, `compilation_profiles.yaml`.
+- **A2:** `project_model.{ml,mli}`, `build_graph.{ml,mli}`,
+  `aux_state.{ml,mli}`, `compile_contract.{ml,mli}`.
+- **A3:** `T0_wrapper.v` / `T1_wrapper.v` / `T4_wrapper.v` / `T5_wrapper.v`
+  (reuse existing proofs); `ProjectClosure.v` (T2); `BuildProfileSound.v`
+  (T3); `CompileProgress.v` (T6); `CompileWellFormed.v` (T7); per ADR-004.
+
+## Alternatives considered
+
+- **Option A: Defer all of §5 to v27 (strict memo-§17 reading).**
+  Leaves v26.2 compile_contract module without a formal backing. Users
+  of compile_contract have no theorem to cite. Rejected.
+- **Option B: Ship runtime modules in v26.2, all proofs in v27.**
+  Runtime without proofs is fine pragmatically, but v27 WS8 then has
+  to do proof AND integration work at once. Better to front-load the
+  proof structure. Rejected.
+- **Option C: Full discharge (concrete toolchain model) in v26.2.**
+  Toolchain modelling is multi-week work that expands v26.2 scope
+  beyond the memo §16.3 scope. Rejected — out of budget.
+
+## Consequences
+
+- v26.2 plan Track A has 3 PRs (A1/A2/A3) of increasing complexity.
+- v27 WS8 focuses on instantiation + hypothesis discharge, not from-
+  scratch proof work.
+- `proofs/ADMISSIBILITY_MAP.md` serves as the handoff document from
+  v26.2 A3 → v27 WS8.
+- By shipping v26.2 as planned, we effectively deliver v27 WS7 (CST
+  substrate) AND WS8 scaffolding. v27 reduces to WS9/10/11/12.

--- a/docs/v26_2/adr/ADR-008-cst-generation-via-post-process-ast.md
+++ b/docs/v26_2/adr/ADR-008-cst-generation-via-post-process-ast.md
@@ -1,0 +1,57 @@
+# ADR-008: CST generation via post-process AST + source slicing
+
+- **Status:** Provisional — pending PR B0.5 audit
+- **Context owner:** v26.2 architectural decisions (plan §2.8)
+
+## Context
+
+To produce a lossless CST, we need a strategy that:
+1. Doesn't duplicate parsing work (Parser_l2 already exists + is proven).
+2. Preserves source-byte information (whitespace, comments, exact positions).
+3. Can be implemented in ~3 engineering days (PR B1 budget).
+
+## Decision
+
+**Post-process existing `Parser_l2` output + source slicing.**
+
+Algorithm:
+1. Parse source with existing `Parser_l2` → list of `located_node` with
+   offsets.
+2. Traverse the AST; for each node, slice the source string at the
+   recorded offsets to produce a typed CST node.
+3. Fill gaps between nodes (whitespace, comments) by scanning the
+   source between consecutive AST offsets.
+4. For unrecognized spans (e.g. `\verb` bodies), produce
+   `Unparsed { text; span; reason }` nodes per ADR-005.
+
+## Prerequisite audit (PR B0.5)
+
+Before PR B1 commits to this strategy, verify `Parser_l2` records
+enough information:
+- ✅ / ❌ `located_node.offset` accurate per AST node
+- ✅ / ❌ Comments preserved OR scannable from source directly
+- ✅ / ❌ Whitespace positions recoverable from offset diffs
+- ✅ / ❌ Group delimiter spans captured
+
+If audit reveals gaps, fallback: add a lightweight lex pass in
+`Cst_of_ast.ml` (~0.5 day extra).
+
+## Alternatives considered
+
+- **Option A: Parallel parser — write a CST-producing parser from scratch.**
+  Duplicates parsing logic. Risk of divergence from existing Parser_l2.
+  Rejected.
+- **Option B: Modify `Parser_l2` to emit CST directly.**
+  Destabilizes a proven, tested module. Breaks `ParserSound.v` proof
+  surface. Rejected.
+- **Option C: AST only — no CST.**
+  Loses memo §16.3 deliverable. Rejected.
+
+## Consequences
+
+- PR B0.5 (parser audit, 0.5 day) is a hard prerequisite of PR B1.
+- If audit fails, B1 grows by 0.5 day for a lightweight lex pass.
+- `Cst_of_ast.ml` is the sole module implementing the strategy;
+  all other code consumes `Cst.t` directly.
+- Future Parser_l2 changes must preserve offset accuracy — add a
+  regression test in B0.5 that locks this invariant.

--- a/docs/v26_2/adr/README.md
+++ b/docs/v26_2/adr/README.md
@@ -1,0 +1,25 @@
+# Architectural Decision Records — v26.2
+
+Each ADR in this directory captures a single decision made during v26.2
+planning. Format follows the standard Michael Nygard ADR template:
+
+- **Status** — Accepted, Rejected, Superseded, Provisional
+- **Context** — the situation that forced the decision
+- **Decision** — what we chose
+- **Alternatives considered** — what we rejected and why
+- **Consequences** — implications of the decision
+
+## Index
+
+- [ADR-001 — core/l2_parser/ alias pattern](ADR-001-core-directory-alias.md)
+- [ADR-002 — aux_state vs build_artifact_state](ADR-002-aux-state-vs-build-artifact-state.md)
+- [ADR-003 — Four graphs (not three)](ADR-003-four-graphs.md)
+- [ADR-004 — T6/T7 hypothesis-parametric via Section](ADR-004-hypothesis-parametric-t6-t7.md)
+- [ADR-005 — CST round-trip two-level](ADR-005-cst-round-trip-two-level.md)
+- [ADR-006 — CST structured subset](ADR-006-cst-subset.md)
+- [ADR-007 — Compile-guarantee stack ships in v26.2](ADR-007-compile-stack-ships-in-v26-2.md)
+- [ADR-008 — CST generation via post-process AST](ADR-008-cst-generation-via-post-process-ast.md)
+
+## Superseded / historical
+
+None yet.

--- a/scripts/tools/check_doc_refs.py
+++ b/scripts/tools/check_doc_refs.py
@@ -139,6 +139,10 @@ def main() -> int:
         # v25 archival docs
         "v25_R1",
         "v25_R0",
+        # v26.2+ planning docs (describe future paths by design)
+        "V26_2_PLAN",
+        "V26_3_PLAN",
+        "v26_2",  # directory of v26.2 planning sub-docs
     }
     doc_files = set()
     for root in roots:

--- a/specs/v26/V26_2_PLAN.md
+++ b/specs/v26/V26_2_PLAN.md
@@ -1,0 +1,636 @@
+# v26.2 — Partial Parsing, Rewrite Substrate, Compile-Guarantee Stack
+
+**Status:** design doc (v3, audited twice). Commit as part of PR A0.
+**Authoritative sources:** `specs/REPO_EXACT_MISSING_ARCHITECTURE_MEMO_V26_V27.md` §5 / §7 / §16.3; `specs/v26/V26_REPO_EXACT_MASTER_SPEC.md`; `specs/v27/V27_REPO_EXACT_MASTER_SPEC.md` (for scope boundary).
+**Target tag:** `v26.2.0`; two optional alpha intermediates (§4.3).
+**Realistic calendar:** 5–6 weeks single-contributor; **3.5 weeks with two-contributor parallel tracks**; shorter possible only at the cost of review depth.
+
+---
+
+## Companion documents (all authored as part of PR A0)
+
+- [`docs/v26_2/USER_PERSONAS.md`](../../docs/v26_2/USER_PERSONAS.md) — three target users; anchors scope decisions.
+- [`docs/v26_2/ROLLBACK_DRILL.md`](../../docs/v26_2/ROLLBACK_DRILL.md) — concrete procedures for v26.2.1 hotfix, apply-fixes corruption recovery, release.yml failure.
+- [`docs/v26_2/COMMUNICATION_PLAN.md`](../../docs/v26_2/COMMUNICATION_PLAN.md) — alpha announcements, release page templates, post-tag check procedure.
+- [`docs/v26_2/FIX_STYLE_GUIDE.md`](../../docs/v26_2/FIX_STYLE_GUIDE.md) — style guide for rule authors adding `fix` suggestions.
+- [`docs/v26_2/CORPUS_LICENSING.md`](../../docs/v26_2/CORPUS_LICENSING.md) — licensing + curation policy for new corpora.
+
+ADRs land separately, one per §2 decision, under `docs/v26_2/adr/ADR-00N-*.md`. Each ADR uses the standard format: Context · Decision · Consequences · Status. The ADRs are written during PR A0 alongside this plan.
+
+## 0. PREREQUISITES (non-negotiable)
+
+This plan starts after ALL of these:
+
+1. **PR #247 merges** (round 10–12 CI gate additions).
+2. **v26.1.0 dry-run succeeds:** `bash scripts/release.sh 26.1.0 --dry-run` exits 0.
+3. **v26.1.0 tagged + pushed:** tag + GitHub release workflow succeeds (SBOM, Cosign sign, Docker push all green).
+4. **Release observability confirmed:** release.yml workflow actually published artefacts — don't assume; verify manually.
+
+```bash
+git checkout main && git pull
+python3 scripts/tools/pre_release_check.py         # must PASS
+bash scripts/release.sh 26.1.0 --dry-run           # first — no side effects
+bash scripts/release.sh 26.1.0                     # bumps version + tags
+git push origin main && git push origin v26.1.0
+# Then: verify https://github.com/.../releases/tag/v26.1.0 has artefacts.
+# If release.yml fails silently, v26.1.0 "tag" is incomplete.
+```
+
+**Contingency:** if `pre_release_check` fails, DO NOT tag. Fix the failing gate first. If `release.yml` fails post-tag, file an issue; do not proceed to v26.2 work until artefacts are published (users can't install a broken tag).
+
+**If v26.1.1 hotfix becomes necessary:** re-base this plan on main-after-hotfix. The prerequisite `main = v26.1.0-or-later` still holds; nothing in v26.2's PRs conflicts with typical hotfix scope.
+
+Rationale: gates are ratcheted to v26.1-complete state; every v26.2 commit compares against a tagged baseline. Without the tag, governance version drifts and regression ratchets have no anchor.
+
+---
+
+## 1. What v26.1 shipped (concrete checklist)
+
+- §4 Language contract: SOLID, runtime-gated
+- §6 E0–E3 editing proofs: SOLID, bound to runtime types (Partial_cst.trust_zone, Parser_l2.located_node, validator_meta)
+- §8 Compile-log integration: shipped, `log_context.ml` facade added P1.7
+- §9 Hybrid invalidation: `invalidation.ml` + `dependency_graph.ml` + `semantic_edges.ml`, proofs in `DependencyInvalidation.v`
+- §10 Validator DAG: 660 contracts, family capability edges, conflict suppression wired
+- §11/§11.2 Execution classes + per-class scheduling: runtime-enforced
+- §12 Support matrix: memo §12.1 path, drift-gated
+- §15 Defects 1–5: all fixed
+- §16.1 v26.0 MUST-SHIP: evidence_scoring + edf_scheduler rewrites, all runtime modules
+- §16.2 v26.1 MUST-SHIP: include graph + dependency graph + ProjectSemantics.v + DependencyInvalidation.v
+
+**Memo §16.3 deferred to v26.2:** lossless CST, partial-doc/hole semantics, damage containment theorems, stable IDs/spans, rewrite engine v1.
+
+**Memo §5 compilation-guarantee stack:** memo is ambiguous about timing (§5.3 defines T0–T7; §16.3 doesn't list them; v27 WS8 claims them). My decision (§2.7 below): **ship scaffolding + hypothesis-parametric proofs in v26.2**; v27 WS8 discharges the hypotheses with a real toolchain model.
+
+---
+
+## 2. Architectural decisions (locked before coding)
+
+### 2.1 `core/l2_parser/` vs `latex-parse/src/`
+
+**Decision: ship under `latex-parse/src/` with alias modules at memo-prescribed paths.**
+
+Trade-off acknowledged: memo prescribes `core/l2_parser/`; we don't have that directory. Options were:
+- **A** (reorg to `core/`): new dune library, many dune edits, real risk of merge conflict with in-flight v26.1 work. 1 full day of build plumbing for zero user-visible value.
+- **B** (alias pattern): 5-line `.ml` + `.mli` wrapper; pattern we've used successfully for `macro_subset`, `invalidation_engine`, `log_context`.
+
+Chose B. Technical-debt flag: memo paths remain "canonical prose, aliased runtime". v27 CST-substrate work could revisit.
+
+### 2.2 `aux_state` vs existing `build_artifact_state`
+
+**Decision: distinct modules, both retained.**
+
+- `build_artifact_state.ml` (v26.0, 30 LOC): thread-local wrapper over `Build_profile.t`; holds a parsed log context.
+- `aux_state.ml` (v26.2, NEW): reads and parses the `.aux` FILE on disk — cross-references (`\newlabel`, `\bibcite`, counters, `\@LN`).
+
+**Scope correction from v2 plan:** .aux parsing is **multi-day work, not a thin wrapper**. The pdflatex `.aux` format has ~20 macro shapes. Estimated 1.5 days for a conservative parser that handles the common 80% and bails safely on the rest.
+
+### 2.3 Four graphs
+
+**Decision correction (from v3 audit): there are FOUR graphs in the runtime, not three. Documented in `docs/FOUR_GRAPHS.md`.**
+
+- `Validator_dag` (v26.0, `validator_dag.ml`): rule dependency + conflict DAG.
+- `project_graph.ml` (v26.1): include graph of `.tex` files (tex→tex via `\input`, `\include`).
+- `dependency_graph.ml` (v26.1): semantic chunk dependencies for invalidation.
+- `build_graph.ml` (v26.2, NEW): **build-pipeline** dependencies (tex→aux, tex→bbl, bib→bbl, tex→pdf).
+
+Distinct edge types, distinct consumers. Unified-graph refactor is a v27 consideration.
+
+### 2.4 Coq-level shape of "hypothesis-parametric" proofs (T6/T7)
+
+**Decision: use `Section` + `Variable` pattern.**
+
+```coq
+Section Compile_progress.
+  Variable project : Type.
+  Variable profile : Type.
+  Variable bounded_build_terminates_for : project -> profile -> Prop.
+  Variable T0_parser_accepts : project -> Prop.
+  Variable T1_expansion_admissible : project -> Prop.
+  (* ... T2-T5 ... *)
+  Variable compilation_succeeds : project -> profile -> Prop.
+
+  (* Model rule of combination: all conditions + termination -> success *)
+  Hypothesis compile_progress_rule :
+    forall p pf,
+      T0_parser_accepts p ->
+      T1_expansion_admissible p ->
+      T2_project_closed p ->
+      T3_profile_compatible p pf ->
+      T4_semantic_coherent p ->
+      T5_rule_safe p ->
+      bounded_build_terminates_for p pf ->
+      compilation_succeeds p pf.
+
+  Theorem compile_progress_under_bound :
+    forall p pf,
+      T0_parser_accepts p ->
+      ... (all of T0-T5) ... ->
+      bounded_build_terminates_for p pf ->
+      compilation_succeeds p pf.
+  Proof. intros. apply compile_progress_rule; assumption. Qed.
+End Compile_progress.
+```
+
+After `End Compile_progress`, the theorem becomes universally-quantified over the Variables:
+
+```coq
+compile_progress_under_bound :
+  forall project profile (bounded : project -> profile -> Prop)
+         (T0 : project -> Prop) ... (compile_rule : ... -> compilation_succeeds p pf),
+  forall p pf, T0 p -> T1 p -> ... -> bounded p pf -> compilation_succeeds p pf.
+```
+
+**Zero `Axiom` / `Parameter` declarations** — `admit-audit` and `anti-axiom` gates still pass. The `Hypothesis` is scoped to the Section; after `End`, it becomes a universally-quantified parameter. This is idiomatic Coq and distinct from a global axiom.
+
+Callers of this theorem (v27 WS8) instantiate the Variables/Hypothesis with a concrete model of the LaTeX toolchain.
+
+**Concrete instantiation sketch (for v27 WS8 to implement):**
+
+```coq
+(* v27 WS8 writes this against a specific toolchain model: *)
+Require Import CompileProgress.
+
+Module PdflatexModel.
+  Inductive project := mk_project (files : list tex_file) (root : tex_file).
+  Definition profile := Pdflatex.
+  Definition bounded_build_terminates_for (p : project) (pf : profile)
+    : Prop := exists n, pdflatex_pass_count p <= n.
+  (* ... instantiate T0..T5 predicates concretely ... *)
+  Lemma instantiated_progress : forall p pf,
+    ...concrete conditions... -> compilation_succeeds p pf.
+  Proof.
+    intros. apply compile_progress_under_bound; eauto.
+  Qed.
+End PdflatexModel.
+```
+
+v26.2 ships the SECTION-PARAMETRIC theorem; v27 WS8 ships the MODULE that instantiates it.
+
+**Gate verification:** before shipping, confirm `anti-axiom` gate (banning `Parameter` / `Axiom`) does NOT fire on Section-quantified Variables. Test with a minimal Coq file; if gate misfires, adjust the regex BEFORE committing the proof.
+
+### 2.5 CST round-trip semantics
+
+**Decision: two-level round-trip promise, with explicit input-validity bounds.**
+
+**Input-validity precondition (UNIVERSAL claims require):** `s` is a valid UTF-8 string of length ≤ `Sys.max_string_length`. The theorem does NOT cover bit-flipped binary garbage; `Cst.of_source` on invalid UTF-8 returns `Error BadEncoding`.
+
+- **Byte-lossless (UNIVERSAL under precondition):** for any valid UTF-8 input `s`, `Cst.to_source (Cst.of_source s) = Ok s` — as bytes. Achieved by using `Unparsed { text; span; reason }` nodes as a fallback for any span the structured parser rejects.
+- **Structure-lossless (SUBSET):** for documents in the declared subset (§2.6), the CST is fully structured — every token/group/env is a typed node, `Unparsed` nodes are absent.
+- **Empty input:** `Cst.of_source ""` returns `Ok (Document [])`, `Cst.to_source` returns `""`. Edge case tested.
+
+This is strictly stronger than my v2 plan said. It means:
+- Users who feed arbitrary LaTeX through `Cst.of_source` + `Cst.to_source` get their bytes back (no data loss ever).
+- The structured-CST subset promise is a SEPARATE claim: within the subset, edits target typed nodes, not fragile spans.
+- `\verb` / `\lstlisting` / catcode-mutation regions become `Unparsed` — still round-trippable, but rewrites can't target them structurally.
+
+### 2.6 CST subset for structured round-trip
+
+**In scope for v26.2 structured CST:**
+- UTF-8 source (multi-byte CODEPOINTS, not byte-only)
+- Standard catcode regime (no mid-document `\catcode` in body)
+- Balanced groups, environments, math modes (inline + display)
+- Comments (full-line + end-of-line), whitespace preserved byte-exact
+- `\newcommand` / `\renewcommand` / `\providecommand` macro definitions
+- Cross-references, labels, refs
+
+**Out of scope for structured CST (fall back to `Unparsed`):**
+- `\verb` / `\verb*` / `\lstlisting` / `fancyvrb` blocks
+- `\begin{comment}` ... `\end{comment}` (verbatim-family)
+- Arbitrary `\def` with non-standard catcode specs
+- `\catcode` declarations in body
+- `\newenvironment` custom environments (out of scope for structured CST; body becomes `Unparsed`)
+- BOM handling (document excludes BOM input)
+- Mixed encodings (UTF-8 only)
+
+Line endings: preserved byte-exact (CRLF / LF passes through unchanged).
+
+**`\input` / `\include` expansion policy:** v26.2 CST does NOT inline included files. `\input{sub}` is kept as a structured token; cross-file analysis happens at the `project_model` layer, not the CST layer. Rationale: CST preserves source of a single file; project-level semantics are orthogonal.
+
+### 2.7 Compile-guarantee stack timing
+
+**Decision: ship A-track scaffolding + T0–T5 mechanized wrappers + T6/T7 hypothesis-parametric proofs in v26.2.** v27 WS8 discharges the T6/T7 hypotheses against a toolchain model.
+
+Alternative rejected: defer all compile-guarantee work to v27. Reason: the runtime modules (project_model, build_graph, aux_state, compile_contract) are standalone valuable for v26.2 users running multi-file projects; they don't need v27's toolchain model.
+
+### 2.8a `--apply-fixes` safety semantics
+
+**Decision** (promoted from v4 audit): `--apply-fixes` MUST ship with these guards or not ship at all:
+
+1. **Backup before write.** `doc.tex` → `doc.tex.bak-<timestamp>` first. CLI prints the backup path.
+2. **Atomic per-file writes.** `doc.tex.tmp` + fsync + rename. No partial writes on crash.
+3. **Multi-file all-or-nothing.** Staging dir + atomic batch rename. Either all succeed or none do.
+4. **Refuse on conflict.** Overlapping `Cst_edit.edit` → fail with listing. No silent merge.
+5. **Refuse on parse failure.** Re-parse after rewrite; abort + restore on parse failure.
+
+Rationale: P2 industrial-writer persona explicitly cannot tolerate silent corruption. Details in [ROLLBACK_DRILL.md](../../docs/v26_2/ROLLBACK_DRILL.md).
+
+### 2.8b Granularity of `--apply-fixes`
+
+**Decision** (promoted from v4 audit): v26.2 ships `--apply-fixes` as all-or-nothing only. `--apply-fixes-for RULE-ID` deferred to v26.3. Rationale: P1/P2 users want bulk application; P3 library users wrap the rewrite engine directly and don't need CLI granularity. Adding the flag later is additive; removing it would be breaking.
+
+### 2.8 CST generation strategy — **actual dependency audit**
+
+**Decision: post-process Parser_l2's located_node output + source slicing.**
+
+**But FIRST audit Parser_l2** to confirm it records enough information for CST reconstruction. Specifically verify:
+- `located_node` records accurate `loc.offset` for every token (grep `Parser_l2.located_node`)
+- Comment positions preserved OR source has comment regex-scannable
+- Whitespace positions recoverable from offset diffs
+
+**If Parser_l2 is inadequate**, fallback: add a lightweight lex pass in `Cst_of_ast.ml` that re-tokenizes the source with comment/whitespace preservation. Cost: ~0.5 day extra.
+
+This audit is a **prerequisite of PR B1**; if the audit fails, B1 scope grows by 0.5 day.
+
+---
+
+## 3. PR sequence
+
+Seven PRs + alpha tags. Per-PR: memo mapping, backout plan, acceptance criteria.
+
+### 3.1 Track A — Compile-guarantee stack
+
+#### PR A0 — Decisions + ADRs + plan commit (0.5 day, pure docs)
+
+**Files:**
+- `specs/v26/V26_2_PLAN.md` (THIS document)
+- `docs/ARCHITECTURAL_DECISIONS.md` — ADR-style record of §2.1–§2.8 decisions
+- `docs/THREE_GRAPHS.md` — project_graph / dependency_graph / build_graph disambiguation
+
+**Memo mapping:** prerequisite for §5, §16.3.
+**Backout:** docs-only; safe to revert.
+
+#### PR A1 — Compile-stack specs (0.5 day)
+
+**Files:**
+- `specs/v26/compilation_guarantee_stack.md` — T0–T7 with PRECISE preconditions, Coq-level signature sketch per §2.4
+- `specs/v26/compilation_profiles.yaml` — engine/toolchain profile metadata
+- `docs/COMPILATION_GUARANTEE.md` — user-facing summary
+- Update `check_memo_files.py` PATH_ALIASES (remove entries that now resolve directly)
+
+**Memo mapping:** §5.5 "new specs".
+**Backout:** docs + yaml; no runtime impact.
+
+#### PR A2 — Compile-stack runtime scaffold (3.5 days)
+
+**Files:**
+- `latex-parse/src/project_model.{ml,mli}` — typed project
+- `latex-parse/src/build_graph.{ml,mli}` — build-pipeline graph (distinct from project/dep graphs; see §2.3)
+- `latex-parse/src/aux_state.{ml,mli}` — **.aux file PARSER** (multi-day work per §2.2 — not a wrapper). **Verification requirement:** parser must succeed on at least 3 real `.aux` files produced by running pdflatex on documents from `corpora/`, not just synthetic fixtures. Scope: pdflatex-only for v26.2; xelatex/lualatex deferred to v26.3. Related aux-family files (`.toc`, `.lof`, `.lot`, `.idx`, `.glg`) are explicitly out of scope.
+- `latex-parse/src/compile_contract.{ml,mli}` — glue module; `check_ready_to_compile` runs T0–T5 at runtime
+- `corpora/compile_contract/` — 5+ sample projects: simple, multi-file, with-bib, with-missing-ref, with-cycle
+- Unit tests: `test_project_model.ml`, `test_build_graph.ml`, `test_aux_state.ml`, `test_compile_contract.ml`
+- **End-to-end integration test:** `test_compile_contract_e2e.ml` — parse corpus project → build project_model → check compile_contract → assert expected result
+- Update `check_memo_files.py` PATH_ALIASES for the new memo-prescribed paths
+
+**Memo mapping:** §5.5 "new runtime modules".
+**Backout:** all modules additive; can revert wholesale. CLI doesn't require them.
+
+**Split recommendation (from v4 audit):** this PR is large (4 new modules, 4 test modules, corpus, integration test). Consider splitting:
+- **A2a:** `project_model` + `build_graph` + their tests (~1.5d)
+- **A2b:** `aux_state` + `compile_contract` + integration test + corpus (~2d)
+
+Splitting reduces review burden and lets A2a merge while A2b's .aux-parser work is still in progress. If time pressure forces a single PR, document that choice was deliberate.
+
+#### PR A3 — Compile-stack proofs + v26.2.0-alpha1 tag (4.5 days)
+
+**Files:**
+- `proofs/ProjectClosure.v` (T2)
+- `proofs/BuildProfileSound.v` (T3)
+- `proofs/CompileProgress.v` (T6) — hypothesis-parametric per §2.4
+- `proofs/CompileWellFormed.v` (T7) — hypothesis-parametric
+- Wrapper proofs: `proofs/T0_wrapper.v` (parser_accept via ParserSound.v), `T1_wrapper.v` (via UserExpand.v), `T4_wrapper.v` (via LabelsUnique.v + ProjectSemantics.v), `T5_wrapper.v` (via per-rule QED chain + explicit gap-documentation)
+- `proofs/ADMISSIBILITY_MAP.md` — lists which hypotheses T6/T7 rely on; entry-point for v27 WS8 discharge
+- `_CoqProject` update
+- **Alpha tag: `v26.2.0-alpha1`** after A3 merges — users can test compile_contract pipeline while B-track proceeds.
+
+**Memo mapping:** §5.3 (T0–T7), §5.5 (new proofs).
+**Backout per proof:** each file independent. Can land T0/T1/T2/T3/T4/T5 wrappers without T6/T7; graceful degradation.
+
+---
+
+### 3.2 Track B — Lossless CST + rewrite
+
+#### PR B0.5 — Parser_l2 capability audit (0.5 day)
+
+**Purpose:** verify §2.8 prerequisite. Pure investigation PR.
+
+**Files:**
+- `docs/PARSER_L2_AUDIT.md` — what Parser_l2 records, what's missing for CST generation, recommended strategy (post-process-only vs. post-process + lightweight lex).
+
+**Backout:** docs-only.
+
+#### PR B1 — Lossless CST foundation (3.5 days, scaled for audit outcome)
+
+**Files:**
+- `latex-parse/src/cst.{ml,mli}` — CST type (per §2.5: `Unparsed` variant included for byte-lossless fallback)
+- `latex-parse/src/stable_spans.{ml,mli}` — extends `Node_id` with shift-on-edit semantics
+- `latex-parse/src/cst_of_ast.{ml,mli}` — AST → CST conversion (post-process strategy per §2.8)
+- `core/l2_parser/cst.{ml,mli}` — alias for memo path
+- **Perf test:** `test_cst_perf.ml` — measure `Cst.of_source` on a large (10MB) LaTeX file; ratchet ceiling at 100ms (vs. current parser ~30ms)
+- Unit tests: `test_cst.ml`, `test_cst_of_ast.ml`, `test_stable_spans.ml`
+
+**Memo mapping:** §16.3 "lossless CST foundation", "stable IDs/spans".
+**Backout:** additive; nothing consumes CST yet.
+
+#### PR B2 — CST round-trip + corpus (3 days, with fallback)
+
+**Files:**
+- `proofs/CSTRoundTrip.v` — **byte-lossless for arbitrary input** (via Unparsed fallback); **structure-lossless for declared subset** (§2.6)
+- `corpora/roundtrip/` — curated from existing `corpora/lint/` + `corpora/perf/` + synthetic edge cases (100+ files)
+- `latex-parse/src/test_cst_roundtrip.ml` — byte-lossless check for every corpus file; structure-lossless check for the declared-subset files
+- `docs/CST_ROUNDTRIP_SCOPE.md` — explicit subset documentation
+
+**Memo mapping:** §16.3 via CST foundation; §7 partial-doc semantics complementary.
+**Risk:** HIGH. Round-trip proofs are where "lossless CST" projects classically fail.
+**Fallback plan (preregistered):** if Coq proof stalls past 3 days:
+- **B2a (mandatory):** runtime byte-lossless test on corpus ships in B2.
+- **B2b (deferred):** `CSTRoundTrip.v` becomes v26.3 scope; docs note the structure-lossless claim is corpus-tested but not Coq-proved in v26.2.
+Proceed with B3 regardless — rewrite engine doesn't require the Coq proof, only the runtime guarantee.
+
+#### PR B3 — Rewrite engine v1 + v26.2.0-alpha2 tag (3 days)
+
+**Files:**
+- `latex-parse/src/rewrite_engine.{ml,mli}`
+- `latex-parse/src/cst_edit.{ml,mli}` — edit algebra with conflict detection
+- `proofs/RewritePreservesCST.v` — structural well-formedness preserved
+- `proofs/RewritePreservesSemantics.v` — local-only semantic preservation (whitespace edits in whitespace regions preserve token stream)
+- `latex-parse/src/validators_common.ml`: add optional `fix : Cst_edit.edit option` field to `result` (additive, labels preserved)
+- `latex-parse/src/validators_cli.ml`: add `--apply-fixes` flag
+- 3+ existing rules produce `fix` suggestions: STRUCT-001 (insert documentclass), TYPO-002 (`--`→`–`), TYPO-003 (`---`→`—`)
+- **Fuzz test:** `test_rewrite_fuzz.ml` — random edit lists applied to random CSTs; assert no corruption or conflict-detection bugs
+- E2E integration test: `test_rule_fix_integration.ml` — validator → fixes → rewrite → parse-verify
+- **Alpha tag: `v26.2.0-alpha2`** after B3 merges.
+
+**Memo mapping:** §16.3 "rewrite engine v1".
+**Risk:** moderate (new API surface that ships to users).
+
+---
+
+### 3.3 PR C — v26.2.0 final tag + documentation consolidation (1 day)
+
+**Files:**
+- `governance/project_facts.yaml` regenerate (theorem count, proof class totals)
+- `CHANGELOG.md` — full `[v26.2.0]` entry, replacing the `-alpha1/-alpha2` working sections
+- `README.md`, `docs/index.md`, `docs/PROOFS.md`, `docs/PROOF_GUIDE.md`, `docs/PROOF_CLASSES.md`, `docs/SUPPORT_MATRIX.md` + `.yaml`, `specs/README.md`, `specs/rules/README.md` — count refresh + new-module mentions
+- **`docs/MIGRATION_v26.1_to_v26.2.md`** (NEW) — user-facing migration guide
+- **`docs/ARCHITECTURE_DIAGRAM.md`** (NEW) — diagram showing project_model / build_graph / aux_state / compile_contract / CST / rewrite_engine
+- **`docs/PROOF_RELATIONSHIPS.md`** (NEW) — T0–T7 stack with arrows to existing proofs (ParserSound, UserExpand, ExecutionClasses, ProjectSemantics, LabelsUnique, per-rule chain)
+- **Differential test run** (HARD BLOCK on tag): run v26.1 and v26.2 over `corpora/regression/`, diff outputs; only the new `fix` field may differ. ANY other field diff (rule fired/not-fired, severity, count, message) is a regression and blocks the tag. No exceptions without explicit changelog justification per diffing rule.
+- `scripts/release.sh 26.2.0` — tag
+
+**Backout per tag:** if the tag exposes a critical bug within 24h, cut `v26.2.1` hotfix; no attempt to unwind the tag.
+
+---
+
+## 4. Timeline + parallelism
+
+### 4.1 Dependencies
+
+```
+v26.1.0 tag (prereq)
+   ↓
+  A0  (decisions)
+   ↓
+  A1 (specs)       B0.5 (parser audit)
+   ↓                ↓
+  A2 (runtime)    B1 (CST)
+   ↓                ↓
+  A3 (proofs)     B2 (round-trip)
+   +              ↓
+  [alpha1]       B3 (rewrite)
+                  +
+                  [alpha2]
+   ↓                ↓
+   └──────► C (v26.2.0 final)
+```
+
+### 4.2 Calendar estimates
+
+Engineering days below include self-review + CI wait; external review cycles overlap (typically 1–2 days per PR, absorbed into the NEXT PR's engineering time).
+
+| PR | Eng. days | Critical path? |
+|---|---|---|
+| A0 | 0.5 | yes |
+| A1 | 0.5 | yes |
+| A2 | 3.5 | yes |
+| A3 | 4.5 | yes |
+| B0.5 | 0.5 | (parallel) |
+| B1 | 3.5 | yes (B-path) |
+| B2 | 3.0 | yes (B-path) |
+| B3 | 3.0 | yes (B-path) |
+| C | 1.0 | yes |
+
+**Single contributor serial:** 0.5+0.5+3.5+4.5+0.5+3.5+3.0+3.0+1.0 = **20 days** (4 weeks)
+**Two contributors parallel:** critical path = A-track (9 days) vs B-track (10.5 days) + C(1) = **~11.5 days** (2.5 weeks). Realistic with review cycle overhead: **3.5 weeks**.
+
+### 4.3 Alpha releases (value-add for user feedback)
+
+- **v26.2.0-alpha1:** after A3 merges. Ships compile_contract pipeline; users with multi-file projects can test.
+- **v26.2.0-alpha2:** after B3 merges. Ships CST + rewrite engine; early adopters can exercise `--apply-fixes`.
+- **v26.2.0:** after C merges. Final.
+
+Alpha tags cost ~0.5 day each (lightweight governance regen + changelog note). High value for catching integration issues before final.
+
+---
+
+## 5. Per-PR governance checklist + explicit acceptance criteria
+
+### 5.1 Universal checklist (every PR)
+
+- [ ] `pre_release_check.py --allow-dirty --skip-build` passes before opening
+- [ ] Governance regenerated if rule/proof counts change (`scripts/tools/generate_project_facts.py`)
+- [ ] Contracts regenerated if family edges change (`scripts/tools/generate_rule_contracts.py`)
+- [ ] `CHANGELOG.md` updated in the `[v26.2.0-alpha]` working section
+- [ ] New `.mli` files: every `val` has ocamldoc comment (gate enforces)
+- [ ] New proofs: added to `_CoqProject`; anti-tautology + proof-substance gates pass
+- [ ] New rules: FAMILY-NNN format (gate enforces)
+- [ ] New YAML: parse + schema check
+- [ ] `check_perf_ratchet` PASSES on unit-tests CI run
+- [ ] All 13 existing gates + build + tests green
+- [ ] `check_memo_files.py` PATH_ALIASES updated to reflect new memo-resolving paths
+- [ ] Reviewer assigned before opening (at minimum: tech-lead; Coq PRs need a second reviewer)
+
+### 5.2 Per-PR specific acceptance criteria
+
+- **A0:** plan + ADRs + four-graphs doc committed; no code; no broken doc-refs.
+- **A1:** `compilation_guarantee_stack.md` + profiles yaml + user-facing doc; memo-files gate resolves both new paths directly.
+- **A2 (or A2a+A2b):** 4 runtime modules + unit tests + 5+ corpus projects + E2E test `test_compile_contract_e2e.ml`; `.aux` parser verified against ≥3 real pdflatex outputs.
+- **A3:** 4 new proofs + 4 wrappers + `ADMISSIBILITY_MAP.md`; anti-axiom gate passes on Section pattern (canary test required); wrapper proofs cite existing theorems correctly.
+- **B0.5:** `PARSER_L2_AUDIT.md` committed with pass/fail on 3 objective criteria: (1) `located_node.offset` accurate per position, (2) comment spans recoverable, (3) whitespace positions recoverable.
+- **B1:** CST type + `cst_of_ast` + stable_spans; perf test at 10MB source ≤ 100ms; type reviewed by a second contributor before merge.
+- **B2:** runtime round-trip test passes on 100+ corpus files; Coq proof either lands OR B2b deferral is formally signed-off in CHANGELOG.
+- **B3:** rewrite_engine + 3 exemplar rules with `fix` suggestions (style-guided per [FIX_STYLE_GUIDE.md](../../docs/v26_2/FIX_STYLE_GUIDE.md)); fuzz test 10,000 random edit lists without corruption; E2E test (validator→fixes→apply→parse) passes; `--apply-fixes` safety semantics (§2.8a) all implemented + unit-tested.
+- **C:** all alpha content consolidated; MIGRATION + ARCHITECTURE + PROOF_RELATIONSHIPS docs merged; differential test passes (HARD BLOCK); release.yml succeeds post-tag (verify artefacts); ROLLBACK_DRILL.md scenarios tested on a fork before tag; COMMUNICATION_PLAN templates used for the published release page.
+
+---
+
+## 6. Testing strategy
+
+### 6.1 Layers
+
+- **Unit tests** per module (existing pattern)
+- **End-to-end integration tests** per PR where the module touches a pipeline: A2 (`test_compile_contract_e2e.ml`), B3 (`test_rule_fix_integration.ml`)
+- **Perf tests** with ratchet: existing `test_l2_gate.ml` + `check_perf_ratchet.py`; NEW `test_cst_perf.ml` in B1
+- **Fuzz tests**: NEW `test_rewrite_fuzz.ml` in B3 (10,000 random edit lists, deterministic seed)
+- **Corpus tests**: NEW `corpora/compile_contract/` (A2), `corpora/roundtrip/` (B2)
+- **Differential tests**: v26.1 vs v26.2 on `corpora/regression/` — gate PR C
+- **Security / threat model** (NEW in v4 audit): `--apply-fixes` consumes rewrite text from rule suggestions which flow through validator code. Document a threat model: rule-supplied fix text is considered TRUSTED (authored by us in-tree); user source is UNTRUSTED but read-only. The rewrite engine must NOT execute arbitrary input as code (no `Scanf.sscanf` into `Obj.magic`, no shell-out).
+
+### 6.2 Differential testing details
+
+Purpose: ensure v26.2 produces IDENTICAL validator output to v26.1 on the same source (except new fix suggestions).
+
+```bash
+# In PR C release-gate script:
+python3 scripts/tools/run_differential_test.py \
+  --baseline-tag v26.1.0 --new-ref HEAD \
+  --corpus corpora/regression/ \
+  --expected-diff-keys "fix"  # only this key may differ
+```
+
+If any non-fix field differs between tags, it's a regression. Requires building this tool (not currently in the plan's scripts); ~0.5 day added to C.
+
+### 6.3 Alpha-release smoke testing
+
+Each alpha tag:
+- `v26.2.0-alpha1`: run full test suite + compile_contract e2e on 3 real-user projects (if we have any)
+- `v26.2.0-alpha2`: run `--apply-fixes` on those same 3 projects; verify output still compiles
+
+---
+
+## 7. Risk register
+
+| # | Risk | Likelihood | Impact | Mitigation | Backout |
+|---|---|---|---|---|---|
+| R1 | CSTRoundTrip.v Coq proof intractable | Med | Hi | Pre-registered B2a/B2b split | Ship runtime-only; defer Coq proof |
+| R2 | T6/T7 Section pattern triggers anti-axiom gate | Low | Hi | §2.4 verified: Hypothesis ≠ Parameter | Reformulate as explicit arg |
+| R3 | Parser_l2 audit reveals CST-gen gap | Med | Med | B0.5 audit PR before B1 code | Add 0.5d for lightweight lex pass |
+| R4 | CST type API commitment wrong | Low-Med | Hi | Architecture-review comment required on B1 | v26.3 breaking change (last resort) |
+| R5 | aux_state parser incomplete on corpus | Med | Med | pdflatex-only explicit scope; xelatex/lualatex deferred | Doc limitation |
+| R6 | Proof-ci time exceeds 15-min budget | Med | Low | Existing proof-farm sharding | Skip shards on PRs |
+| R7 | Merge conflict between tracks (CHANGELOG/governance) | Low | Low | Per-PR rebase cadence; CHANGELOG section structure | Merge manually |
+| R8 | Coq 8.18 → Rocq 9 forced mid-project | Low | Med | Lock 8.18 in opam | Upgrade all proofs at once |
+| R9 | API-compat break in ad hoc PR | Low | Hi | `Validators.result` add-only; new modules new API | Reject PR |
+| R10 | CI flake blocks merge | Med | Low | Meta-gate catches gate-script bugs; known flakes documented | Rerun |
+| R11 | Single contributor burnout on 6-week plan | Med | Med | Alpha tags give visible progress | Redistribute PRs |
+| R12 | v26.1.0 critical bug post-tag | Low | Hi | Fast-cut v26.1.1 hotfix; v26.2 proceeds on main | Hotfix branch |
+| R13 | PR A0 decisions contested in review | Med | Med | Circulate §2 decisions to likely reviewers BEFORE opening A0; collect objections async | Rework A0 |
+| R14 | CI build time balloons with new modules/proofs | Med | Low | Monitor proof-ci elapsed; shard via existing proof-farm if >20min | Split _CoqProject |
+| R15 | Release-tag rollback needed (v26.2.0 critical bug) | Low | Hi | v26.2.1 hotfix; tag is never "unpublished", only superseded | Cut v26.2.1 quickly |
+| R16 | Coq Section/Variable pattern trips anti-axiom gate | Low | Med | Pre-verified in §2.4; small canary proof tests the gate | Adjust regex |
+| R17 | Alpha adopters report breakage between alpha1 and alpha2 | Med | Low | Alpha tags are explicitly "for testing"; document no-SLA | Document in release notes |
+| R18 | Single Coq reviewer bottleneck | Med | Med | Identify 2nd reviewer early; rotate per PR | Accept slower merges |
+| R19 | Corpus `.aux` test fails because pdflatex isn't in CI | Med | Low | Check-in pre-generated .aux files; skip if pdflatex missing | Generate once, commit |
+| R20 | v26.2 main drifts under hotfixes to v26.1.x | Low | Med | Rebase cadence on v26.2 branches; explicit re-basing clause | Rebase |
+
+---
+
+## 8. API stability commitment (v26.2 is additive over v26.1)
+
+- No public function signature changes.
+- No rule IDs renamed or removed.
+- No Coq theorem statements weakened.
+- `Validators.result` gains `fix : Cst_edit.edit option` field — in OCaml, adding a record field is source-compatible ONLY IF existing callers use label-based construction (`{ id; severity; message; count }`) without exhaustiveness-required patterns.
+
+  **Verification required in PR B3:** before merging the field addition, run
+  ```
+  grep -rn "match .* with" latex-parse/ | grep -v test_ | \
+    awk '/{ id *=|{ severity *=/' | head
+  ```
+  Any exhaustive pattern match on `result` that would break with a new field MUST be refactored to use `_` wildcard or explicitly ignore `fix`. If none found, the additive claim holds. If found, either refactor those call sites OR retract the additive claim (would force v26.2 to be a minor-major bump).
+
+- New modules are new public API surface (`Cst`, `Cst_edit`, `Rewrite_engine`, `Project_model`, `Build_graph`, `Aux_state`, `Compile_contract`, `Stable_spans`).
+- Memo-alias modules in `core/l2_parser/` are re-exports; same API as canonical `latex-parse/src/` modules.
+
+**Deprecations and breaking changes are v27 scope.**
+
+---
+
+## 9. Scope-saving note for v27
+
+By shipping v26.2 as planned:
+- **v27 WS7 (CST substrate) deliverables:** CST layer ✓, CST↔AST mapping ✓, stable IDs ✓, rewrite engine ✓, round-trip preservation ✓ (runtime + Coq-if-B2-lands), fix-preservation framework ✓. **Effectively delivered by v26.2.**
+- **v27 WS8 (stronger compile-guarantee stack) deliverables:** engine profile semantics ✓, toolchain profile semantics ✓, theorem stack documented and partially mechanised ✓, project compile guarantee ✓ (hypothesis-parametric). **Effectively delivered by v26.2.**
+
+v27 focus then reduces to WS9 (editorial policy), WS10 (collaboration), WS11 (platform/deployment), WS12 (extension plane).
+
+---
+
+## 10. Deferrals
+
+### Deferred to v26.3 (explicit)
+
+- xelatex / lualatex .aux parser variants
+- Full `CSTRoundTrip.v` coverage of `\verb`, catcode mutations, `\lstlisting`
+- Automatic conflict-aware rewrite merging
+- Rolling `fix` suggestions for all 660 rules (v26.2 has ~3 exemplars)
+- `specs/v26/partial_document_semantics.yaml` (memo §7; prose doc ships in v26.2)
+
+### Deferred to v27 (per memo §17)
+
+- WS9 Editorial policy system
+- WS10 Collaboration platform
+- WS11 Deployment / permissions
+- WS12 Extension plane + foreign contracts
+- Discharge of T6/T7 hypotheses with real toolchain model (WS8 refinement)
+
+### Out of v26.x entirely
+
+- gRPC interface (memo §10 "only if demand warrants")
+- Runtime observability / SLOs (deployment concern, not library concern)
+- Coq extraction for full runtime-binding verification (requires CST surgery to have a richer target)
+
+---
+
+## 11. Process decisions (pre-filled, override if needed)
+
+v3 left these as open questions; v4 fills in default answers. Override if project reality differs.
+
+- **Branch strategy:** feature-branch-per-PR, merge-commit into main. Matches #241–#247 history. No long-lived v26.2 branch.
+- **Reviewer assignment:** each PR's reviewer TBD at open-time; Coq PRs (A3, B2, B3) require 2 reviewers minimum. Explicit rule: author cannot self-merge Coq work.
+- **RC tag?** No — ship alpha1 (after A3), alpha2 (after B3), then final. Skipping rc keeps the cadence lean.
+- **Alpha adoption tracking:** monitor GitHub Issues tagged `v26.2-alpha-feedback`. If zero external feedback after 1 week of alpha1, ship alpha2 + final on schedule. No active solicitation — per [COMMUNICATION_PLAN.md](../../docs/v26_2/COMMUNICATION_PLAN.md) silence policy.
+- **Change-management approval:** this plan needs tech-lead sign-off before PR A0 opens. Sign-off = an inline comment on PR A0 draft or a short approval commit to the repo.
+- **Plan-file splitting:** done in v4 — §6 testing + §7 risks stay in-plan; personas, rollback, communications, style, corpus split into `docs/v26_2/`.
+- **Licensing of new files:** new OCaml modules inherit repo's MIT license (already in `LICENSE`). No per-file copyright headers required (matches existing convention).
+- **i18n for fix messages:** English-only in v26.2. Locale deferred per [USER_PERSONAS.md](../../docs/v26_2/USER_PERSONAS.md).
+- **Metrics/telemetry:** none in v26.2 code. Deploy-time concern.
+- **Docs organisation:** flat `docs/` stays for now; `docs/v26_2/` groups release-specific docs. Not yet refactoring to `docs/by-layer/`.
+
+---
+
+## 12. First concrete action
+
+Open **PR A0**: commit this plan + ADRs + three-graphs doc. Pure docs. 4 hours.
+
+After PR #247 merges and v26.1.0 is tagged:
+
+```
+git checkout main && git pull
+git checkout -b v26.2/a0-decisions
+# Files already in place from this planning session:
+#   specs/v26/V26_2_PLAN.md
+# Create:
+#   docs/ARCHITECTURAL_DECISIONS.md
+#   docs/THREE_GRAPHS.md
+python3 scripts/tools/pre_release_check.py --allow-dirty --skip-build
+git commit -m "docs(v26.2): PR A0 — architectural decisions + plan"
+git push -u origin v26.2/a0-decisions
+gh pr create --title "docs(v26.2): PR A0 — decisions + plan" \
+  --body "..."
+```
+
+---
+
+## 13. v26.3 preview (horizon)
+
+After v26.2.0 ships:
+- Extended aux_state parsers (xelatex, lualatex)
+- `CSTRoundTrip.v` full proof (lift deferral from B2b)
+- Rolling fix coverage for more rules
+- Rewrite conflict-aware merge
+- partial_document_semantics.yaml
+
+v26.3 is a smaller, more incremental release than v26.1 / v26.2. Estimated 2-3 weeks.
+
+v27 follows: editorial / collaboration / platform. Entirely new product.


### PR DESCRIPTION
## Summary

Opens the v26.2 track. Pure documentation: zero code, zero proofs. Locks the architectural decisions that PR A1/B1 depend on before coding starts.

## What's in this PR

### Main plan
- [`specs/v26/V26_2_PLAN.md`](../blob/v26.2/a0-plan-and-adrs/specs/v26/V26_2_PLAN.md) — five-round-audited plan (v1 → v5). Seven PRs (A0/A1/A2/A3 + B0.5/B1/B2/B3) + final tag PR C. Per-PR acceptance criteria, 20-row risk register, API stability commitment, timeline (single-contributor 4-6 weeks, two-contributor parallel ~3.5 weeks), alpha-tag strategy.

### Companion sub-docs (authored as part of A0)
- [`docs/v26_2/USER_PERSONAS.md`](../blob/v26.2/a0-plan-and-adrs/docs/v26_2/USER_PERSONAS.md) — P1 academic / P2 industrial / P3 library consumer; anchors every contested feature decision.
- [`docs/v26_2/ROLLBACK_DRILL.md`](../blob/v26.2/a0-plan-and-adrs/docs/v26_2/ROLLBACK_DRILL.md) — concrete 3-hour hotfix procedure, apply-fixes corruption recovery, release.yml failure recovery.
- [`docs/v26_2/COMMUNICATION_PLAN.md`](../blob/v26.2/a0-plan-and-adrs/docs/v26_2/COMMUNICATION_PLAN.md) — GitHub Releases templates, alpha expectations, post-tag verification.
- [`docs/v26_2/FIX_STYLE_GUIDE.md`](../blob/v26.2/a0-plan-and-adrs/docs/v26_2/FIX_STYLE_GUIDE.md) — canonical patterns + anti-patterns for rule authors adding `fix : Cst_edit.edit option` suggestions.
- [`docs/v26_2/CORPUS_LICENSING.md`](../blob/v26.2/a0-plan-and-adrs/docs/v26_2/CORPUS_LICENSING.md) — licensing policy + curation process for new corpora.

### Gate tweak
- `scripts/tools/check_doc_refs.py`: adds `V26_2_PLAN` and `v26_2/` to the planning-docs exclusion list. Plans reference future file paths by design.

## Locked architectural decisions (plan §2)

After three rounds of audit:

1. **`core/l2_parser/` alias pattern** — ship under `latex-parse/src/` with thin alias modules at memo-prescribed paths.
2. **`aux_state` vs `build_artifact_state`** — distinct modules; `aux_state` parses the .aux FILE, `build_artifact_state` wraps the runtime profile.
3. **Four graphs** — `Validator_dag` + `project_graph` + `dependency_graph` + `build_graph` all distinct, documented in `docs/FOUR_GRAPHS.md` (written in A1).
4. **Hypothesis-parametric T6/T7 proofs** — `Section` + `Variable` pattern; zero `Axiom` / `Parameter` declarations; canary test required before shipping.
5. **CST round-trip semantics** — byte-lossless for any valid UTF-8 via `Unparsed` fallback; structure-lossless for declared subset (§2.6).
6. **CST subset** — UTF-8 multi-byte OK; `\verb` / `\lstlisting` / catcode-body-mutation out.
7. **T6/T7 timing** — ship in v26.2 hypothesis-parametric; v27 WS8 discharges hypotheses.
8. **CST generation** — post-process Parser_l2 AST + source slicing. Parser_l2 capability audit (PR B0.5) is prerequisite.

## What this PR does NOT do

- No code.
- No proofs.
- No CI changes beyond the doc-refs gate exclusion.
- Does not commit to any implementation details — those come in A1+.

## Test plan
- [x] All 13 CI gates PASS
- [x] `pre_release_check.py --allow-dirty --skip-build` PASSES
- [x] `check_doc_refs.py` PASSES with new exclusions applied
- [x] No broken internal doc links across the 5 new sub-docs