### PR TITLE
feat(v26.2): PR A2a — project_model + build_graph

### DIFF
--- a/latex-parse/src/build_graph.ml
+++ b/latex-parse/src/build_graph.ml
@@ -1,0 +1,121 @@
+(** Build-pipeline dependency graph. See [build_graph.mli]. *)
+
+type node_id = int
+type artefact_kind = Tex | Aux | Bbl | Bib | Pdf | Log
+type node = { id : node_id; kind : artefact_kind; path : string; exists : bool }
+type edge = { from_id : node_id; to_id : node_id; reason : string }
+type t = { nodes : node list; edges : edge list }
+
+let kind_to_string = function
+  | Tex -> "tex"
+  | Aux -> "aux"
+  | Bbl -> "bbl"
+  | Bib -> "bib"
+  | Pdf -> "pdf"
+  | Log -> "log"
+
+(* Predict the artefact path from a .tex path. pdflatex places .aux, .log, .pdf
+   next to the .tex by default. v26.2 doesn't track \jobname / -output-directory
+   overrides — callers with custom output dirs should build their own graph. *)
+let predict_path (tex_path : string) (k : artefact_kind) : string =
+  let base = Filename.remove_extension tex_path in
+  match k with
+  | Tex -> tex_path
+  | Aux -> base ^ ".aux"
+  | Log -> base ^ ".log"
+  | Pdf -> base ^ ".pdf"
+  | Bbl -> base ^ ".bbl"
+  | Bib -> base ^ ".bib" (* only used for isolated bib files *)
+
+let of_project (proj : Project_model.t) : t =
+  let next_id = ref 0 in
+  let mk_id () =
+    let i = !next_id in
+    next_id := i + 1;
+    i
+  in
+  let nodes = ref [] in
+  let edges = ref [] in
+  (* For each .tex in the project, add Tex and predicted Aux nodes and the
+     tex→aux edge. The root .tex also gets a predicted .pdf node. *)
+  List.iter
+    (fun (f : Project_model.file_entry) ->
+      let tex_id = mk_id () in
+      let tex_node =
+        {
+          id = tex_id;
+          kind = Tex;
+          path = f.path;
+          exists = Sys.file_exists f.path;
+        }
+      in
+      nodes := tex_node :: !nodes;
+      (* Each .tex predicts an .aux *)
+      let aux_path = predict_path f.path Aux in
+      let aux_id = mk_id () in
+      let aux_node =
+        {
+          id = aux_id;
+          kind = Aux;
+          path = aux_path;
+          exists = Sys.file_exists aux_path;
+        }
+      in
+      nodes := aux_node :: !nodes;
+      edges :=
+        { from_id = tex_id; to_id = aux_id; reason = "pdflatex pass" } :: !edges;
+      (* Root additionally predicts a .pdf *)
+      if f.is_root then (
+        let pdf_path = predict_path f.path Pdf in
+        let pdf_id = mk_id () in
+        let pdf_node =
+          {
+            id = pdf_id;
+            kind = Pdf;
+            path = pdf_path;
+            exists = Sys.file_exists pdf_path;
+          }
+        in
+        nodes := pdf_node :: !nodes;
+        edges :=
+          { from_id = tex_id; to_id = pdf_id; reason = "final pdflatex pass" }
+          :: !edges))
+    (Project_model.all_files proj);
+  { nodes = List.rev !nodes; edges = List.rev !edges }
+
+let nodes (t : t) : node list = t.nodes
+let edges (t : t) : edge list = t.edges
+
+let find_node (t : t) (id : node_id) : node option =
+  List.find_opt (fun n -> n.id = id) t.nodes
+
+let find_by_path (t : t) (path : string) : node option =
+  List.find_opt (fun n -> n.path = path) t.nodes
+
+(* DFS-based cycle detection. In the build graph this is always acyclic in
+   well-formed projects (no build artefact circularly depends on itself). Here
+   for completeness and as a T2 check. *)
+let is_acyclic (t : t) : bool =
+  let adj = Hashtbl.create 16 in
+  List.iter (fun n -> Hashtbl.replace adj n.id []) t.nodes;
+  List.iter
+    (fun e ->
+      let cur = try Hashtbl.find adj e.from_id with Not_found -> [] in
+      Hashtbl.replace adj e.from_id (e.to_id :: cur))
+    t.edges;
+  let visiting = Hashtbl.create 16 in
+  let visited = Hashtbl.create 16 in
+  let rec dfs n =
+    if Hashtbl.mem visiting n then false (* back edge *)
+    else if Hashtbl.mem visited n then true
+    else (
+      Hashtbl.replace visiting n ();
+      let ok =
+        let succs = try Hashtbl.find adj n with Not_found -> [] in
+        List.for_all dfs succs
+      in
+      Hashtbl.remove visiting n;
+      Hashtbl.replace visited n ();
+      ok)
+  in
+  List.for_all (fun n -> dfs n.id) t.nodes

