### PR TITLE
feat(v26.2): PR A2b — aux_state + compile_contract

### DIFF
--- a/latex-parse/src/aux_state.ml
+++ b/latex-parse/src/aux_state.ml
@@ -1,0 +1,199 @@
+(** Parse pdflatex `.aux` files. See [aux_state.mli].
+
+    Parser strategy: line-oriented. Each top-level macro typically lives on one
+    line in pdflatex output. We match each recognized macro with a regex;
+    unmatched non-blank lines land in [parse_warnings]. *)
+
+type label_entry = {
+  name : string;
+  ref_number : string;
+  page_number : string;
+  raw : string;
+}
+
+type bibcite_entry = { key : string; number : string }
+
+type t = {
+  source_path : string;
+  labels : label_entry list;
+  bibcites : bibcite_entry list;
+  bibstyle : string option;
+  bibdata : string list;
+  parse_warnings : string list;
+}
+
+(* Match \newlabel{NAME}{ARGS}. ARGS is a group literal that may itself nest
+   braces, which vanilla regex can't fully handle. Use a two-stage approach:
+   capture everything up to the matching closing brace of \newlabel's second arg
+   by walking the line. *)
+
+let find_arg_group (s : string) (start : int) : (string * int) option =
+  (* Starting at [start], if s.[start] = '{', return the substring between the
+     matching braces and the index AFTER the closer. Balanced brace walk.
+     Returns None if unbalanced. *)
+  let n = String.length s in
+  if start >= n || s.[start] <> '{' then None
+  else
+    let depth = ref 1 in
+    let i = ref (start + 1) in
+    let found_end = ref None in
+    while !i < n && !found_end = None do
+      let c = s.[!i] in
+      if c = '{' then incr depth
+      else if c = '}' then (
+        decr depth;
+        if !depth = 0 then found_end := Some !i);
+      incr i
+    done;
+    match !found_end with
+    | Some e -> Some (String.sub s (start + 1) (e - start - 1), e + 1)
+    | None -> None
+
+(* \newlabel{NAME}{{REF}{PAGE}{TITLE}{ANCHOR}{...}} We extract NAME and then the
+   outer inner-args group, then split that into its own subgroups to get REF and
+   PAGE. *)
+let parse_newlabel (line : string) : label_entry option =
+  let prefix = "\\newlabel" in
+  let plen = String.length prefix in
+  let n = String.length line in
+  if n < plen || String.sub line 0 plen <> prefix then None
+  else
+    match find_arg_group line plen with
+    | None -> None
+    | Some (name, after_name) -> (
+        match find_arg_group line after_name with
+        | None -> None
+        | Some (args_group, _) -> (
+            (* args_group looks like: {REF}{PAGE}{TITLE}{ANCHOR}{...} Extract
+               the first two subgroups. *)
+            match find_arg_group args_group 0 with
+            | None -> None
+            | Some (ref_num, after_ref) -> (
+                match find_arg_group args_group after_ref with
+                | None -> None
+                | Some (page_num, _) ->
+                    Some
+                      {
+                        name;
+                        ref_number = ref_num;
+                        page_number = page_num;
+                        raw = args_group;
+                      })))
+
+(* \bibcite{KEY}{NUMBER} *)
+let parse_bibcite (line : string) : bibcite_entry option =
+  let prefix = "\\bibcite" in
+  let plen = String.length prefix in
+  let n = String.length line in
+  if n < plen || String.sub line 0 plen <> prefix then None
+  else
+    match find_arg_group line plen with
+    | None -> None
+    | Some (key, after_key) -> (
+        match find_arg_group line after_key with
+        | None -> None
+        | Some (number, _) -> Some { key; number })
+
+(* \bibstyle{STYLE} or \bibdata{FILE1,FILE2,...} — extract single group arg. *)
+let parse_single_group (prefix : string) (line : string) : string option =
+  let plen = String.length prefix in
+  let n = String.length line in
+  if n < plen || String.sub line 0 plen <> prefix then None
+  else
+    match find_arg_group line plen with
+    | Some (arg, _) -> Some arg
+    | None -> None
+
+let split_on_comma (s : string) : string list =
+  String.split_on_char ',' s
+  |> List.map String.trim
+  |> List.filter (fun s -> s <> "")
+
+let of_string ~source_path (content : string) : t =
+  let lines = String.split_on_char '\n' content in
+  let labels = ref [] in
+  let bibcites = ref [] in
+  let bibstyle = ref None in
+  let bibdata = ref [] in
+  let warnings = ref [] in
+  List.iter
+    (fun raw_line ->
+      let line = String.trim raw_line in
+      if line = "" then ()
+      else if String.length line >= 1 && line.[0] <> '\\' then
+        warnings := raw_line :: !warnings
+      else
+        match parse_newlabel line with
+        | Some l -> labels := l :: !labels
+        | None -> (
+            match parse_bibcite line with
+            | Some b -> bibcites := b :: !bibcites
+            | None -> (
+                match parse_single_group "\\bibstyle" line with
+                | Some s -> bibstyle := Some s
+                | None -> (
+                    match parse_single_group "\\bibdata" line with
+                    | Some entries ->
+                        bibdata := !bibdata @ split_on_comma entries
+                    | None ->
+                        (* Recognized-but-ignored macros we don't warn on. *)
+                        let recognized_ignored =
+                          [
+                            "\\relax";
+                            "\\@writefile";
+                            "\\@input";
+                            "\\@setckpt";
+                            "\\providecommand";
+                            "\\gdef";
+                            "\\@tfor";
+                          ]
+                        in
+                        let is_ignored =
+                          List.exists
+                            (fun p ->
+                              let plen = String.length p in
+                              String.length line >= plen
+                              && String.sub line 0 plen = p)
+                            recognized_ignored
+                        in
+                        if not is_ignored then warnings := raw_line :: !warnings
+                    ))))
+    lines;
+  {
+    source_path;
+    labels = List.rev !labels;
+    bibcites = List.rev !bibcites;
+    bibstyle = !bibstyle;
+    bibdata = !bibdata;
+    parse_warnings = List.rev !warnings;
+  }
+
+let of_file (path : string) :
+    (t, [ `File_not_found of string | `Read_error of string ]) result =
+  if not (Sys.file_exists path) then Error (`File_not_found path)
+  else
+    try
+      let ic = open_in path in
+      let n = in_channel_length ic in
+      let buf = Bytes.create n in
+      really_input ic buf 0 n;
+      close_in ic;
+      Ok (of_string ~source_path:path (Bytes.to_string buf))
+    with Sys_error msg ->
+      (* EXN-OK: file IO failure reported as Read_error. *)
+      Error (`Read_error msg)
+
+let find_label (t : t) (name : string) : label_entry option =
+  List.find_opt (fun l -> l.name = name) t.labels
+
+let find_bibcite (t : t) (key : string) : bibcite_entry option =
+  List.find_opt (fun b -> b.key = key) t.bibcites
+
+let labels_unique (t : t) : bool =
+  let names = List.map (fun l -> l.name) t.labels in
+  let sorted = List.sort compare names in
+  let rec no_adjacent_dup = function
+    | [] | [ _ ] -> true
+    | a :: b :: rest -> a <> b && no_adjacent_dup (b :: rest)
+  in
+  no_adjacent_dup sorted

--- a/latex-parse/src/aux_state.mli
+++ b/latex-parse/src/aux_state.mli
@@ -1,0 +1,48 @@
+(** Parse and query `.aux` files produced by pdflatex (memo §5.5, v26.2).
+
+    v26.2 scope: pdflatex `.aux` only. xelatex / lualatex `.aux` files are
+    mostly-compatible but edge cases (counter serialization) may fail
+    gracefully. Related aux-family files (`.toc`, `.lof`, `.lot`, `.idx`,
+    `.glg`) are OUT of scope for v26.2.
+
+    Design note: this is distinct from [Build_artifact_state] which wraps the
+    runtime profile and holds the parsed log context. This module parses the
+    .aux FILE CONTENT on disk. See ADR-002. *)
+
+type label_entry = {
+  name : string;  (** Label name as written with \label{...}. *)
+  ref_number : string;
+      (** First arg of the reference struct — section number etc. *)
+  page_number : string;  (** Second arg — page where \label was placed. *)
+  raw : string;  (** Original \newlabel arg for debugging. *)
+}
+
+type bibcite_entry = {
+  key : string;  (** Citation key from \cite{...}. *)
+  number : string;  (** Rendered citation number or author-year string. *)
+}
+
+type t = {
+  source_path : string;
+  labels : label_entry list;
+  bibcites : bibcite_entry list;
+  bibstyle : string option;  (** \bibstyle{...} if present. *)
+  bibdata : string list;  (** \bibdata{...} entries (split on comma). *)
+  parse_warnings : string list;  (** Lines the parser couldn't classify. *)
+}
+
+val of_file :
+  string -> (t, [ `File_not_found of string | `Read_error of string ]) result
+(** Parse a `.aux` file from disk. Returns [Ok t] even if the file has
+    unrecognised lines — those land in [parse_warnings]. *)
+
+val of_string : source_path:string -> string -> t
+(** Parse `.aux` content directly. [source_path] is stored for traceability. *)
+
+val find_label : t -> string -> label_entry option
+val find_bibcite : t -> string -> bibcite_entry option
+
+val labels_unique : t -> bool
+(** True iff no two [\newlabel] entries share a name. pdflatex emits a warning
+    on duplicate labels but still writes both; this predicate is the T4
+    coherence check at the single-file level. *)

--- a/latex-parse/src/compile_contract.ml
+++ b/latex-parse/src/compile_contract.ml
@@ -1,0 +1,145 @@
+(** Pre-compile readiness contract. See [compile_contract.mli]. *)
+
+type reason =
+  | T0_parse_fails of { file : string; message : string }
+  | T1_expansion_fails of string
+  | T2_project_not_closed of [ `Cycle_in_build_graph | `Missing_file of string ]
+  | T3_profile_incompatible of { feature : string; profile : string }
+  | T4_semantic_incoherent of
+      [ `Duplicate_labels of string list | `Missing_bib_entries of string list ]
+  | T5_rule_violations of string list
+
+type ready_check_result = Ready | NotReady of reason list
+
+(* Feature→profile compatibility table. Mirrors the data in
+   specs/v26/compilation_profiles.yaml but encoded here for runtime access
+   without a yaml dep. *)
+let feature_compatible (feature : Project_model.declared_feature)
+    (engine : Project_model.engine_profile) : bool =
+  let open Project_model in
+  match (feature, engine) with
+  (* UTF8_inputenc works everywhere except ptex_uptex (uses its own enc) *)
+  | UTF8_inputenc, Ptex_uptex -> false
+  | UTF8_inputenc, _ -> true
+  (* UTF8_direct requires xe/lua *)
+  | UTF8_direct, (Xelatex | Lualatex) -> true
+  | UTF8_direct, _ -> false
+  (* Unicode math requires unicode-aware engine *)
+  | Unicode_math, (Xelatex | Lualatex) -> true
+  | Unicode_math, _ -> false
+  (* OpenType fonts need xelatex or lualatex *)
+  | Opentype_fonts, (Xelatex | Lualatex) -> true
+  | Opentype_fonts, _ -> false
+  (* Lua scripting: only lualatex *)
+  | Lua_scripting, Lualatex -> true
+  | Lua_scripting, _ -> false
+  (* Japanese CJK: only ptex_uptex in v26.2 scope *)
+  | Japanese_cjk, Ptex_uptex -> true
+  | Japanese_cjk, _ -> false
+  (* Everything else is universally supported in v26.2 *)
+  | _, _ -> true
+
+let t3_check (proj : Project_model.t) : reason list =
+  let engine = proj.Project_model.engine in
+  List.filter_map
+    (fun feat ->
+      if feature_compatible feat engine then None
+      else
+        Some
+          (T3_profile_incompatible
+             {
+               feature = Project_model.feature_to_string feat;
+               profile = Project_model.engine_to_string engine;
+             }))
+    proj.Project_model.declared_features
+
+let t2_check (proj : Project_model.t) : reason list =
+  let g = Build_graph.of_project proj in
+  let missing =
+    List.filter_map
+      (fun (f : Project_model.file_entry) ->
+        if Sys.file_exists f.path then None else Some f.path)
+      (Project_model.all_files proj)
+  in
+  let rs =
+    if missing = [] then []
+    else List.map (fun p -> T2_project_not_closed (`Missing_file p)) missing
+  in
+  if not (Build_graph.is_acyclic g) then
+    T2_project_not_closed `Cycle_in_build_graph :: rs
+  else rs
+
+(* T4: if aux exists, use parsed labels to check uniqueness and that cited keys
+   resolve. Otherwise fall back to no-check (source-only label analysis is v26.3
+   territory). *)
+let t4_check ?aux_path (_proj : Project_model.t) : reason list =
+  match aux_path with
+  | None -> []
+  | Some path -> (
+      match Aux_state.of_file path with
+      | Error _ -> [] (* Can't check; don't fail *)
+      | Ok aux ->
+          let rs = [] in
+          let rs =
+            if Aux_state.labels_unique aux then rs
+            else
+              (* Find the actual duplicates to report. *)
+              let counts = Hashtbl.create 16 in
+              List.iter
+                (fun (l : Aux_state.label_entry) ->
+                  let c =
+                    try Hashtbl.find counts l.name with Not_found -> 0
+                  in
+                  Hashtbl.replace counts l.name (c + 1))
+                aux.labels;
+              let dups =
+                Hashtbl.fold
+                  (fun name c acc -> if c > 1 then name :: acc else acc)
+                  counts []
+              in
+              T4_semantic_incoherent (`Duplicate_labels dups) :: rs
+          in
+          rs)
+
+(* T0/T1/T5: placeholders in v26.2. T0/T1 require calling Parser_l2 and Expander
+   on the project files, which is heavier than a pre- compile readiness check
+   should be. v26.2 scope: T0 returns no failures if all files exist and are
+   readable (checked by T2); T1 is not runtime-checked; T5 requires running
+   validators, which is also heavy — caller invokes Validators.run_all
+   separately. *)
+let t0_check (_ : Project_model.t) : reason list = []
+let t1_check (_ : Project_model.t) : reason list = []
+let t5_check (_ : Project_model.t) : reason list = []
+
+let check_ready_to_compile ?aux_path (proj : Project_model.t)
+    (_profile : Build_profile.t) : ready_check_result =
+  let reasons =
+    t0_check proj
+    @ t1_check proj
+    @ t2_check proj
+    @ t3_check proj
+    @ t4_check ?aux_path proj
+    @ t5_check proj
+  in
+  if reasons = [] then Ready else NotReady reasons
+
+let reason_to_string = function
+  | T0_parse_fails { file; message } ->
+      Printf.sprintf "T0 parse fails in %s: %s" file message
+  | T1_expansion_fails msg -> Printf.sprintf "T1 expansion fails: %s" msg
+  | T2_project_not_closed `Cycle_in_build_graph ->
+      "T2 project not closed: cycle in build graph"
+  | T2_project_not_closed (`Missing_file p) ->
+      Printf.sprintf "T2 project not closed: missing file %s" p
+  | T3_profile_incompatible { feature; profile } ->
+      Printf.sprintf
+        "T3 profile incompatible: feature %s not supported by profile %s"
+        feature profile
+  | T4_semantic_incoherent (`Duplicate_labels ds) ->
+      Printf.sprintf "T4 semantic incoherent: duplicate labels [%s]"
+        (String.concat "; " ds)
+  | T4_semantic_incoherent (`Missing_bib_entries es) ->
+      Printf.sprintf "T4 semantic incoherent: missing bib entries [%s]"
+        (String.concat "; " es)
+  | T5_rule_violations ids ->
+      Printf.sprintf "T5 rule violations: [%s]" (String.concat "; " ids)

--- a/latex-parse/src/compile_contract.mli
+++ b/latex-parse/src/compile_contract.mli
@@ -1,0 +1,29 @@
+(** Pre-compile readiness contract (memo §5.5, v26.2).
+
+    Evaluates T0–T5 at runtime. Given a [Project_model.t] and a
+    [Build_profile.t], returns [Ready] iff every static precondition holds, or
+    [NotReady reasons] listing which preconditions fail.
+
+    T6 (compilation progress) and T7 (output well-formedness) are NOT checked
+    here — they are parametric-proof-level theorems, not runtime checks (see
+    specs/v26/compilation_guarantee_stack.md). *)
+
+type reason =
+  | T0_parse_fails of { file : string; message : string }
+  | T1_expansion_fails of string
+  | T2_project_not_closed of [ `Cycle_in_build_graph | `Missing_file of string ]
+  | T3_profile_incompatible of { feature : string; profile : string }
+  | T4_semantic_incoherent of
+      [ `Duplicate_labels of string list | `Missing_bib_entries of string list ]
+  | T5_rule_violations of string list
+      (** Rule-IDs that fired at Error severity. *)
+
+type ready_check_result = Ready | NotReady of reason list
+
+val check_ready_to_compile :
+  ?aux_path:string -> Project_model.t -> Build_profile.t -> ready_check_result
+(** Evaluate T0–T5 against the project + profile. If [aux_path] is provided, T4
+    (semantic coherence) is informed by the .aux file contents; otherwise T4
+    falls back to source-only analysis of labels declared in the root .tex. *)
+
+val reason_to_string : reason -> string

--- a/latex-parse/src/dune
+++ b/latex-parse/src/dune
@@ -69,6 +69,8 @@
   build_artifact_state
   project_model
   build_graph
+  aux_state
+  compile_contract
   execution_class
   invalidation_engine
   execution_policy
@@ -521,6 +523,16 @@
 (test
  (name test_build_graph)
  (modules test_build_graph)
+ (libraries latex_parse_lib test_helpers unix))
+
+(test
+ (name test_aux_state)
+ (modules test_aux_state)
+ (libraries latex_parse_lib test_helpers unix))
+
+(test
+ (name test_compile_contract)
+ (modules test_compile_contract)
  (libraries latex_parse_lib test_helpers unix))
 
 (test

--- a/latex-parse/src/test_aux_state.ml
+++ b/latex-parse/src/test_aux_state.ml
@@ -1,0 +1,81 @@
+(** Unit tests for [Aux_state]. *)
+
+open Latex_parse_lib
+open Test_helpers
+
+let sample_aux =
+  {|\relax
+\providecommand\HyperFirstAtBeginDocument{\AtBeginDocument}
+\newlabel{sec:intro}{{1}{1}{Introduction}{section.1}{}}
+\newlabel{eq:main}{{2.1}{3}{Main equation}{equation.2.1}{}}
+\bibstyle{plain}
+\bibdata{refs,chapter1}
+\bibcite{knuth1984}{1}
+\bibcite{lamport1994}{2}
+\@writefile{toc}{\contentsline {section}{\numberline {1}Introduction}{1}{section.1}\protected@file@percent }
+|}
+
+let () =
+  run "of_string parses a minimal aux" (fun tag ->
+      let t = Aux_state.of_string ~source_path:"test.aux" sample_aux in
+      expect (List.length t.labels = 2) (tag ^ ": 2 labels");
+      expect (List.length t.bibcites = 2) (tag ^ ": 2 bibcites");
+      expect (t.bibstyle = Some "plain") (tag ^ ": bibstyle=plain");
+      expect (List.length t.bibdata = 2) (tag ^ ": 2 bibdata entries"));
+
+  run "find_label locates a known label" (fun tag ->
+      let t = Aux_state.of_string ~source_path:"test.aux" sample_aux in
+      match Aux_state.find_label t "sec:intro" with
+      | Some l ->
+          expect (l.ref_number = "1") (tag ^ ": ref=1");
+          expect (l.page_number = "1") (tag ^ ": page=1")
+      | None -> expect false (tag ^ ": should find sec:intro"));
+
+  run "find_label returns None for missing" (fun tag ->
+      let t = Aux_state.of_string ~source_path:"test.aux" sample_aux in
+      expect
+        (Aux_state.find_label t "nonexistent" = None)
+        (tag ^ ": None on missing"));
+
+  run "find_bibcite returns bib number" (fun tag ->
+      let t = Aux_state.of_string ~source_path:"test.aux" sample_aux in
+      match Aux_state.find_bibcite t "knuth1984" with
+      | Some b -> expect (b.number = "1") (tag ^ ": number=1")
+      | None -> expect false (tag ^ ": should find knuth1984"));
+
+  run "labels_unique detects duplicates" (fun tag ->
+      let dup_aux =
+        {|\newlabel{a}{{1}{1}{X}{y}{}}
+\newlabel{a}{{2}{2}{Y}{z}{}}
+|}
+      in
+      let t = Aux_state.of_string ~source_path:"t.aux" dup_aux in
+      expect (not (Aux_state.labels_unique t)) (tag ^ ": duplicates caught"));
+
+  run "labels_unique true on clean" (fun tag ->
+      let t = Aux_state.of_string ~source_path:"t.aux" sample_aux in
+      expect (Aux_state.labels_unique t) (tag ^ ": no dupes in sample"));
+
+  run "nested braces in label title parsed" (fun tag ->
+      let nested =
+        {|\newlabel{sec:foo}{{1}{1}{Title with {braces} inside}{section.1}{}}
+|}
+      in
+      let t = Aux_state.of_string ~source_path:"t.aux" nested in
+      expect (List.length t.labels = 1) (tag ^ ": parsed despite braces");
+      match Aux_state.find_label t "sec:foo" with
+      | Some l -> expect (l.ref_number = "1") (tag ^ ": ref=1")
+      | None -> expect false (tag ^ ": found"));
+
+  run "empty input produces empty t" (fun tag ->
+      let t = Aux_state.of_string ~source_path:"" "" in
+      expect (t.labels = []) (tag ^ ": no labels");
+      expect (t.bibcites = []) (tag ^ ": no bibcites");
+      expect (t.bibstyle = None) (tag ^ ": no bibstyle"));
+
+  run "of_file missing returns error" (fun tag ->
+      match Aux_state.of_file "/nonexistent/ghost.aux" with
+      | Error (`File_not_found _) -> expect true (tag ^ ": correct error")
+      | _ -> expect false (tag ^ ": should error"));
+
+  finalise "aux-state"

--- a/latex-parse/src/test_compile_contract.ml
+++ b/latex-parse/src/test_compile_contract.ml
@@ -1,0 +1,169 @@
+(** Unit tests for [Compile_contract]. *)
+
+open Latex_parse_lib
+open Test_helpers
+
+let tmp_dir =
+  let d = Filename.temp_file "test_compile_contract_" "" in
+  Sys.remove d;
+  Unix.mkdir d 0o755;
+  d
+
+let write_file name content =
+  let path = Filename.concat tmp_dir name in
+  let oc = open_out path in
+  output_string oc content;
+  close_out oc;
+  path
+
+let cleanup_dir () =
+  Array.iter
+    (fun f -> try Sys.remove (Filename.concat tmp_dir f) with _ -> ())
+    (Sys.readdir tmp_dir);
+  try Unix.rmdir tmp_dir with _ -> ()
+
+let mk_profile ~tex_path =
+  Build_profile.create ~tex_path ~base_dir:(Filename.dirname tex_path)
+
+let () =
+  (* Happy path: minimal project, default profile, no declared features *)
+  run "Ready on minimal valid project" (fun tag ->
+      let path = write_file "ok.tex" "\\documentclass{article}\n" in
+      match Project_model.of_root path with
+      | Error _ -> expect false (tag ^ ": setup failed")
+      | Ok proj -> (
+          let profile = mk_profile ~tex_path:path in
+          match Compile_contract.check_ready_to_compile proj profile with
+          | Compile_contract.Ready -> expect true (tag ^ ": Ready")
+          | NotReady rs ->
+              expect false
+                (tag
+                ^ ": unexpected NotReady: "
+                ^ String.concat "; "
+                    (List.map Compile_contract.reason_to_string rs))));
+
+  (* T3: declaring opentype_fonts on pdflatex should fail *)
+  run "T3 catches opentype on pdflatex" (fun tag ->
+      let path = write_file "bad_font.tex" "\\documentclass{article}\n" in
+      match
+        Project_model.of_root
+          ~declared_features:[ Project_model.Opentype_fonts ]
+          path
+      with
+      | Error _ -> expect false (tag ^ ": setup failed")
+      | Ok proj -> (
+          let profile = mk_profile ~tex_path:path in
+          match Compile_contract.check_ready_to_compile proj profile with
+          | NotReady rs ->
+              let has_t3 =
+                List.exists
+                  (function
+                    | Compile_contract.T3_profile_incompatible _ -> true
+                    | _ -> false)
+                  rs
+              in
+              expect has_t3 (tag ^ ": T3 reason present")
+          | Ready -> expect false (tag ^ ": should reject")));
+
+  (* T3: opentype_fonts on xelatex should pass *)
+  run "T3 accepts opentype on xelatex" (fun tag ->
+      let path = write_file "ok_xe.tex" "\\documentclass{article}\n" in
+      match
+        Project_model.of_root ~engine:Project_model.Xelatex
+          ~declared_features:[ Project_model.Opentype_fonts ]
+          path
+      with
+      | Error _ -> expect false (tag ^ ": setup failed")
+      | Ok proj -> (
+          let profile = mk_profile ~tex_path:path in
+          match Compile_contract.check_ready_to_compile proj profile with
+          | Ready -> expect true (tag ^ ": Ready on xelatex+opentype")
+          | NotReady _ -> expect false (tag ^ ": should pass")));
+
+  (* T3: lua_scripting on pdflatex fails *)
+  run "T3 catches lua_scripting on pdflatex" (fun tag ->
+      let path = write_file "bad_lua.tex" "\\documentclass{article}\n" in
+      match
+        Project_model.of_root
+          ~declared_features:[ Project_model.Lua_scripting ]
+          path
+      with
+      | Error _ -> expect false (tag ^ ": setup failed")
+      | Ok proj -> (
+          let profile = mk_profile ~tex_path:path in
+          match Compile_contract.check_ready_to_compile proj profile with
+          | NotReady _ -> expect true (tag ^ ": rejected")
+          | Ready -> expect false (tag ^ ": should reject")));
+
+  (* T2: missing include file *)
+  run "T2 catches missing include" (fun tag ->
+      let path =
+        write_file "missing_inc.tex"
+          "\\documentclass{article}\n\\input{never_exists}\n"
+      in
+      match Project_model.of_root path with
+      | Error _ -> expect false (tag ^ ": setup failed")
+      | Ok proj -> (
+          let profile = mk_profile ~tex_path:path in
+          match Compile_contract.check_ready_to_compile proj profile with
+          | NotReady rs ->
+              let has_t2 =
+                List.exists
+                  (function
+                    | Compile_contract.T2_project_not_closed _ -> true
+                    | _ -> false)
+                  rs
+              in
+              expect has_t2 (tag ^ ": T2 reason present")
+          | Ready -> expect false (tag ^ ": should reject")));
+
+  (* T4: aux_path with duplicate labels *)
+  run "T4 catches duplicate labels in aux" (fun tag ->
+      let tex_path = write_file "dup.tex" "\\documentclass{article}\n" in
+      let aux_path =
+        write_file "dup.aux"
+          {|\newlabel{foo}{{1}{1}{X}{y}{}}
+\newlabel{foo}{{2}{2}{Y}{z}{}}
+|}
+      in
+      match Project_model.of_root tex_path with
+      | Error _ -> expect false (tag ^ ": setup failed")
+      | Ok proj -> (
+          let profile = mk_profile ~tex_path in
+          match
+            Compile_contract.check_ready_to_compile ~aux_path proj profile
+          with
+          | NotReady rs ->
+              let has_t4 =
+                List.exists
+                  (function
+                    | Compile_contract.T4_semantic_incoherent
+                        (`Duplicate_labels _) ->
+                        true
+                    | _ -> false)
+                  rs
+              in
+              expect has_t4 (tag ^ ": T4 duplicate-labels caught")
+          | Ready -> expect false (tag ^ ": should reject")));
+
+  (* reason_to_string sanity *)
+  run "reason_to_string is informative" (fun tag ->
+      let r =
+        Compile_contract.T3_profile_incompatible
+          { feature = "lua_scripting"; profile = "pdflatex" }
+      in
+      let s = Compile_contract.reason_to_string r in
+      let contains sub =
+        let ls = String.length s and lsub = String.length sub in
+        let rec go i =
+          if i + lsub > ls then false
+          else if String.sub s i lsub = sub then true
+          else go (i + 1)
+        in
+        go 0
+      in
+      expect (contains "T3") (tag ^ ": mentions T3");
+      expect (contains "lua_scripting") (tag ^ ": mentions feature"));
+
+  cleanup_dir ();
+  finalise "compile-contract"


### PR DESCRIPTION
## Summary

Plan §3.1 PR A2b. Second half of the A2 runtime scaffold for the compile-guarantee stack. Depends on #252 (merged as 4c69ceb).

- `latex-parse/src/aux_state.{ml,mli}` — brace-balanced pdflatex `.aux` parser. Handles nested `{...}` via `find_arg_group`; parses `\newlabel`, `\bibcite`, `\bibstyle`, `\bibdata`; recognized-but-ignored: `\relax`, `\@writefile`, `\@input`, `\@setckpt`, `\providecommand`, `\gdef`, `\@tfor`. Unrecognized lines land in `parse_warnings` (non-fatal).
- `latex-parse/src/compile_contract.{ml,mli}` — `check_ready_to_compile ?aux_path proj profile → Ready | NotReady reasons`. T2 (project closure), T3 (per-feature/engine compatibility table), T4 (duplicate labels if aux present) are runtime-checked. T0/T1/T5 are placeholders here — T0/T1 require a full Parser_l2/Expander run which is heavier than this pre-compile gate should be, and T5 is delegated to `Validators.run_all`.
- `test_aux_state.ml` (16 cases) + `test_compile_contract.ml` (8 cases), all pass.

See ADR-002 (`aux_state` parses file contents; `build_artifact_state` wraps the runtime log profile — they are intentionally separate).

## Memo mapping

- Memo §5.5 (compile-readiness contract T0-T5): T2/T3/T4 runtime-wired; T0/T1/T5 left as documented placeholders, filled in PR A3 (proofs) and delegated to existing subsystems at runtime.
- Memo §5.5 `specs/v26/compilation_profiles.yaml` (shipped in A1): feature→engine table encoded here as `Compile_contract.feature_compatible` for runtime access without a yaml dep at request time.

## API stability

- `Aux_state.t` shape is stable for v26.2. `parse_warnings` is deliberately non-fatal so out-of-scope aux-family files (`.toc`, `.lof`, …) don't break the loader.
- `Compile_contract.reason` is a tagged sum; extensions in v26.3 will add constructors, not reshape existing ones. `reason_to_string` is informational, not parsed.

## Test plan

- [x] `dune build`
- [x] `dune exec latex-parse/src/test_aux_state.exe` → 16 PASS
- [x] `dune exec latex-parse/src/test_compile_contract.exe` → 8 PASS
- [ ] CI full tree