### PR TITLE
feat(v26.2): PR A1 — compilation guarantee stack specs

### DIFF
--- a/docs/COMPILATION_GUARANTEE.md
+++ b/docs/COMPILATION_GUARANTEE.md
@@ -1,0 +1,137 @@
+# Compilation guarantee — user-facing summary
+
+**For LaTeX Perfectionist v26.2+.**
+
+This doc summarises what claims v26.2 makes about your project's
+compilability, and what claims it explicitly does not make. Formal
+details live in [specs/v26/compilation_guarantee_stack.md](../specs/v26/compilation_guarantee_stack.md)
+and [specs/v26/compilation_profiles.yaml](../specs/v26/compilation_profiles.yaml).
+
+---
+
+## TL;DR
+
+Run `latex_parse_cli --compile-check path/to/main.tex` before running
+latexmk. If it says **Ready**, you can trust these properties (within
+the declared profile):
+
+- Your source parses cleanly.
+- Your user-defined macros are in the bounded subset and don't cycle.
+- Your multi-file project is closed (no missing `\input`, no cycles).
+- Your selected engine supports every declared feature.
+- No Error-level style rule still fires.
+
+Everything else about compile success falls back on the toolchain
+itself — v26.2 ships theorems **parametric on toolchain convergence**;
+if pdflatex, xelatex, or lualatex does its job, you're good.
+
+---
+
+## What `--compile-check` runs
+
+The CLI's `--compile-check` flag invokes `Compile_contract.check_ready_to_compile`
+in `latex-parse/src/compile_contract.ml`. This checks five conditions
+(T0 through T5 in the [theorem stack](../specs/v26/compilation_guarantee_stack.md)):
+
+| Check | What it verifies | Failure reason kind |
+|---|---|---|
+| T0 Parse | `Parser_l2.parse` accepts the source | `T0_parse_fails` |
+| T1 Expansion | User macros are in-subset + acyclic | `T1_expansion_fails` |
+| T2 Project closed | All `\input`s resolve; no include-cycles | `T2_project_not_closed` |
+| T3 Profile compat | Engine supports all declared features | `T3_profile_incompatible` |
+| T4 Semantic coherence | Labels unique across files; refs resolve; counters/bib consistent | `T4_semantic_incoherent` |
+| T5 Rule safety | No Error-level lint rule fires | `T5_rule_violations` |
+
+If all five pass, `check_ready_to_compile` returns `Ready`. Otherwise a
+list of structured reasons is returned.
+
+---
+
+## Theorems that are NOT runtime checks
+
+- **T6 (compilation progress):** if T0–T5 hold AND the toolchain
+  converges in bounded passes, compilation succeeds. v26.2 ships this
+  as a **conditional** theorem (hypothesis-parametric). The toolchain
+  itself is the "prover" at runtime — we trust pdflatex / xelatex /
+  lualatex to converge.
+- **T7 (output well-formedness):** if T6 holds AND the toolchain
+  produces a well-formed artefact, the output satisfies the subset's
+  output contract (valid PDF graph, refs resolved). Same parametric
+  pattern.
+
+Full discharge of T6/T7 (instantiating the toolchain model in Coq)
+is [v27 WS8](../specs/v27/V27_REPO_EXACT_MASTER_SPEC.md) work.
+
+---
+
+## Per-profile coverage
+
+| Profile | Status | T6/T7 discharge |
+|---|---|---|
+| pdflatex | GA | v26.2 hypothesis-parametric; v27 WS8 concrete |
+| xelatex | beta | same; v26.3 adds xelatex aux-parser |
+| lualatex | beta | same; \\directlua side effects out of scope |
+| pTeX/upTeX | experimental | no T6/T7 claim in v26.2 |
+
+Full profile metadata: [compilation_profiles.yaml](../specs/v26/compilation_profiles.yaml).
+
+---
+
+## What this is NOT
+
+- **A replacement for latexmk.** Run `--compile-check` first for
+  fast-fail; then run your real build. They're complementary.
+- **A style checker.** The existing validators cover that.
+  `--compile-check` only verifies compile-readiness, not style.
+- **A guarantee against LaTeX bugs.** If pdflatex itself has a bug on
+  your document, v26.2 can't catch it — T6 is parametric on toolchain
+  correctness.
+- **A Coq-extracted runtime.** v26.2's Coq theorems verify the
+  abstract pipeline; the runtime OCaml is hand-written and tested,
+  not mechanically extracted. v27 may ship an extracted variant.
+
+---
+
+## Example: CI usage
+
+```yaml
+# .github/workflows/my-paper.yml
+- name: Check compile readiness
+  run: latex_parse_cli --compile-check main.tex
+- name: Build with latexmk
+  if: success()
+  run: latexmk -pdf main.tex
+```
+
+`--compile-check` exits 0 on Ready, non-zero on any failure reason.
+Exit codes + structured stderr let CI fail fast before latexmk bills
+you for compute on a document that can't possibly compile cleanly.
+
+---
+
+## Example: library usage
+
+```ocaml
+open Latex_parse_lib
+
+let () =
+  let project = Project_model.of_root "main.tex" in
+  let profile = Build_profile.detect () in
+  match Compile_contract.check_ready_to_compile project profile with
+  | Ready -> print_endline "OK to compile"
+  | NotReady reasons ->
+      List.iter (fun r -> print_endline (reason_to_string r)) reasons
+```
+
+For formal reasoning, instantiate the Section-quantified theorems in
+`proofs/CompileProgress.v` with your own toolchain model and discharge
+the `compile_progress_rule` hypothesis.
+
+---
+
+## References
+
+- [specs/v26/compilation_guarantee_stack.md](../specs/v26/compilation_guarantee_stack.md)  — T0–T7 formal detail
+- [specs/v26/compilation_profiles.yaml](../specs/v26/compilation_profiles.yaml) — profile metadata
+- [docs/v26_2/adr/ADR-007](v26_2/adr/ADR-007-compile-stack-ships-in-v26-2.md) — why this ships in v26.2
+- [docs/SUPPORT_MATRIX.md](SUPPORT_MATRIX.md) — broader support matrix

