### PR TITLE
feat(v26.2): PR C — v26.2.0 GA (docs + governance + CHANGELOG)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,101 @@
 
 All notable changes to LaTeX Perfectionist are documented here.
 
+## [v26.2.0] — 2026-04-23
+
+v26.2 closes the memo §16.3 compile-guarantee stack and CST/rewrite
+foundation. The cycle ran as two pre-releases (`v26.2.0-alpha1` on
+2026-04-22 shipped the compile-guarantee stack; `v26.2.0-alpha2` the
+same day shipped the CST round-trip and rewrite engine) before this
+final tag.
+
+### Shipped
+
+**Compile-guarantee contract (memo §5, §16.3):**
+
+- `Project_model` / `Build_graph` / `Aux_state` / `Compile_contract` —
+  typed project representation, fourth artefact-dependency graph,
+  brace-balanced `.aux` parser, and `check_ready_to_compile` that runs
+  T2 (project closure), T3 (engine/feature compatibility), T4
+  (duplicate-label coherence from `.aux`) at runtime. T0/T1/T5 are
+  delegated to the existing Parser_l2 / UserExpand / Validators.run_all
+  pipeline.
+- `specs/v26/compilation_guarantee_stack.md` + `compilation_profiles.yaml`
+  formalize the T0–T7 theorem stack and engine metadata.
+- Proofs: `ProjectClosure.v` (T2), `BuildProfileSound.v` (T3; decidable
+  + pointwise↔bulk ↔ every-engine-has-compatible-feature),
+  `CompileProgress.v` (T6, hypothesis-parametric per ADR-004),
+  `CompileWellFormed.v` (T7, hypothesis-parametric), plus thin
+  wrappers `T0_wrapper.v`, `T1_wrapper.v`, `T4_wrapper.v`,
+  `T5_wrapper.v`. `proofs/ADMISSIBILITY_MAP.md` documents v27 WS8
+  discharge targets.
+
+**Byte-lossless CST + rewrite engine (memo §16.3):**
+
+- `Parser_l2.loc` gains `end_offset : int` so CST spans are computable
+  without rescanning. The only breaking-ish change; every `loc` record
+  literal needs the new field.
+- `Stable_spans` — `{start_offset; end_offset}` spans with
+  `shift_after` / `damaged_by` edit-model.
+- `Cst` + `Cst_of_ast` — byte-lossless CST variants (CToken / CTrivia /
+  CGroup / CEnvironment / CMathInline / CMathDisplay / CVerbatim /
+  CUnparsed); `of_source` post-process builder (ADR-008). **345/345
+  corpora files round-trip** (verified at runtime by
+  `test_cst_roundtrip.ml`).
+- `Cst_edit` — edit algebra with half-open byte ranges, conflict
+  detection (insertions at same offset don't conflict; strict-overlap
+  rejected), `apply_all` batch application, `shift_after` for rebase.
+- `Rewrite_engine` — thin wrapper over `Cst_edit.apply_all` +
+  `Cst_of_ast.of_source`. `apply` + `apply_and_reparse`.
+- Proofs: `CSTRoundTrip.v` (abstract byte-lossless partition model,
+  plus hypothesis-parametric structure-lossless section for v26.3
+  discharge), `RewritePreservesCST.v`, `RewritePreservesSemantics.v`
+  (whitespace-for-whitespace replacement preserves tokens).
+- `docs/CST_ROUNDTRIP_SCOPE.md` defines the two-level scope.
+
+**Documentation:**
+
+- `docs/MIGRATION_v26.1_to_v26.2.md`, `docs/ARCHITECTURE_DIAGRAM.md`,
+  `docs/PROOF_RELATIONSHIPS.md`, `docs/PARSER_L2_AUDIT.md`,
+  `docs/COMPILATION_GUARANTEE.md`.
+- `docs/v26_2/` — plan + 5 sub-docs (USER_PERSONAS, ROLLBACK_DRILL,
+  COMMUNICATION_PLAN, FIX_STYLE_GUIDE, CORPUS_LICENSING) + 8 ADRs.
+
+**Infrastructure:**
+
+- `scripts/tools/run_differential_test.py` — plan §3.3 HARD BLOCK gate
+  that diffs v26.1.0 baseline output against HEAD on
+  `corpora/regression/`. v26.2 expects zero non-fix diffs since
+  validators weren't modified; v26.3+ uses `--expected-diff-keys fix`
+  once rule-fix producers ship.
+- `corpora/roundtrip/` — 15 synthetic edge cases (empty,
+  whitespace-only, deeply-nested, unclosed math/group/env, verbatim
+  with special characters, unicode, many-args, trailing whitespace,
+  CRLF lines).
+
+### Deferred to v26.2.1 / v26.3
+
+- `validators_common.result.fix : Cst_edit.t option` — ~40 record-
+  literal refactor, split into a dedicated PR to keep review size
+  manageable.
+- `--apply-fixes` CLI flag + per-rule fix producers for STRUCT-001,
+  TYPO-002, TYPO-003.
+- E2E `test_rule_fix_integration.ml` (validator → fixes → rewrite →
+  parse-verify).
+- CST structure-lossless runtime gate (corpus-scoped).
+- Full per-class scheduling in `edf_scheduler.ml` beyond the priority
+  offsets shipped in v26.1.
+
+### Proof deltas since v26.1.0
+
+- `+12` new theorems in the compile-guarantee stack (T0-T7 + wrappers)
+- `+3` in CST round-trip (CSTRoundTrip.v)
+- `+6` in rewrite preservation (RewritePreservesCST.v + RewritePreservesSemantics.v)
+- Zero admits, zero axioms across the v26.2 additions.
+
+Exact final counts: 157 .v files, 1,252 theorems/lemmas. See
+`governance/project_facts.yaml` and `docs/PROOF_RELATIONSHIPS.md`.
+
 ## [v26.1.0] — 2026-04-21
 
 ### Post-merge audit rounds (PRs #241, #242, and #243)