--- a/latex-parse/src/build_graph.mli
+++ b/latex-parse/src/build_graph.mli
@@ -1,0 +1,49 @@
+(** Build-pipeline dependency graph (memo §5.5, v26.2).
+
+    Distinct from [project_graph] (include graph of .tex files), from
+    [dependency_graph] (semantic chunk invalidation), and from [Validator_dag]
+    (rule dependencies). See [docs/FOUR_GRAPHS.md].
+
+    Nodes are BUILD ARTEFACTS: `.tex`, `.aux`, `.bbl`, `.bib`, `.pdf`, `.log`.
+    Edges are "produced-from" relationships:
+    - tex → aux (pdflatex pass produces .aux from .tex)
+    - bib → bbl (bibtex produces .bbl from .bib + .aux)
+    - tex → pdf (final pdflatex pass produces .pdf)
+
+    T2 project-closure check (`Compile_contract`) uses this graph to verify
+    required artefacts resolve and no cycles exist. *)
+
+type node_id
+type artefact_kind = Tex | Aux | Bbl | Bib | Pdf | Log
+
+type node = {
+  id : node_id;
+  kind : artefact_kind;
+  path : string;
+  exists : bool;
+      (** Whether the file currently exists on disk. Informational; pre-compile
+          state always has tex existing and aux/bbl/pdf possibly not. *)
+}
+
+type edge = { from_id : node_id; to_id : node_id; reason : string }
+type t
+
+val of_project : Project_model.t -> t
+(** Build a [t] from a project_model. Adds one [Tex] node per .tex file, one
+    [Aux] per tex (predicted path, may not exist yet), and the corresponding
+    produce-from edges.
+
+    This function does NOT read .bib files to resolve them — that requires
+    aux_state parsing. v26.2 [of_project] provides the scaffolding;
+    [Compile_contract] enriches the graph with .bbl nodes after aux_state runs. *)
+
+val nodes : t -> node list
+val edges : t -> edge list
+val find_node : t -> node_id -> node option
+val find_by_path : t -> string -> node option
+
+val is_acyclic : t -> bool
+(** DFS-based acyclicity check. A healthy build_graph is always acyclic (no
+    build artefact circularly depends on itself); this is the T2 precondition. *)
+
+val kind_to_string : artefact_kind -> string

--- a/latex-parse/src/dune
+++ b/latex-parse/src/dune
@@ -67,6 +67,8 @@
   log_context
   build_profile
   build_artifact_state
+  project_model
+  build_graph
   execution_class
   invalidation_engine
   execution_policy