--- a/specs/v26/compilation_guarantee_stack.md
+++ b/specs/v26/compilation_guarantee_stack.md
@@ -1,0 +1,253 @@
+# Compilation guarantee theorem stack (v26.2 + v27 WS8)
+
+**Status:** v26.2 ships hypothesis-parametric T0–T7 scaffolding; v27 WS8 discharges hypotheses with a concrete toolchain model.
+**Authoritative:** memo `REPO_EXACT_MISSING_ARCHITECTURE_MEMO_V26_V27.md` §5.
+**Companion ADR:** [ADR-004](../../docs/v26_2/adr/ADR-004-hypothesis-parametric-t6-t7.md), [ADR-007](../../docs/v26_2/adr/ADR-007-compile-stack-ships-in-v26-2.md).
+
+---
+
+## 1. What this stack claims
+
+> For projects in `LP-Core(engine, profile)`, if parsing succeeds, all
+> required artefacts resolve, macro registration is accepted, the
+> project DAG is closed, and all Error-level rules pass, then compilation
+> succeeds under the selected build profile and yields a well-formed
+> output artefact.
+
+This is not one theorem — it's a **stack of eight**, each guarding a
+specific step of the compile pipeline. Individually each is simpler; the
+composition is the project's compile contract.
+
+---
+
+## 2. The eight theorems
+
+### T0 — Parser acceptance
+
+**Informal:** If source is in `LP-Core`, `Parser_l2.parse` accepts and produces an AST.
+
+**Coq shape** (v26.2, wrapper around existing `ParserSound.v`):
+```coq
+Theorem T0_parser_accepts :
+  forall (s : string),
+    in_lp_core s -> exists ast, Parser_l2.parse s = Ok ast.
+```
+
+**v26.2 wrapper file:** `proofs/T0_wrapper.v`.
+**Status:** mechanized (reuses existing `ParserSound.v`).
+
+### T1 — Expansion admissibility
+
+**Informal:** For admissible user and built-in macros, expansion terminates and preserves language admissibility.
+
+**Coq shape** (v26.2 wrapper around existing `UserExpand.v`):
+```coq
+Theorem T1_expansion_admissible :
+  forall (doc : document) (registry : User_macro_registry.t),
+    all_macros_in_subset registry ->
+    acyclic_registry registry ->
+    exists doc', expand doc registry = Ok doc'.
+```
+
+**v26.2 wrapper file:** `proofs/T1_wrapper.v`.
+**Status:** mechanized (reuses `UserExpand.v` termination + `UserMacroRegistrySound.v`).
+
+### T2 — Project closure
+
+**Informal:** The project include/build graph is finite, acyclic where required, and all required assets resolve.
+
+**Coq shape** (v26.2, extends existing `ProjectSemantics.v`):
+```coq
+Theorem T2_project_closed :
+  forall (p : project),
+    project_well_formed p ->
+    acyclic_project p ->
+    (forall f, included_from p f -> In f p.(proj_files)).
+```
+
+**v26.2 file:** `proofs/ProjectClosure.v`.
+**Status:** new mechanization, extends `ProjectSemantics.v`.
+
+### T3 — Build profile admissibility
+
+**Informal:** The selected engine/toolchain profile is compatible with the project's declared features.
+
+**Coq shape** (v26.2):
+```coq
+Theorem T3_profile_compatible :
+  forall (p : project) (prof : profile),
+    decidable_feature_support prof p.(declared_features) = true ->
+    profile_admits p prof.
+```
+
+**v26.2 file:** `proofs/BuildProfileSound.v`.
+**Status:** new; decidability is the load-bearing content.
+
+### T4 — Semantic state coherence
+
+**Informal:** Global semantic state over project files is consistent — labels, refs, counters, bibliography, float metadata, etc.
+
+**Coq shape** (v26.2, wrapper around `LabelsUnique.v` + `ProjectSemantics.v`):
+```coq
+Theorem T4_semantic_coherent :
+  forall (p : project),
+    T2_project_closed p ->
+    labels_globally_unique p /\
+    refs_resolve_within p /\
+    counters_consistent p /\
+    bib_entries_resolve p.
+```
+
+**v26.2 wrapper file:** `proofs/T4_wrapper.v`.
+**Status:** labels + refs mechanized; counters + bib are
+hypothesis-parametric in v26.2, discharged in v27 WS8.
+
+### T5 — Rule safety
+
+**Informal:** If no Error-level rule fires within its proof class / contract class, no statically detectable violation remains inside the contract.
+
+**Coq shape** (v26.2 wrapper around per-rule QED chain):
+```coq
+Theorem T5_rule_safe :
+  forall (p : project) (rules : list rule_t),
+    all_error_rules_pass p rules ->
+    no_static_violation p.
+```
+
+**v26.2 wrapper file:** `proofs/T5_wrapper.v`.
+**Status:** mechanized where per-rule proofs exist
+(see `proofs/generated/`); gaps documented in `proofs/T5_wrapper.v`
+header for rules with only family-level proofs.
+
+### T6 — Compilation progress
+
+**Informal:** Given T0–T5 and bounded build assumptions, the project compiles without fatal errors.
+
+**Coq shape** (v26.2, hypothesis-parametric per ADR-004):
+```coq
+Section Compile_progress.
+  Variable bounded_build_terminates_for : project -> profile -> Prop.
+  Hypothesis compile_progress_rule :
+    forall p pf,
+      T0_accepts p -> T1_admissible p -> T2_closed p ->
+      T3_compatible p pf -> T4_coherent p -> T5_safe p ->
+      bounded_build_terminates_for p pf ->
+      compilation_succeeds p pf.
+
+  Theorem T6_compile_progress_under_bound :
+    forall p pf,
+      T0_accepts p -> T1_admissible p -> T2_closed p ->
+      T3_compatible p pf -> T4_coherent p -> T5_safe p ->
+      bounded_build_terminates_for p pf ->
+      compilation_succeeds p pf.
+  Proof. intros; apply compile_progress_rule; assumption. Qed.
+End Compile_progress.
+```
+
+**v26.2 file:** `proofs/CompileProgress.v`.
+**Status:** hypothesis-parametric. v27 WS8 instantiates
+`bounded_build_terminates_for` and `compile_progress_rule` against a
+concrete toolchain model (e.g. `Module PdflatexModel`).
+
+### T7 — Output well-formedness
+
+**Informal:** Produced artefacts satisfy the subset's output contract — valid PDF graph, no missing refs within scope, etc.
+
+**Coq shape** (v26.2, hypothesis-parametric per ADR-004):
+```coq
+Section Output_wellformed.
+  Variable output_format_well_formed : artefact -> Prop.
+  Hypothesis output_wellformed_rule :
+    forall p pf out,
+      compilation_succeeds p pf ->
+      produces p pf out ->
+      output_format_well_formed out.
+
+  Theorem T7_output_wellformed :
+    forall p pf out,
+      T6_compile_progress_under_bound p pf ->
+      produces p pf out ->
+      output_format_well_formed out.
+End Output_wellformed.
+```
+
+**v26.2 file:** `proofs/CompileWellFormed.v`.
+**Status:** hypothesis-parametric. v27 WS8 discharges `output_format_well_formed` against PDF / DVI / PS artefact validators.
+
+---
+
+## 3. Runtime counterpart
+
+Each theorem has a runtime checker in `latex-parse/src/compile_contract.ml`:
+
+```ocaml
+val check_ready_to_compile :
+  Project_model.t -> Build_profile.t -> ready_check_result
+
+type ready_check_result =
+  | Ready
+  | NotReady of reason list
+
+type reason =
+  | T0_parse_fails of string
+  | T1_expansion_fails of string
+  | T2_project_not_closed of cycle_or_missing
+  | T3_profile_incompatible of string
+  | T4_semantic_incoherent of string
+  | T5_rule_violations of rule_id list
+```
+
+T6/T7 are proof-only at runtime (they say "if everything else holds, compile
+succeeds"). Callers don't check T6/T7 at runtime — they check T0–T5 via
+`check_ready_to_compile`, invoke the toolchain, and trust T6/T7 to match
+the toolchain's behaviour per the v27 WS8 instantiation.
+
+---
+
+## 4. v27 WS8 discharge path
+
+v27 WS8 writes a concrete toolchain model:
+
+```coq
+Module PdflatexModel.
+  Definition profile := Pdflatex.
+  Definition project := ...
+  Definition bounded_build_terminates_for (p : project) (pf : profile)
+    : Prop := pdflatex_pass_count_bounded p.
+  Lemma bounded_pass_count_holds : forall p pf, ... .
+  Definition compile_progress_rule : ... := ... .
+  Definition output_format_well_formed (out : artefact) : Prop :=
+    valid_pdf out.
+End PdflatexModel.
+```
+
+`PdflatexModel` instantiates the Section Variables from v26.2's
+`CompileProgress.v` and `CompileWellFormed.v`, producing concrete
+theorems:
+
+```coq
+Theorem pdflatex_compile_progress :
+  forall p, ... -> compilation_succeeds p Pdflatex.
+```
+
+---
+
+## 5. What's NOT covered
+
+- **LP-Extended** (best-effort contract tier): only T0–T5 run; T6/T7 skip.
+- **LP-Foreign** (out of contract): all theorems skip; runtime can't make claims.
+- **Engine-specific output contracts for xelatex / lualatex:** v27+ scope.
+- **Bibliography semantics beyond \bibliography \cite / \newlabel from .aux:** v27 WS8 refinement.
+- **Non-deterministic toolchain behaviour** (e.g. pdflatex with different `\write18` settings): out of scope.
+
+---
+
+## 6. References
+
+- Memo §5 — full informal specification of T0–T7.
+- ADR-004 — hypothesis-parametric pattern rationale.
+- ADR-007 — why v26.2 scaffolding vs v27-only.
+- `specs/v26/compilation_profiles.yaml` — machine-readable profile metadata.
+- `docs/COMPILATION_GUARANTEE.md` — user-facing summary.
+- `proofs/ADMISSIBILITY_MAP.md` — (created in PR A3) maps every
+  hypothesis T6/T7 rely on to v27 WS8 discharge tasks.

--- a/specs/v26/compilation_profiles.yaml
+++ b/specs/v26/compilation_profiles.yaml
@@ -1,0 +1,120 @@
+# Compilation profiles — v26.2
+#
+# Machine-readable metadata for each supported engine/toolchain profile.
+# Consumed by:
+#   - latex-parse/src/build_profile.ml (runtime profile type)
+#   - latex-parse/src/compile_contract.ml (T3 profile-admissibility check)
+#   - docs/COMPILATION_GUARANTEE.md (user-facing profile table)
+#
+# Companion: specs/v26/compilation_guarantee_stack.md §§ T3, T7.
+# ADR:       docs/v26_2/adr/ADR-007-compile-stack-ships-in-v26-2.md
+
+version: v26.2
+schema_version: 1
+
+profiles:
+  - id: pdflatex
+    name: "pdflatex"
+    status: "GA"
+    aux_format: pdflatex        # v26.2 aux_state.ml parses this only
+    output_format: pdf
+    supported_features:
+      - utf8_inputenc            # \usepackage[utf8]{inputenc}
+      - babel_standard           # standard babel languages
+      - amsmath
+      - hyperref
+      - graphicx_eps_only        # EPS figures; no native PDF vector
+      - bibtex
+      - natbib
+      - biblatex_backend_bibtex
+    unsupported_features:
+      - unicode_math              # use unicode-math package → xelatex
+      - opentype_fonts            # system fonts → xelatex / lualatex
+      - lua_scripting             # \directlua → lualatex
+    toolchain_version_range:
+      min: "3.14159265-2.6-1.40.20"   # TeX Live 2019 minimum
+      tested: "3.14159265-2.6-1.40.25" # TeX Live 2024 tested
+    pass_iteration:
+      bounded: true
+      typical_max: 5               # most projects converge ≤5 passes
+    documented_limits:
+      max_input_bytes: 10485760    # 10 MiB
+      max_project_files: 500
+
+  - id: xelatex
+    name: "xelatex"
+    status: "beta"                 # v26.2: runtime detection works; aux_state parser is pdflatex-only
+    aux_format: pdflatex           # xelatex writes mostly-compatible .aux
+    output_format: pdf
+    supported_features:
+      - utf8_direct                # no inputenc required; native UTF-8
+      - opentype_fonts
+      - babel_standard
+      - polyglossia
+      - unicode_math
+      - amsmath
+      - hyperref
+      - graphicx_png_jpg_pdf       # native multi-format
+    unsupported_features:
+      - lua_scripting
+    toolchain_version_range:
+      min: "0.999991"
+      tested: "0.999996"
+    pass_iteration:
+      bounded: true
+      typical_max: 4
+    known_limitations:
+      - "v26.2 aux_state parser is pdflatex-only; xelatex .aux files usually parse but edge cases (different counter serializations) may fail. v26.3 ships xelatex-aware parser."
+
+  - id: lualatex
+    name: "lualatex"
+    status: "beta"
+    aux_format: pdflatex            # lualatex .aux similar to pdflatex
+    output_format: pdf
+    supported_features:
+      - utf8_direct
+      - opentype_fonts
+      - lua_scripting
+      - babel_standard
+      - polyglossia
+      - unicode_math
+      - amsmath
+      - hyperref
+      - graphicx_png_jpg_pdf
+    unsupported_features: []
+    toolchain_version_range:
+      min: "1.10.0"
+      tested: "1.18.0"
+    pass_iteration:
+      bounded: true
+      typical_max: 4
+    known_limitations:
+      - "v26.2 aux_state parser is pdflatex-only; lualatex handled same as xelatex (see xelatex.known_limitations)."
+      - "\\directlua side effects may cause compile failures that v26.2 can't predict; rule safety (T5) covers only static analysis."
+
+  - id: ptex_uptex
+    name: "pTeX / upTeX (Japanese)"
+    status: "experimental"
+    aux_format: pdflatex            # best effort
+    output_format: dvi_or_pdf
+    supported_features:
+      - japanese_cjk
+      - pjapanese
+      - pBabel
+    unsupported_features:
+      - unicode_math
+      - opentype_fonts
+    toolchain_version_range:
+      min: "3.10.0"
+      tested: null
+    pass_iteration:
+      bounded: true
+      typical_max: 6                # Japanese typesetting often needs more passes
+    known_limitations:
+      - "Experimental. v26.2 compile_contract returns [Ready] for simple ptex documents but cannot claim T6/T7 soundness."
+      - "No dedicated aux_state variant; relies on pdflatex-compatible subset."
+
+# Global notes
+notes:
+  - "v26.2 ships formal T6/T7 proofs parametric on bounded_build_terminates_for and output_format_well_formed. v27 WS8 discharges these per profile."
+  - "status levels follow docs/SUPPORT_MATRIX.yaml semantics: GA > beta > alpha > experimental."


### PR DESCRIPTION
## Summary

Plan §3.1 PR A1. Pure specs, no code, no proofs. Depends on A0 (PR #250, merged). Unblocks PR A2 (runtime scaffold) and PR A3 (proofs).

## Contents

### `specs/v26/compilation_guarantee_stack.md`
T0–T7 theorem stack with Coq signature sketches per ADR-004. References existing proof modules (ParserSound, UserExpand, LabelsUnique, ProjectSemantics) as wrappers where they apply. T6/T7 explicitly hypothesis-parametric via Section + Variable pattern — v27 WS8 discharges the hypotheses with a concrete toolchain model.

### `specs/v26/compilation_profiles.yaml`
Machine-readable per-engine metadata:
- **pdflatex** — GA. v26.2 aux_state parser targets this.
- **xelatex** — beta. .aux parser works but edge cases deferred to v26.3.
- **lualatex** — beta. `\directlua` side effects out of scope for T5.
- **ptex_uptex** — experimental. No T6/T7 claim in v26.2.

Each profile lists `supported_features`, `unsupported_features`, `toolchain_version_range`, `pass_iteration` bounds, and `known_limitations`.

### `docs/COMPILATION_GUARANTEE.md`
User-facing summary addressing the three personas from USER_PERSONAS.md:
- **P1 academic** — run `latex_parse_cli --compile-check main.tex` before latexmk
- **P2 industrial CI** — fail-fast predicate, structured exit codes, per-engine coverage table
- **P3 library consumer** — OCaml API + Coq theorem instantiation path

## What this PR does NOT do

- No code (A2 delivers runtime modules)
- No proofs (A3 delivers `proofs/CompileProgress.v` etc.)
- Does not modify existing modules

## Test plan
- [x] All 13 CI gates PASS
- [x] `pre_release_check.py --allow-dirty --skip-build` PASSES
- [x] `check_doc_refs.py` passes on new COMPILATION_GUARANTEE.md (internal links resolve)
- [x] `check_memo_files.py` resolves `specs/v26/compilation_profiles.yaml` directly (removed from PATH_ALIASES in A0 pending, may need next-PR tweak)