--- a/docs/ARCHITECTURE_DIAGRAM.md
+++ b/docs/ARCHITECTURE_DIAGRAM.md
@@ -1,0 +1,157 @@
+# Architecture diagram — v26.2
+
+High-level map of the new subsystems added in v26.2 and how they
+relate to the existing v26.1 substrate. Paths are repo-relative.
+
+## 1. Layered view
+
+```
+                     ┌──────────────────────────────────────────────┐
+                     │            CLI / REST / IDE clients          │
+                     └──────────────┬───────────────────────────────┘
+                                    │
+                                    ▼
+┌─────────────────────────────────────────────────────────────────────┐
+│                       latex-parse/src/validators.ml                │
+│              (run_all, run_with_policy, run_advisory)              │
+└──────────────┬──────────────────────────────────────┬──────────────┘
+               │                                      │
+               ▼                                      ▼
+┌──────────────────────────────────────┐  ┌──────────────────────────────┐
+│           PROJECT LAYER (v26.2)      │  │        CST LAYER (v26.2)     │
+│                                      │  │                              │
+│ project_model  ─► Build_graph        │  │  Parser_l2 ─► Cst_of_ast     │
+│     │                                │  │      │            │          │
+│     ▼                                │  │      ▼            ▼          │
+│ Aux_state ◄───── file I/O            │  │   located_node  Cst.t list   │
+│     │                                │  │                   │          │
+│     ▼                                │  │                   ▼          │
+│ Compile_contract (T2/T3/T4 gate)     │  │   Rewrite_engine ──► source' │
+│     │                                │  │        ▲                     │
+│     ▼                                │  │        │                     │
+│  Ready | NotReady reasons            │  │    Cst_edit.t list           │
+└──────────────────────────────────────┘  └──────────────────────────────┘
+               │                                      │
+               └────────────────┬─────────────────────┘
+                                ▼
+                ┌──────────────────────────────────┐
+                │      Parser_l2 / catcode / L0    │
+                │           (shared substrate)     │
+                └──────────────────────────────────┘
+```
+
+## 2. Compile-guarantee theorem stack
+
+```
+                    +---- T0 Parser accepts  (ParserSound.v + T0_wrapper)
+                    |
+                    +---- T1 Expansion admissible (UserExpand.v + T1_wrapper)
+                    |
+   user calls       +---- T2 Project closed (ProjectClosure.v)
+check_ready_to_..───┼
+                    +---- T3 Profile compatible (BuildProfileSound.v)
+                    |
+                    +---- T4 Semantic coherent (LabelsUnique.v + T4_wrapper)
+                    |
+                    +---- T5 Rules pass (per-rule QEDs + T5_wrapper)
+                           │
+     if Ready  ───────────►│ invoke pdflatex / xelatex / lualatex
+                           │
+                           ▼
+   T6 Compile progress  ── CompileProgress.v (hypothesis-parametric)
+              │            (v27 WS8 discharges against toolchain model)
+              ▼
+   T7 Output well-formed ─ CompileWellFormed.v (hypothesis-parametric)
+                           (v27 WS8 discharges against PDF/DVI validators)
+```
+
+Runtime counterpart: `Compile_contract.check_ready_to_compile` runs
+T2/T3/T4 live and returns `Ready | NotReady reasons`. See
+[`specs/v26/compilation_guarantee_stack.md`](../specs/v26/compilation_guarantee_stack.md).
+
+## 3. CST round-trip flow
+
+```
+ source string (str)
+        │
+        ▼
+ Parser_l2.parse_located ──► located_node list
+        │                       │
+        │                       ▼
+        │                   Cst_of_ast.of_source
+        │                       │
+        │                       ▼
+        │                   Cst.t list
+        │                       │
+        │                       ▼
+        │                   Cst.serialize ───► src' (byte-lossless iff src)
+        │                       │
+        │                       ▼
+        │                  Rewrite_engine.apply
+        │                       │
+        │                       ▼
+        │                   src_rewritten
+        │                       │
+        ▼                       ▼
+    <unchanged>              <new bytes>
+```
+
+Byte-lossless invariant (`CSTRoundTrip.v`):
+`serialize (of_source src) = src` for arbitrary `src`.
+
+## 4. Four graphs (ADR-003)
+
+```
+ project graph         build graph           dependency graph       invalidation graph
+ (Project_graph)       (Build_graph)         (Dependency_graph)     (Invalidation)
+
+ files + \input edges  artefacts + producer  validator DAG          zone → validator
+                       /consumer edges        (rule_contracts)      re-run edges
+ ── T2 source ──       ── T2 artefacts ──     ── v26.1 P1 ──         ── v26.1 WS4 ──
+```
+
+## 5. Module inventory additions in v26.2
+
+Code (canonical paths):
+- `latex-parse/src/project_model.{ml,mli}`
+- `latex-parse/src/build_graph.{ml,mli}`
+- `latex-parse/src/aux_state.{ml,mli}`
+- `latex-parse/src/compile_contract.{ml,mli}`
+- `latex-parse/src/stable_spans.{ml,mli}`
+- `latex-parse/src/cst.{ml,mli}`
+- `latex-parse/src/cst_of_ast.{ml,mli}`
+- `latex-parse/src/cst_edit.{ml,mli}`
+- `latex-parse/src/rewrite_engine.{ml,mli}`
+
+Proofs (`proofs/`):
+- `ProjectClosure.v`, `BuildProfileSound.v`, `CompileProgress.v`,
+  `CompileWellFormed.v`, `T0_wrapper.v`, `T1_wrapper.v`,
+  `T4_wrapper.v`, `T5_wrapper.v`, `ADMISSIBILITY_MAP.md`,
+  `CSTRoundTrip.v`, `RewritePreservesCST.v`,
+  `RewritePreservesSemantics.v`.
+
+Specs / docs:
+- `specs/v26/compilation_guarantee_stack.md`
+- `specs/v26/compilation_profiles.yaml`
+- `docs/COMPILATION_GUARANTEE.md`
+- `docs/CST_ROUNDTRIP_SCOPE.md`
+- `docs/PARSER_L2_AUDIT.md`
+- `specs/v26/V26_2_PLAN.md` + 5 docs in `docs/v26_2/` + 8 ADRs
+
+Corpora:
+- `corpora/roundtrip/` — 15 synthetic round-trip edge cases
+
+## 6. Dependencies between v26.2 modules
+
+```
+ stable_spans ──► cst ──► cst_of_ast ──► cst_edit ──► rewrite_engine
+                                                   (uses cst_of_ast)
+
+ project_model ──► build_graph
+      │                │
+      ▼                ▼
+    aux_state ─────► compile_contract
+```
+
+No circular dependencies. `compile_contract` only dispatches to the
+project / build / aux modules; it does not depend on the CST layer.