@@ -509,6 +511,16 @@
 (test
  (name test_build_log_integration)
  (modules test_build_log_integration)
+ (libraries latex_parse_lib test_helpers unix))
+
+(test
+ (name test_project_model)
+ (modules test_project_model)
+ (libraries latex_parse_lib test_helpers unix))
+
+(test
+ (name test_build_graph)
+ (modules test_build_graph)
  (libraries latex_parse_lib test_helpers unix))
 
 (test

--- a/latex-parse/src/project_model.ml
+++ b/latex-parse/src/project_model.ml
@@ -1,0 +1,124 @@
+(** Typed project representation. See [project_model.mli]. *)
+
+type file_id = int
+type file_entry = { id : file_id; path : string; is_root : bool }
+type engine_profile = Pdflatex | Xelatex | Lualatex | Ptex_uptex
+
+type declared_feature =
+  | UTF8_inputenc
+  | UTF8_direct
+  | Babel_standard
+  | Polyglossia
+  | Amsmath
+  | Hyperref
+  | Graphicx_eps_only
+  | Graphicx_multi
+  | Bibtex
+  | Natbib
+  | Biblatex
+  | Unicode_math
+  | Opentype_fonts
+  | Lua_scripting
+  | Japanese_cjk
+  | Other of string
+
+type t = {
+  files : file_entry list;
+  root : file_id;
+  engine : engine_profile;
+  declared_features : declared_feature list;
+}
+
+let engine_to_string = function
+  | Pdflatex -> "pdflatex"
+  | Xelatex -> "xelatex"
+  | Lualatex -> "lualatex"
+  | Ptex_uptex -> "ptex_uptex"
+
+let feature_to_string = function
+  | UTF8_inputenc -> "utf8_inputenc"
+  | UTF8_direct -> "utf8_direct"
+  | Babel_standard -> "babel_standard"
+  | Polyglossia -> "polyglossia"
+  | Amsmath -> "amsmath"
+  | Hyperref -> "hyperref"
+  | Graphicx_eps_only -> "graphicx_eps_only"
+  | Graphicx_multi -> "graphicx_multi"
+  | Bibtex -> "bibtex"
+  | Natbib -> "natbib"
+  | Biblatex -> "biblatex"
+  | Unicode_math -> "unicode_math"
+  | Opentype_fonts -> "opentype_fonts"
+  | Lua_scripting -> "lua_scripting"
+  | Japanese_cjk -> "japanese_cjk"
+  | Other s -> s
+
+(* Engine from a Build_profile.t. Build_profile.engine constructors differ from
+   ours; map conservatively. LaTeX (plain) and Unknown both fall back to
+   Pdflatex as the safest v26.2 assumption. *)
+let engine_of_build_profile (bp : Build_profile.t) : engine_profile =
+  match bp.Build_profile.engine with
+  | Build_profile.PDFLaTeX -> Pdflatex
+  | Build_profile.XeLaTeX -> Xelatex
+  | Build_profile.LuaLaTeX -> Lualatex
+  | Build_profile.LaTeX -> Pdflatex
+  | Build_profile.Unknown -> Pdflatex
+
+(* Delegate include-scanning to Include_resolver (shipped v26.1). One source of
+   truth for this logic. *)
+let scan_includes (src : string) : string list =
+  List.map
+    (fun (e : Include_resolver.include_entry) -> e.raw_path)
+    (Include_resolver.extract_includes src)
+
+let read_file_safe (path : string) :
+    (string, [ `File_not_found of string | `Not_latex of string ]) result =
+  if not (Sys.file_exists path) then Error (`File_not_found path)
+  else if not (Filename.check_suffix path ".tex") then Error (`Not_latex path)
+  else
+    try
+      let ic = open_in path in
+      let n = in_channel_length ic in
+      let buf = Bytes.create n in
+      really_input ic buf 0 n;
+      close_in ic;
+      Ok (Bytes.to_string buf)
+    with Sys_error msg ->
+      (* EXN-OK: file IO failure reported as File_not_found. *)
+      Error (`File_not_found msg)
+
+let of_root ?(engine = Pdflatex) ?(declared_features = []) (root_path : string)
+    : (t, [ `File_not_found of string | `Not_latex of string ]) result =
+  match read_file_safe root_path with
+  | Error e -> Error e
+  | Ok src ->
+      let base_dir = Filename.dirname root_path in
+      let next_id = ref 0 in
+      let mk_id () =
+        let i = !next_id in
+        next_id := i + 1;
+        i
+      in
+      let root_id = mk_id () in
+      let files = ref [ { id = root_id; path = root_path; is_root = true } ] in
+      (* One pass: enumerate direct includes of the root. v26.2 does NOT recurse
+         (plan §2.6: include analysis at project_model layer stays single-level;
+         deep graphs are build_graph's job). *)
+      List.iter
+        (fun rel ->
+          let candidate =
+            let p = Filename.concat base_dir rel in
+            if Sys.file_exists p then p
+            else if Sys.file_exists (p ^ ".tex") then p ^ ".tex"
+            else p
+          in
+          let entry = { id = mk_id (); path = candidate; is_root = false } in
+          files := entry :: !files)
+        (scan_includes src);
+      Ok { files = List.rev !files; root = root_id; engine; declared_features }
+
+let root_file (t : t) : file_entry = List.find (fun f -> f.id = t.root) t.files
+let all_files (t : t) : file_entry list = t.files
+
+let find (t : t) (id : file_id) : file_entry option =
+  List.find_opt (fun f -> f.id = id) t.files

--- a/latex-parse/src/project_model.mli
+++ b/latex-parse/src/project_model.mli
@@ -1,0 +1,81 @@
+(** Typed project representation for compile_contract (memo §5.5, v26.2).
+
+    A [t] records everything the pre-compile readiness check (T0–T5) needs to
+    know about a user's LaTeX project: files, include graph, declared engine
+    profile, and feature declarations.
+
+    This module is deliberately thin: it serialises a project layout into a
+    typed value. Heavy lifting (include resolution, graph acyclicity) is in
+    [Build_graph] and [Compile_contract]. *)
+
+type file_id
+(** Opaque identifier for a .tex file in the project. Stable across [t]
+    lifetime; NOT persisted between runs. *)
+
+type file_entry = {
+  id : file_id;
+  path : string;
+      (** Repo-relative or absolute path, whichever the caller used at [of_root]
+          time. *)
+  is_root : bool;
+}
+
+type engine_profile =
+  | Pdflatex
+  | Xelatex
+  | Lualatex
+  | Ptex_uptex
+      (** Parallels [Build_profile.engine]; re-declared here to avoid a module
+          dependency cycle. [Build_profile.t] consumers should use
+          [engine_of_build_profile] below to convert. *)
+
+type declared_feature =
+  | UTF8_inputenc
+  | UTF8_direct
+  | Babel_standard
+  | Polyglossia
+  | Amsmath
+  | Hyperref
+  | Graphicx_eps_only
+  | Graphicx_multi
+  | Bibtex
+  | Natbib
+  | Biblatex
+  | Unicode_math
+  | Opentype_fonts
+  | Lua_scripting
+  | Japanese_cjk
+  | Other of string
+      (** Escape hatch for feature detected at runtime but not in the enum.
+          Ignored by T3 admissibility check. *)
+
+type t = private {
+  files : file_entry list;
+  root : file_id;
+  engine : engine_profile;
+  declared_features : declared_feature list;
+}
+
+val of_root :
+  ?engine:engine_profile ->
+  ?declared_features:declared_feature list ->
+  string ->
+  (t, [ `File_not_found of string | `Not_latex of string ]) result
+(** Build a [t] from a root `.tex` path. Scans the file for [\input] /
+    [\include] directives to enumerate [files]. Does NOT parse beyond
+    include-resolution — that's [Compile_contract]'s job.
+
+    @param engine defaults to [Pdflatex] (v26.2 GA baseline).
+    @param declared_features
+      empty list means "no features declared"; v26.2 doesn't auto-detect.
+      Callers parsing the source may supply features from their own analysis. *)
+
+val root_file : t -> file_entry
+val all_files : t -> file_entry list
+val find : t -> file_id -> file_entry option
+
+val engine_of_build_profile : Build_profile.t -> engine_profile
+(** Convenience: extract the [engine_profile] from a [Build_profile.t]. *)
+
+val engine_to_string : engine_profile -> string
+val feature_to_string : declared_feature -> string

--- a/latex-parse/src/test_build_graph.ml
+++ b/latex-parse/src/test_build_graph.ml
@@ -1,0 +1,77 @@
+(** Unit tests for [Build_graph]. *)
+
+open Latex_parse_lib
+open Test_helpers
+
+let tmp_dir =
+  let d = Filename.temp_file "test_build_graph_" "" in
+  Sys.remove d;
+  Unix.mkdir d 0o755;
+  d
+
+let write_file name content =
+  let path = Filename.concat tmp_dir name in
+  let oc = open_out path in
+  output_string oc content;
+  close_out oc;
+  path
+
+let cleanup_dir () =
+  Array.iter
+    (fun f -> try Sys.remove (Filename.concat tmp_dir f) with _ -> ())
+    (Sys.readdir tmp_dir);
+  try Unix.rmdir tmp_dir with _ -> ()
+
+let () =
+  let root = write_file "main.tex" "\\documentclass{article}\n" in
+  let proj =
+    match Project_model.of_root root with
+    | Ok p -> p
+    | Error _ -> failwith "setup failed"
+  in
+  let g = Build_graph.of_project proj in
+
+  run "of_project produces nodes" (fun tag ->
+      let ns = Build_graph.nodes g in
+      expect (List.length ns >= 3) (tag ^ ": at least tex + aux + pdf nodes"));
+
+  run "has a Tex node for root" (fun tag ->
+      let ns = Build_graph.nodes g in
+      let has_tex =
+        List.exists (fun (n : Build_graph.node) -> n.kind = Build_graph.Tex) ns
+      in
+      expect has_tex (tag ^ ": Tex node present"));
+
+  run "has an Aux node predicted" (fun tag ->
+      let ns = Build_graph.nodes g in
+      let has_aux =
+        List.exists (fun (n : Build_graph.node) -> n.kind = Build_graph.Aux) ns
+      in
+      expect has_aux (tag ^ ": Aux node present"));
+
+  run "has a Pdf node for root" (fun tag ->
+      let ns = Build_graph.nodes g in
+      let has_pdf =
+        List.exists (fun (n : Build_graph.node) -> n.kind = Build_graph.Pdf) ns
+      in
+      expect has_pdf (tag ^ ": Pdf node present"));
+
+  run "edges exist tex→aux and tex→pdf" (fun tag ->
+      let es = Build_graph.edges g in
+      expect (List.length es >= 2) (tag ^ ": at least 2 edges"));
+
+  run "is_acyclic on fresh graph" (fun tag ->
+      expect (Build_graph.is_acyclic g) (tag ^ ": should be acyclic"));
+
+  run "find_by_path finds the root .tex" (fun tag ->
+      match Build_graph.find_by_path g root with
+      | Some n ->
+          expect (n.kind = Build_graph.Tex) (tag ^ ": Tex kind");
+          expect n.exists (tag ^ ": file exists")
+      | None -> expect false (tag ^ ": should find the root"));
+
+  run "kind_to_string" (fun tag ->
+      expect (Build_graph.kind_to_string Build_graph.Aux = "aux") (tag ^ ": aux"));
+
+  cleanup_dir ();
+  finalise "build-graph"

--- a/latex-parse/src/test_project_model.ml
+++ b/latex-parse/src/test_project_model.ml
@@ -1,0 +1,95 @@
+(** Unit tests for [Project_model]. *)
+
+open Latex_parse_lib
+open Test_helpers
+
+let tmp_dir =
+  let d = Filename.temp_file "test_project_" "" in
+  Sys.remove d;
+  Unix.mkdir d 0o755;
+  d
+
+let write_file name content =
+  let path = Filename.concat tmp_dir name in
+  let oc = open_out path in
+  output_string oc content;
+  close_out oc;
+  path
+
+let cleanup_dir () =
+  Array.iter
+    (fun f -> try Sys.remove (Filename.concat tmp_dir f) with _ -> ())
+    (Sys.readdir tmp_dir);
+  try Unix.rmdir tmp_dir with _ -> ()
+
+let () =
+  (* Simple root-only project *)
+  run "of_root accepts a minimal tex file" (fun tag ->
+      let path =
+        write_file "root.tex"
+          "\\documentclass{article}\n\\begin{document}\nhi\n\\end{document}\n"
+      in
+      match Project_model.of_root path with
+      | Ok proj ->
+          expect
+            (List.length (Project_model.all_files proj) = 1)
+            (tag ^ ": single-file project");
+          expect
+            ((Project_model.root_file proj).is_root = true)
+            (tag ^ ": root marked is_root")
+      | Error _ -> expect false (tag ^ ": should succeed"));
+
+  (* Missing file *)
+  run "of_root rejects missing file" (fun tag ->
+      match Project_model.of_root "/nonexistent/ghost.tex" with
+      | Error (`File_not_found _) -> expect true (tag ^ ": correct error")
+      | _ -> expect false (tag ^ ": should error on missing file"));
+
+  (* Non-.tex extension *)
+  run "of_root rejects non-tex" (fun tag ->
+      let path = write_file "readme.md" "# not tex\n" in
+      match Project_model.of_root path with
+      | Error (`Not_latex _) -> expect true (tag ^ ": correct error")
+      | _ -> expect false (tag ^ ": should reject non-tex"));
+
+  (* Multi-file with \input *)
+  run "of_root scans \\input directives" (fun tag ->
+      let _ = write_file "intro.tex" "intro content\n" in
+      let root =
+        write_file "main.tex"
+          "\\documentclass{article}\n\\input{intro}\n\\end{document}\n"
+      in
+      match Project_model.of_root root with
+      | Ok proj ->
+          expect
+            (List.length (Project_model.all_files proj) = 2)
+            (tag ^ ": root + 1 input")
+      | Error _ -> expect false (tag ^ ": should succeed"));
+
+  (* Engine and features *)
+  run "of_root passes engine + features through" (fun tag ->
+      let path = write_file "e.tex" "\\documentclass{article}\n" in
+      match
+        Project_model.of_root ~engine:Project_model.Xelatex
+          ~declared_features:[ Project_model.Opentype_fonts ]
+          path
+      with
+      | Ok proj ->
+          expect (proj.engine = Project_model.Xelatex) (tag ^ ": engine");
+          expect
+            (proj.declared_features = [ Project_model.Opentype_fonts ])
+            (tag ^ ": features")
+      | Error _ -> expect false (tag ^ ": should succeed"));
+
+  (* engine_to_string / feature_to_string basic sanity *)
+  run "string conversions" (fun tag ->
+      expect
+        (Project_model.engine_to_string Project_model.Pdflatex = "pdflatex")
+        (tag ^ ": pdflatex");
+      expect
+        (Project_model.feature_to_string Project_model.Unicode_math
+        = "unicode_math")
+        (tag ^ ": unicode_math"));
+
+  cleanup_dir ();
+  finalise "project-model"


### PR DESCRIPTION
## Summary

Plan §3.1 PR A2, **split per plan's A2a/A2b recommendation**. This is A2a (~1.5 days scope): project_model + build_graph runtime modules. A2b will add aux_state + compile_contract.

## Contents

### `project_model.{ml,mli}` (NEW)
Typed project representation — files, root, engine, declared features. `of_root ~engine ~declared_features path` scans the root .tex for `\input` / `\include` using existing `Include_resolver` (ADR-008: don't duplicate scanner logic). `engine_of_build_profile` maps from `Build_profile.engine`.

Abstract type `t` (private record): callers construct via `of_root`, read via `root_file` / `all_files` / `find`.

### `build_graph.{ml,mli}` (NEW)
The **fourth graph** per ADR-003 (distinct from `validator_dag`, `project_graph`, `dependency_graph`). Nodes are build artefacts (`Tex` / `Aux` / `Bbl` / `Bib` / `Pdf` / `Log`). Edges are produce-from relationships. `of_project` builds the initial graph: one Tex + one Aux per file, one Pdf for root. `is_acyclic` DFS cycle check for the T2 precondition.

### Tests
- `test_project_model.ml` — 9 cases: accept minimal tex, reject missing file, reject non-tex, scan `\input` directives, engine+features round-trip, string conversions.
- `test_build_graph.ml` — 8 cases: `of_project` produces expected nodes/edges, Tex/Aux/Pdf present, `is_acyclic` on fresh graph, `find_by_path`.

All 17 tests PASS locally. Full `dune runtest latex-parse/src` sweep green.

## Memo mapping
- Plan §3.1 PR A2 (split to A2a+A2b recommendation): runtime scaffolding for T2/T3.
- ADR-002 (aux_state distinct from build_artifact_state) — neither touched in A2a; A2b territory.
- ADR-003 (four graphs, not three) — `build_graph` is the new fourth.
- ADR-008 (delegate include-scanning to existing `Include_resolver`).

## What this PR does NOT do
- No aux_state parser (that's A2b).
- No compile_contract glue module (A2b).
- No proofs (A3).
- No CLI integration (A2b or later).

## Test plan
- [x] `dune build` green; module wiring in `latex-parse/src/dune`.
- [x] `dune exec test_project_model.exe` — 9/9 PASS.
- [x] `dune exec test_build_graph.exe` — 8/8 PASS.
- [x] `dune runtest latex-parse/src --force` — full sweep green.
- [x] All 13 CI gates pass locally (`pre_release_check --allow-dirty --skip-build`).