### PR TITLE
fix(differential): strip timing lines before hashing

### DIFF
--- a/scripts/tools/run_differential_test.py
+++ b/scripts/tools/run_differential_test.py
@@ -48,9 +48,28 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
+def strip_timing(stdout: bytes) -> bytes:
+    """Remove timing-only lines from validator stdout so the hash
+    reflects semantic output (rule fires, severity, message, count),
+    not wall-clock variability.
+
+    Stripped patterns:
+    - ``# layer=… total_ms=…`` headers
+    - ``# <RULE-ID>\\t<ms>`` per-rule timing comments
+    - Any other ``# `` comment line (defensive: validators_cli emits
+      timing-only comments; semantic output lines don't start with ``#``).
+    """
+    kept = []
+    for line in stdout.splitlines(keepends=True):
+        if line.startswith(b"# "):
+            continue
+        kept.append(line)
+    return b"".join(kept)
+
+
 def emit_validator_output(binary: Path, corpus_dir: Path) -> dict[str, str]:
     """Run [binary] on every .tex under [corpus_dir] and return a
-    {relative_path: sha256_of_stdout} map."""
+    {relative_path: sha256_of_stdout_sans_timing} map."""
     results: dict[str, str] = {}
     for tex in sorted(corpus_dir.rglob("*.tex")):
         try:
@@ -61,7 +80,7 @@ def emit_validator_output(binary: Path, corpus_dir: Path) -> dict[str, str]:
                 timeout=60,
             ).stdout
             rel = tex.relative_to(REPO_ROOT).as_posix()
-            results[rel] = hashlib.sha256(out).hexdigest()
+            results[rel] = hashlib.sha256(strip_timing(out)).hexdigest()
         except subprocess.TimeoutExpired:
             results[tex.relative_to(REPO_ROOT).as_posix()] = "TIMEOUT"
     return results


### PR DESCRIPTION
## Summary

Small post-v26.2.0 follow-up. Surfaced during the v26.2.0 pre-tag audit: the differential-test script hashes validators_cli stdout verbatim, but that output includes per-rule wall-clock timings that vary between runs. Pre-fix behaviour: 330/330 FAIL on v26.1.0 vs v26.2.0 despite semantically-identical output. Post-fix: PASS on all 330 files.

## Fix

Add \`strip_timing()\` to filter out comment lines (\`^# \`) before SHA-256 hashing. \`validators_cli\` emits timings only as \`# rule-id\\t<ms>\` / \`# layer=… total_ms=…\`; semantic rule-fire output never starts with \`#\`. The strip is precise.

Verified locally:

\`\`\`
[differential] PASS: 330 files, 0 diffs between v26.1.0 and HEAD
\`\`\`

## Why post-tag

The fix was discovered while running the HARD-BLOCK gate *before* tagging v26.2.0. Because the underlying validator output is bit-identical, v26.2.0 is correct without this fix — the gate was just measuring the wrong thing. Shipping the fix as a separate PR keeps the v26.2.0 tag unchanged and avoids a retag.

## Test plan

- [x] v26.1.0 vs HEAD diff: PASS (0 files differ).
- [ ] CI.