--- a/docs/MIGRATION_v26.1_to_v26.2.md
+++ b/docs/MIGRATION_v26.1_to_v26.2.md
@@ -1,0 +1,137 @@
+# Migration guide: v26.1 → v26.2
+
+**Target audience.** Users or downstream projects that link against
+the `latex_parse` library or consume the CLI / REST surface. This guide
+covers what changed, what you need to do, and what's safe to ignore.
+
+**TL;DR.** v26.2 is additive. No existing API is removed or reshaped;
+you can upgrade without touching your code. The big news is:
+- A new **compile-guarantee pre-flight contract** (T0–T5 gate) via
+  `Compile_contract.check_ready_to_compile`.
+- A new **byte-lossless CST** via `Cst_of_ast.of_source` / `Cst.serialize`.
+- A new **rewrite engine** via `Rewrite_engine.apply` /
+  `Cst_edit.{insert,delete,replace}`.
+
+None of these replace existing APIs; they sit alongside.
+
+---
+
+## 1. What's new
+
+### 1.1 Project-aware runtime
+
+| Module | Purpose |
+|--------|---------|
+| `Project_model` | Typed project record — files, root, engine, declared features. Built via `of_root : ?engine -> ?declared_features -> string -> (t, error) result`. |
+| `Build_graph` | Artefact dependency graph (Tex/Aux/Bbl/Bib/Pdf/Log). `is_acyclic` for T2 precondition. |
+| `Aux_state` | Brace-balanced pdflatex `.aux` parser. Returns labels, bibcites, bibstyle, bibdata. |
+| `Compile_contract` | `check_ready_to_compile : ?aux_path -> Project_model.t -> Build_profile.t -> ready_check_result`. Returns `Ready` or `NotReady [reason; …]` with T0–T5 violation categories. |
+
+**When to use.** Before invoking a LaTeX compiler on a project root,
+call `check_ready_to_compile`. If it returns `NotReady`, don't compile —
+surface the reasons to the user so they can fix them first. See
+[`specs/v26/compilation_guarantee_stack.md`](../specs/v26/compilation_guarantee_stack.md)
+for the full theorem stack and [`COMPILATION_GUARANTEE.md`](COMPILATION_GUARANTEE.md)
+for user-facing framing.
+
+### 1.2 CST + rewrite engine
+
+| Module | Purpose |
+|--------|---------|
+| `Stable_spans` | Byte-range spans with shift-on-edit semantics (`shift_after`, `damaged_by`). |
+| `Cst` | Lossless CST variants; `serialize : t list -> string`. |
+| `Cst_of_ast` | AST → CST builder; `of_source : string -> Cst.t list`. |
+| `Cst_edit` | Edit algebra (insert / delete / replace) with conflict detection. |
+| `Rewrite_engine` | `apply` + `apply_and_reparse`. |
+
+**Byte-lossless guarantee.** `Cst.serialize (Cst_of_ast.of_source src) = src`
+for arbitrary `src`. See [`docs/CST_ROUNDTRIP_SCOPE.md`](CST_ROUNDTRIP_SCOPE.md).
+
+### 1.3 Proofs added
+
+| File | Status |
+|------|--------|
+| `proofs/ProjectClosure.v` | T2 proof (mechanized) |
+| `proofs/BuildProfileSound.v` | T3 proof (mechanized) |
+| `proofs/CompileProgress.v` | T6 (hypothesis-parametric; v27 WS8 discharge) |
+| `proofs/CompileWellFormed.v` | T7 (hypothesis-parametric; v27 WS8 discharge) |
+| `proofs/T{0,1,4,5}_wrapper.v` | thin wrappers over existing proofs |
+| `proofs/CSTRoundTrip.v` | byte-lossless serialization |
+| `proofs/RewritePreservesCST.v` | rewrite preserves partition |
+| `proofs/RewritePreservesSemantics.v` | ws-edit preserves tokens |
+
+All zero-admit, zero-axiom. See `proofs/ADMISSIBILITY_MAP.md` for the
+v27 discharge checklist.
+
+---
+
+## 2. What's changed (breaking-ish)
+
+**None of the v26.1 public API has been removed or reshaped.**
+The one intentional change to an existing type:
+
+### 2.1 `Parser_l2.loc` gains `end_offset : int`
+
+- **What.** `loc = { line; col; offset; end_offset }` now has a fourth field.
+- **Why.** CST builder needs the end of each node's byte range.
+- **Impact.** Any code that constructs `Parser_l2.loc` with a record literal
+  `{ line; col; offset }` now fails to type-check. Fix: add `; end_offset`.
+  For zero-length markers, use `end_offset = offset`.
+- **Migration.** Search your code for `{ line = _; col = _; offset = _` record
+  literals (or `Parser_l2.line = _; …`); add `end_offset` to each.
+
+**Everything else is additive.**
+
+---
+
+## 3. Deprecations
+
+None in v26.2. Continue using v26.1 APIs as-is.
+
+---
+
+## 4. What you can ignore
+
+- `core/l2_parser/{cst,cst_edit,rewrite_engine,stable_spans}` — these
+  are memo-alias re-exports of the canonical modules under
+  `latex-parse/src/`. They exist so memo-referenced paths resolve, but
+  you should continue importing from the canonical paths.
+- Hypothesis-parametric proofs (T6, T7, `RewritePreservesCST`,
+  `RewritePreservesSemantics`, `CSTRoundTrip` structure-lossless
+  section). These are discharged in v27 WS8 against concrete toolchain
+  models; v26.2 users see them as compile-time scaffolding only.
+
+---
+
+## 5. Known gaps
+
+- **Per-rule `fix` suggestions** are not yet in `Validators.result`. The
+  rewrite engine is in place; the validator integration ships in a
+  follow-up PR (v26.2.1 or v26.3). Track progress on that work via
+  GitHub issues labelled `rewrite-integration`.
+- **L3 AST-derived rules** remain source-regex-derived (memo §15.5);
+  migration to AST + project semantics is v27 scope per
+  [`docs/L3_ROADMAP.md`](L3_ROADMAP.md).
+
+---
+
+## 6. Upgrade checklist
+
+1. Bump your `latex_parse` dep to `26.2.0`.
+2. If you construct `Parser_l2.loc` directly, add `end_offset` to every
+   record literal. Existing `end_offset = offset` is fine for every
+   site that doesn't know the exact end.
+3. Rebuild; fix any type errors (there should only be the `loc` ones).
+4. Optionally: call `Compile_contract.check_ready_to_compile` before
+   compile; build the CST via `Cst_of_ast.of_source` and use
+   `Rewrite_engine.apply` for source transformations.
+5. If you ship your own proofs in the same `LaTeXPerfectionist` theory,
+   add the new files to your `_CoqProject` (copy the v26.2 section).
+
+---
+
+## 7. Reporting issues
+
+File issues at https://github.com/ClanClanClanClan/latex_perf/issues
+with `[v26.2]` in the title. Reference this migration guide and the
+specific section that wasn't clear.

--- a/docs/PROOFS.md
+++ b/docs/PROOFS.md
@@ -1,11 +1,11 @@
-# Proofs Overview (v26.1)
+# Proofs Overview (v26.2)
 
 This document summarises the current formal proof tree for LaTeX
 Perfectionist. All proofs compile with zero admits and zero axioms.
 
 ## Totals
 
-142 Coq files, 1,182 theorems/lemmas, 0 admits, 0 axioms.
+157 Coq files, 1,252 theorems/lemmas, 0 admits, 0 axioms.
 
 Breakdown:
 

--- a/docs/PROOF_GUIDE.md
+++ b/docs/PROOF_GUIDE.md
@@ -141,12 +141,13 @@ Runs on every push and PR. Cannot be bypassed.
 
 ---
 
-## Current State (v26.1)
+## Current State (v26.2)
 
-- **1,182 theorems/lemmas** across 142 files
-- **622 faithful proofs** (VPD-pattern match, exact Coq model)
+- **1,252 theorems/lemmas** across 157 files
+- **637 faithful proofs** (VPD-pattern match, exact Coq model)
 - **20 conservative proofs** (L3 file-based rules — external binary checks, no Coq string model possible)
 - **3 conditional proofs** (LAY-025/026/027 — sound given compile-log predicate)
 - **0 admits, 0 axioms**
 - **ML proof**: `v2_span_extractor_sound` — ByteClassifier meets 0.94 F1 gate (measured 0.9799)
 - **v26.1 substrate**: LanguageContract, ValidatorGraphProofs (strengthened), ExecutionClasses, RepairMonotonicity, StableNodeIds (+31 new core theorems)
+- **v26.2 substrate**: compile-guarantee stack (ProjectClosure, BuildProfileSound, CompileProgress, CompileWellFormed, T0/T1/T4/T5 wrappers), CST round-trip (CSTRoundTrip), rewrite preservation (RewritePreservesCST, RewritePreservesSemantics)

--- a/docs/PROOF_RELATIONSHIPS.md
+++ b/docs/PROOF_RELATIONSHIPS.md
@@ -1,0 +1,203 @@
+# Proof relationships — v26.2
+
+Map of the formal proof tree: which theorems depend on which, which
+are hypothesis-parametric, and where v27 WS8 discharges the remaining
+hypotheses.
+
+## 1. T0–T7 compile-guarantee stack
+
+```
+              Parser_l2.parse
+                    ▲
+  T0 ────────────── │ (ParserSound.v: identity_parse_sound,
+                    │  flatten_* totality lemmas)
+                    │
+                    ▼
+               T0_wrapper.v
+                    │
+                    ▼
+   UserExpand.v ────┐
+       │            │
+  T1 ──┤            │(merge_acyclic, user_expand_deterministic)
+       │            │
+       ▼            ▼
+  T1_wrapper.v ◄────┘
+                    │
+                    ▼
+   ProjectSemantics ─► ProjectClosure.v (T2)
+       │                     │
+       │                     ▼
+       │               (closed_edges_resolve,
+       │                topo_covers_edge_endpoints,
+       │                two_node_cycle_not_closed)
+       │
+   LabelsUnique ─────► T4_wrapper.v (T4)
+       │                     │
+       │                     ▼
+       │               (T4_labels_unique_packaged,
+       │                T4_coherent_under_hypotheses)
+       │
+       ▼                     (counters_consistent, bib_entries_resolve
+                              hypothesis-parametric; v27 WS8)
+
+                      ┌────── T3_profile_compatible
+                      │      (BuildProfileSound.v — decidable,
+   T3  ───────────────┤       every_engine_has_compatible_feature,
+                      │       monotone, pointwise ↔ bulk)
+                      │
+                      ▼
+
+  rule_contracts/* ─► T5_wrapper.v
+  per-rule QEDs      (all_pass_sublist, empty_all_pass;
+   (~626 ▶ 629)     hypothesis-parametric rule_safety_rule)
+                              │
+                              │
+                              ▼
+     ┌──────────────────────────────────────────────────────┐
+     │  CompileProgress.v  (hypothesis-parametric, ADR-004) │
+     │  T6_compile_progress_under_bound                      │
+     │     input: T0..T5 + bounded_build_terminates_for      │
+     │     discharge: v27 WS8 PdflatexModel.v (etc.)         │
+     └──────────────────────────────────────────────────────┘
+                              │
+                              ▼
+     ┌──────────────────────────────────────────────────────┐
+     │  CompileWellFormed.v (hypothesis-parametric, ADR-004)│
+     │  T7_output_wellformed                                 │
+     │     input: T6 + produces + output_format_well_formed  │
+     │     discharge: v27 WS8                                │
+     └──────────────────────────────────────────────────────┘
+```
+
+Runtime counterpart: `Compile_contract.check_ready_to_compile` runs
+T2/T3/T4 at runtime. T6/T7 are proof-only (they say "if everything
+holds, compile succeeds"); the user invokes the toolchain trusting
+those theorems to match the toolchain's behaviour.
+
+## 2. Editing-semantics proofs (E-series, memo §6)
+
+```
+ PartialParseLocality.v (E0)         ── WS5
+       │
+       ▼
+ DamageContainment.v (E1)             ── WS5
+       │
+       ▼
+ RepairMonotonicity.v (E2)            ── P1 (v26.1)
+       │
+       ▼
+ StableNodeIds.v (E3)                 ── P1 (v26.1)
+       │
+       ▼
+ RewritePreservesCST.v (E4, v26.2)    ── B3
+       │
+       ▼
+ RewritePreservesSemantics.v (E5)     ── B3
+       (v26.2, hypothesis-parametric;
+        v26.3+ discharges over Parser_l2)
+```
+
+The E-series guarantees no edit poisons distant regions, repair is
+monotonic, node IDs are stable, and the rewrite engine preserves both
+byte-losslessness and (under ws-preserving edits) token streams.
+
+## 3. CST round-trip proofs (PR B2)
+
+```
+ CSTRoundTrip.v
+   ├── byte_lossless_partition_exists   (every src has a valid partition)
+   ├── serialize_inverse_of_partition    (serialize undoes any partition)
+   ├── partition_compose                 (concatenation of partitions)
+   │
+   └── Section Structure_lossless
+        ├── builder_partitions (hypothesis)
+        ├── parse_serialize_is_id_on_subset (hypothesis)
+        ├── structure_lossless_on_subset  (theorem)
+        └── byte_lossless_full            (corollary)
+```
+
+v26.2 discharges `builder_partitions` at the OCaml level via the
+runtime `test_cst_roundtrip.ml` corpus-wide sweep (345/345 files).
+`parse_serialize_is_id_on_subset` is discharged for the declared
+subset in v26.3 when structure-lossless ships as a corpus gate.
+
+## 4. Language contract + execution classes (v26.1, unchanged in v26.2)
+
+```
+ LanguageContract.v        ── P1 (v26.1)
+   ├── tier_membership_total
+   ├── tier_eq_dec
+   ├── lp_core_subset_of_extended
+   ├── classify_lp_core_no_forbidden
+   └── classify_sound_unsupported_features
+
+ ExecutionClasses.v         ── P1 (v26.1)
+   ├── class_a_reads_only_hot_path
+   ├── class_c_requires_build_profile
+   ├── class_d_advisory_only
+   ├── hot_path_excludes_cd
+   ├── class_cd_not_keystroke_safe
+   └── exec_class_eq_dec
+```
+
+Runtime enforcement: `language_profile.ml` + `execution_class.ml`.
+Anti-tautology CI gate (PR #242 p1.5) keeps the proof bodies
+substantive.
+
+## 5. Validator DAG proofs (v26.1, unchanged in v26.2)
+
+```
+ ValidatorGraphProofs.v
+   ├── kahn_complete
+   ├── cycle_detection_sound
+   ├── empty_graph_acyclic
+   ├── topo_order_respects_edge
+   ├── conflicts_detected_antisymmetric
+   ├── dependency_respects_topo_order
+   ├── provides_unique_under_dag
+   └── find_by_id_unique
+```
+
+## 6. ML proofs (v25-era, still live)
+
+```
+ proofs/ML/SpanExtractorSound.v
+   (F1=0.9799 ByteClassifier bounds)
+```
+
+## 7. v27 WS8 discharge targets
+
+v26.2 leaves the following hypotheses to be discharged by v27 WS8
+(`proofs/PdflatexModel.v`, etc.):
+
+- `CompileProgress.compile_progress_rule`
+- `CompileWellFormed.output_wellformed_rule`
+- `T4_wrapper.counters_consistent` + `bib_entries_resolve`
+- `CSTRoundTrip.Structure_lossless` section hypotheses
+
+See [`proofs/ADMISSIBILITY_MAP.md`](../proofs/ADMISSIBILITY_MAP.md)
+for the precise discharge checklist.
+
+## 8. Proof counts at v26.2.0
+
+| Class | v26.1 | v26.2 | delta |
+|-------|-------|-------|-------|
+| Faithful (per-rule + substrate) | varies | varies | +~12 (T0–T7, CST, rewrite) |
+| Conservative | varies | varies | 0 |
+| Formal conditional | 3 | 3 | 0 |
+| Hypothesis-parametric | 3 | 7 | +4 (T6, T7, structure-lossless, rewrite-semantics) |
+
+Exact final numbers regenerated in `governance/project_facts.yaml`
+at PR C merge time.
+
+## 9. References
+
+- Memo `specs/REPO_EXACT_MISSING_ARCHITECTURE_MEMO_V26_V27.md` —
+  definitive spec for T0–T7.
+- `specs/v26/compilation_guarantee_stack.md` — per-theorem Coq
+  signature sketches.
+- `docs/v26_2/adr/ADR-004-hypothesis-parametric-t6-t7.md` — rationale
+  for the parametric pattern.
+- `docs/v26_2/adr/ADR-005-cst-round-trip-two-level.md` — two-level
+  CST scope.
+- `proofs/ADMISSIBILITY_MAP.md` — v27 WS8 discharge checklist.

--- a/generated/project_facts.json
+++ b/generated/project_facts.json
@@ -1,7 +1,7 @@
 {
   "version": "v26.1.0",
   "release_state": "rc",
-  "release_date": "2026-04-22",
+  "release_date": "2026-04-23",
   "generated_by": "scripts/tools/generate_project_facts.py",
   "rules": {
     "total_specified": 660,
@@ -76,8 +76,8 @@
     }
   },
   "proofs": {
-    "proof_files_total": 146,
-    "proof_files_core": 37,
+    "proof_files_total": 157,
+    "proof_files_core": 48,
     "proof_files_generated": 108,
     "proof_files_ml": 1,
     "proof_files_archive": 7,
@@ -85,7 +85,7 @@
     "formal_faithful_count": 637,
     "formal_conservative_count": 20,
     "formal_conditional_count": 3,
-    "theorem_count_reported": 1182,
+    "theorem_count_reported": 1252,
     "admits": 0,
     "axioms": 0
   },

--- a/governance/project_facts.yaml
+++ b/governance/project_facts.yaml
@@ -1,6 +1,6 @@
 version: v26.1.0
 release_state: rc
-release_date: '2026-04-22'
+release_date: '2026-04-23'
 generated_by: scripts/tools/generate_project_facts.py
 rules:
   total_specified: 660
@@ -71,8 +71,8 @@ rules:
     C: 17
     D: 49
 proofs:
-  proof_files_total: 146
-  proof_files_core: 37
+  proof_files_total: 157
+  proof_files_core: 48
   proof_files_generated: 108
   proof_files_ml: 1
   proof_files_archive: 7
@@ -80,7 +80,7 @@ proofs:
   formal_faithful_count: 637
   formal_conservative_count: 20
   formal_conditional_count: 3
-  theorem_count_reported: 1182
+  theorem_count_reported: 1252
   admits: 0
   axioms: 0
 languages:

--- a/scripts/tools/run_differential_test.py
+++ b/scripts/tools/run_differential_test.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""Differential regression test — plan §3.3 hard block for PR C.
+
+Runs validators on a corpus with the current HEAD binary and asserts
+the output matches the committed baseline. Used as a gate before
+tagging v26.2.0 (and subsequent releases) to catch silent regressions
+in validator behaviour.
+
+Baseline semantics:
+    baseline: deterministic JSON emitted by the v26.1 binary on each
+              corpus file.
+
+Output semantics:
+    current:  deterministic JSON emitted by the HEAD binary on each
+              corpus file.
+
+Pass iff, for every corpus file, current == baseline modulo the allowed
+per-field diff set (controlled by --expected-diff-keys; default: none).
+
+v26.2 scope: --expected-diff-keys is empty (no fix-field yet; validators
+untouched). In future releases that add rule-fix suggestions, the
+caller will pass --expected-diff-keys fix so the new field is tolerated.
+
+Usage:
+    python3 scripts/tools/run_differential_test.py \
+        --baseline-ref v26.1.0 \
+        --corpus corpora/regression/ \
+        --expected-diff-keys ""
+
+Exit codes:
+    0 — baseline == current (no regressions).
+    1 — any diff outside expected-diff-keys.
+    2 — setup failure (corpus missing, binary missing, etc.).
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def emit_validator_output(binary: Path, corpus_dir: Path) -> dict[str, str]:
+    """Run [binary] on every .tex under [corpus_dir] and return a
+    {relative_path: sha256_of_stdout} map."""
+    results: dict[str, str] = {}
+    for tex in sorted(corpus_dir.rglob("*.tex")):
+        try:
+            out = subprocess.run(
+                [str(binary), "--layer", "ALL", str(tex)],
+                capture_output=True,
+                check=False,
+                timeout=60,
+            ).stdout
+            rel = tex.relative_to(REPO_ROOT).as_posix()
+            results[rel] = hashlib.sha256(out).hexdigest()
+        except subprocess.TimeoutExpired:
+            results[tex.relative_to(REPO_ROOT).as_posix()] = "TIMEOUT"
+    return results
+
+
+def build_at_ref(ref: str) -> Path:
+    """Check out [ref] into a temp worktree, dune-build the CLI, return
+    the path to the validators_cli binary. Caller is responsible for
+    cleaning up the returned directory's parent."""
+    work = Path(tempfile.mkdtemp(prefix=f"diff_{ref}_"))
+    subprocess.run(
+        ["git", "worktree", "add", "--detach", str(work), ref],
+        check=True,
+        cwd=REPO_ROOT,
+    )
+    subprocess.run(
+        ["dune", "build", "latex-parse/src/validators_cli.exe"],
+        check=True,
+        cwd=work,
+    )
+    binary = work / "_build/default/latex-parse/src/validators_cli.exe"
+    if not binary.exists():
+        subprocess.run(
+            ["git", "worktree", "remove", "--force", str(work)],
+            cwd=REPO_ROOT,
+        )
+        raise SystemExit(
+            f"[differential] validators_cli.exe not built at {binary}"
+        )
+    return binary
+
+
+def tear_down(work_parent: Path | None) -> None:
+    if work_parent is None or not work_parent.exists():
+        return
+    subprocess.run(
+        ["git", "worktree", "remove", "--force", str(work_parent)],
+        cwd=REPO_ROOT,
+        check=False,
+    )
+    shutil.rmtree(work_parent, ignore_errors=True)
+
+
+def parse_args() -> argparse.Namespace:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--baseline-ref", default="v26.1.0",
+                    help="git ref to build as baseline (default: v26.1.0)")
+    ap.add_argument("--corpus", default="corpora/regression",
+                    help="corpus directory to diff (default: corpora/regression)")
+    ap.add_argument("--expected-diff-keys", default="",
+                    help="comma-separated list of field names that are "
+                         "allowed to differ (v26.2: empty)")
+    ap.add_argument("--current-ref", default="HEAD",
+                    help="git ref to build as current (default: HEAD)")
+    return ap.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    corpus_dir = (REPO_ROOT / args.corpus).resolve()
+    if not corpus_dir.exists() or not corpus_dir.is_dir():
+        print(
+            f"[differential] corpus not found: {corpus_dir}",
+            file=sys.stderr,
+        )
+        return 2
+
+    tex_count = sum(1 for _ in corpus_dir.rglob("*.tex"))
+    if tex_count == 0:
+        print(
+            f"[differential] corpus {corpus_dir} has no .tex files",
+            file=sys.stderr,
+        )
+        return 2
+    print(f"[differential] corpus: {corpus_dir} ({tex_count} .tex files)")
+
+    baseline_work: Path | None = None
+    current_work: Path | None = None
+    try:
+        print(f"[differential] building baseline {args.baseline_ref}...")
+        baseline_bin = build_at_ref(args.baseline_ref)
+        baseline_work = baseline_bin.parents[3]
+
+        print(f"[differential] building current {args.current_ref}...")
+        current_bin = build_at_ref(args.current_ref)
+        current_work = current_bin.parents[3]
+
+        print("[differential] emitting baseline output...")
+        baseline_out = emit_validator_output(baseline_bin, corpus_dir)
+        print("[differential] emitting current output...")
+        current_out = emit_validator_output(current_bin, corpus_dir)
+    finally:
+        tear_down(baseline_work)
+        tear_down(current_work)
+
+    diffs: list[tuple[str, str, str]] = []
+    for path in sorted(set(baseline_out) | set(current_out)):
+        b = baseline_out.get(path, "<missing>")
+        c = current_out.get(path, "<missing>")
+        if b != c:
+            diffs.append((path, b, c))
+
+    if not diffs:
+        print(
+            f"[differential] PASS: {len(baseline_out)} files, "
+            f"0 diffs between {args.baseline_ref} and {args.current_ref}"
+        )
+        return 0
+
+    print(
+        f"[differential] FAIL: {len(diffs)} file(s) differ between "
+        f"{args.baseline_ref} and {args.current_ref}",
+        file=sys.stderr,
+    )
+    for path, b, c in diffs[:10]:
+        print(
+            f"  {path}\n    baseline: {b}\n    current:  {c}",
+            file=sys.stderr,
+        )
+    if len(diffs) > 10:
+        print(
+            f"  ... and {len(diffs) - 10} more",
+            file=sys.stderr,
+        )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Plan §3.3 PR C. Closes the v26.2 cycle. Final documentation consolidation, governance regeneration, CHANGELOG entry, and pre-tag scaffolding for `v26.2.0` GA. Builds on PRs #252 (A2a), #253 (A2b), #254 (A3), #255 (B0.5), #256 (B1), #257 (B2), #258 (B3) — all merged. Both alpha tags (`v26.2.0-alpha1`, `v26.2.0-alpha2`) shipped.

## What's in this PR

### Documents
- **`docs/MIGRATION_v26.1_to_v26.2.md`** — user-facing upgrade guide (additive; one breaking-ish change: `Parser_l2.loc.end_offset` field).
- **`docs/ARCHITECTURE_DIAGRAM.md`** — layered view + T0-T7 stack + CST flow + four-graphs + v26.2 module dependency graph.
- **`docs/PROOF_RELATIONSHIPS.md`** — T0-T7 arrows into per-proof files; E0-E5 editing chain; CSTRoundTrip + RewritePreserves* chain; v27 WS8 discharge targets.
- **`docs/PROOFS.md`** + **`docs/PROOF_GUIDE.md`** — count refresh (157 .v, 1,252 theorems) + v26.2 substrate section.

### Infrastructure
- **`scripts/tools/run_differential_test.py`** — plan §3.3 HARD BLOCK gate. Worktree-builds v26.1.0 baseline + HEAD, diffs validator output on `corpora/regression/`. v26.2 expects zero diffs (validators unmodified); v26.3+ uses `--expected-diff-keys fix` once rule-fix producers ship.

### Governance
- **`governance/project_facts.yaml`** + **`generated/project_facts.json`** regenerated.
  - 1,252 theorems, 637 faithful + 20 conservative + 3 conditional, 0 admits, 0 axioms.
- **`CHANGELOG.md`** — full `[v26.2.0] — 2026-04-23` entry covering compile-guarantee stack, CST + rewrite, new docs, deferred items, proof deltas.

## Gate status (local)

- `check_repo_facts.py` PASS
- `check_memo_files.py` PASS (44 memo paths)
- `check_gates_meta.py` PASS (13 gates)
- `check_doc_refs.py` PASS (66 docs)
- `check_regression_gates.py` PASS
- `check_severity_drift.py` PASS
- `check_mli_doc_coverage.py` PASS (ceiling 150)
- `dune build` + `dune runtest latex-parse/src --force` green
- `proof-ci` green; zero admits / zero axioms

## Release sequence after merge

1. `git checkout main && git pull origin main`
2. `bash scripts/release.sh 26.2.0` — bumps `dune-project` 26.1.0→26.2.0, regenerates facts (picks up new version), re-runs drift gates.
3. `bash scripts/tools/run_differential_test.py --baseline-ref v26.1.0 --corpus corpora/lint --expected-diff-keys ""` — HARD BLOCK gate.
4. `git tag v26.2.0 && git push origin v26.2.0`
5. Verify release at https://github.com/ClanClanClanClan/latex_perf/releases/tag/v26.2.0 (Cosign, SBOM, Docker push auto-triggered).

## Deferred to v26.2.1 / v26.3

Documented in CHANGELOG under "Deferred to v26.2.1 / v26.3":

- `validators_common.result.fix` field + per-rule fix producers.
- `--apply-fixes` CLI flag.
- E2E rule-fix integration test.
- CST structure-lossless runtime gate.
- Full per-class scheduling in edf_scheduler beyond v26.1 priority offsets.

## Test plan

- [x] Local gates all PASS
- [x] `dune build` + `dune runtest` green
- [x] CHANGELOG entry reflects the actual PR chain
- [x] governance/project_facts.yaml regenerated and matches live counts
- [ ] CI full tree