### PR TITLE
feat(v26.2.1): PR #1 — result.fix field + mk_result helpers

### DIFF
--- a/latex-parse/src/rest_handlers.ml
+++ b/latex-parse/src/rest_handlers.ml
@@ -192,7 +192,7 @@ let handle_tokenize body ~catalogue =
                 ( List.map
                     (fun (r : Latex_parse_lib.Validators.result) ->
                       let open Latex_parse_lib.Validators in
-                      let { id; severity; message; count } = r in
+                      let { id; severity; message; count; _ } = r in
                       (id, `String (severity_to_string severity), message, count))
                     xs,
                   dur,
@@ -353,7 +353,7 @@ let handle_expand body path ~catalogue =
               List.map
                 (fun (r : Latex_parse_lib.Validators.result) ->
                   let open Latex_parse_lib.Validators in
-                  let { id; severity; message; count } = r in
+                  let { id; severity; message; count; _ } = r in
                   (id, `String (severity_to_string severity), message, count))
                 xs
             in

--- a/latex-parse/src/test_chunk_store.ml
+++ b/latex-parse/src/test_chunk_store.ml
@@ -96,12 +96,8 @@ let () =
       expect (Chunk_store.lookup_chunk cache id = None) (tag ^ ": miss");
       Chunk_store.store_chunk cache id
         [
-          {
-            Validators_common.id = "TEST-001";
-            severity = Info;
-            message = "test";
-            count = 1;
-          };
+          Validators_common.mk_result ~id:"TEST-001" ~severity:Info
+            ~message:"test" ~count:1;
         ];
       match Chunk_store.lookup_chunk cache id with
       | Some results ->

--- a/latex-parse/src/test_edf_scheduler.ml
+++ b/latex-parse/src/test_edf_scheduler.ml
@@ -14,12 +14,8 @@ let mk_task ?(layer = 0) ?(chunk = 0L) ?(priority = 0.0)
     work =
       (fun () ->
         [
-          {
-            Validators_common.id = result_id;
-            severity = Info;
-            message = "test";
-            count = 1;
-          };
+          Validators_common.mk_result ~id:result_id ~severity:Info
+            ~message:"test" ~count:1;
         ]);
   }
 

--- a/latex-parse/src/test_evidence_scoring.ml
+++ b/latex-parse/src/test_evidence_scoring.ml
@@ -18,12 +18,9 @@ let () =
 
   (* Test 2: score_result assigns correct confidence by family *)
   let mk_result id =
-    {
-      Latex_parse_lib.Validators_common.id;
-      severity = Latex_parse_lib.Validators_common.Warning;
-      message = "test";
-      count = 1;
-    }
+    Latex_parse_lib.Validators_common.mk_result ~id
+      ~severity:Latex_parse_lib.Validators_common.Warning ~message:"test"
+      ~count:1
   in
   let typo =
     Latex_parse_lib.Evidence_scoring.score_result (mk_result "TYPO-001") []

--- a/latex-parse/src/validators.ml
+++ b/latex-parse/src/validators.ml
@@ -296,15 +296,12 @@ let run_all (src : string) : result list =
        %!"
       (String.length src) max_input_bytes;
     [
-      {
-        id = "SYS-001";
-        severity = Warning;
-        message =
-          Printf.sprintf
-            "Input truncated: %d bytes exceeds %d byte safety limit"
-            (String.length src) max_input_bytes;
-        count = 1;
-      };
+      mk_result ~id:"SYS-001" ~severity:Warning
+        ~message:
+          (Printf.sprintf
+             "Input truncated: %d bytes exceeds %d byte safety limit"
+             (String.length src) max_input_bytes)
+        ~count:1;
     ])
   else
     (* Check cache first (spec W19) *)

--- a/latex-parse/src/validators.mli
+++ b/latex-parse/src/validators.mli
@@ -14,7 +14,25 @@ type result = {
   severity : severity;
   message : string;
   count : int;
+  fix : Cst_edit.t list option;
+      (** Optional fix suggestions. Introduced in v26.2.1. See
+          [Validators_common.mk_result] / [mk_result_with_fix] helpers. *)
 }
+
+val mk_result :
+  id:string -> severity:severity -> message:string -> count:int -> result
+(** Construct a [result] with [fix = None]. Prefer this over raw record literals
+    so that future fields default correctly. *)
+
+val mk_result_with_fix :
+  id:string ->
+  severity:severity ->
+  message:string ->
+  count:int ->
+  fix:Cst_edit.t list ->
+  result
+(** Construct a [result] carrying a non-empty edit list. Raises
+    [Invalid_argument] on an empty [fix] list (use {!mk_result}). *)
 
 type rule = {
   id : string;

--- a/latex-parse/src/validators_common.ml
+++ b/latex-parse/src/validators_common.ml
@@ -9,7 +9,29 @@ type result = {
   severity : severity;
   message : string;
   count : int;
+  fix : Cst_edit.t list option;
+      (** Optional fix suggestions. [None] = no fix available for this firing;
+          [Some []] is ill-formed (use [None]); [Some edits] is a
+          non-overlapping edit set that, when applied via
+          [Rewrite_engine.apply], makes the rule stop firing on the output.
+          Introduced in v26.2.1 to back the [--apply-fixes] CLI flag. See
+          [docs/v26_2/FIX_STYLE_GUIDE.md] for producer conventions. *)
 }
+
+(** Construct a [result] with no fix suggestion ([fix = None]). Every rule
+    introduced before v26.2.1 should use this helper; rules that emit fix
+    suggestions use [mk_result_with_fix] below. *)
+let mk_result ~id ~severity ~message ~count =
+  { id; severity; message; count; fix = None }
+
+(** Construct a [result] that carries a non-empty edit list. Fails if [fix] is
+    the empty list — an empty [Some] is indistinguishable from [None]
+    semantically but harder to audit, so the caller must pass [mk_result ...]
+    when no fix is available. *)
+let mk_result_with_fix ~id ~severity ~message ~count ~fix =
+  if fix = [] then
+    invalid_arg "Validators_common.mk_result_with_fix: empty fix list"
+  else { id; severity; message; count; fix = Some fix }
 
 type rule = {
   id : string;

--- a/latex-parse/src/validators_l0.ml
+++ b/latex-parse/src/validators_l0.ml
@@ -12,12 +12,8 @@ let no_tabs : rule =
     String.iter (fun c -> if c = '\t' then incr cnt) s;
     if !cnt > 0 then
       Some
-        {
-          id = "STRUCT-003";
-          severity = Error;
-          message = "Tab characters found";
-          count = !cnt;
-        }
+        (mk_result ~id:"STRUCT-003" ~severity:Error
+           ~message:"Tab characters found" ~count:!cnt)
     else None
   in
   { id = "STRUCT-003"; run; languages = [] }
@@ -33,12 +29,8 @@ let require_documentclass : rule =
     else if contains_substring s "\\documentclass" then None
     else
       Some
-        {
-          id = "STRUCT-001";
-          severity = Warning;
-          message = "Missing \\documentclass";
-          count = 1;
-        }
+        (mk_result ~id:"STRUCT-001" ~severity:Warning
+           ~message:"Missing \\documentclass" ~count:1)
   in
   { id = "STRUCT-001"; run; languages = [] }
 
@@ -52,12 +44,8 @@ let unmatched_braces : rule =
     done;
     if !bal <> 0 then
       Some
-        {
-          id = "STRUCT-004";
-          severity = Warning;
-          message = "Unmatched braces count";
-          count = abs !bal;
-        }
+        (mk_result ~id:"STRUCT-004" ~severity:Warning
+           ~message:"Unmatched braces count" ~count:(abs !bal))
     else None
   in
   { id = "STRUCT-004"; run; languages = [] }
@@ -74,12 +62,8 @@ let missing_section_title : rule =
     in
     if has_match re_empty || has_match re_missing then
       Some
-        {
-          id = "STRUCT-002";
-          severity = Warning;
-          message = "Empty section title";
-          count = 1;
-        }
+        (mk_result ~id:"STRUCT-002" ~severity:Warning
+           ~message:"Empty section title" ~count:1)
     else None
   in
   { id = "STRUCT-002"; run; languages = [] }
@@ -95,12 +79,8 @@ let r_enc_007 : rule =
     let cnt = count_substring s "\xe2\x80\x8b" in
     if cnt > 0 then
       Some
-        {
-          id = "ENC-007";
-          severity = Warning;
-          message = "Zero‑width space U+200B present";
-          count = cnt;
-        }
+        (mk_result ~id:"ENC-007" ~severity:Warning
+           ~message:"Zero‑width space U+200B present" ~count:cnt)
     else None
   in
   { id = "ENC-007"; run; languages = [] }
@@ -123,12 +103,8 @@ let r_enc_012 : rule =
     done;
     if !cnt > 0 then
       Some
-        {
-          id = "ENC-012";
-          severity = Error;
-          message = "C1 control characters U+0080–009F present";
-          count = !cnt;
-        }
+        (mk_result ~id:"ENC-012" ~severity:Error
+           ~message:"C1 control characters U+0080–009F present" ~count:!cnt)
     else None
   in
   { id = "ENC-012"; run; languages = [] }
@@ -139,12 +115,8 @@ let r_enc_017 : rule =
     let cnt = count_substring s "\xc2\xad" in
     if cnt > 0 then
       Some
-        {
-          id = "ENC-017";
-          severity = Warning;
-          message = "Soft hyphen U+00AD found in source";
-          count = cnt;
-        }
+        (mk_result ~id:"ENC-017" ~severity:Warning
+           ~message:"Soft hyphen U+00AD found in source" ~count:cnt)
     else None
   in
   { id = "ENC-017"; run; languages = [] }
@@ -157,12 +129,8 @@ let r_enc_020 : rule =
     in
     if cnt > 0 then
       Some
-        {
-          id = "ENC-020";
-          severity = Warning;
-          message = "Invisible formatting mark U+200E/U+200F present";
-          count = cnt;
-        }
+        (mk_result ~id:"ENC-020" ~severity:Warning
+           ~message:"Invisible formatting mark U+200E/U+200F present" ~count:cnt)
     else None
   in
   { id = "ENC-020"; run; languages = [] }
@@ -173,12 +141,8 @@ let r_enc_021 : rule =
     let cnt = count_substring s "\xe2\x81\xa0" in
     if cnt > 0 then
       Some
-        {
-          id = "ENC-021";
-          severity = Warning;
-          message = "WORD JOINER U+2060 present";
-          count = cnt;
-        }
+        (mk_result ~id:"ENC-021" ~severity:Warning
+           ~message:"WORD JOINER U+2060 present" ~count:cnt)
     else None
   in
   { id = "ENC-021"; run; languages = [] }
@@ -193,12 +157,9 @@ let r_enc_022 : rule =
     in
     if cnt > 0 then
       Some
-        {
-          id = "ENC-022";
-          severity = Warning;
-          message = "Interlinear annotation chars U+FFF9–FFFB detected";
-          count = cnt;
-        }
+        (mk_result ~id:"ENC-022" ~severity:Warning
+           ~message:"Interlinear annotation chars U+FFF9–FFFB detected"
+           ~count:cnt)
     else None
   in
   { id = "ENC-022"; run; languages = [] }
@@ -209,12 +170,8 @@ let r_enc_023 : rule =
     let cnt = count_substring s "\xe2\x80\xaf" in
     if cnt > 0 then
       Some
-        {
-          id = "ENC-023";
-          severity = Warning;
-          message = "NARROW NB‑SPACE U+202F outside French context";
-          count = cnt;
-        }
+        (mk_result ~id:"ENC-023" ~severity:Warning
+           ~message:"NARROW NB‑SPACE U+202F outside French context" ~count:cnt)
     else None
   in
   { id = "ENC-023"; run; languages = [] }
@@ -231,12 +188,8 @@ let r_enc_024 : rule =
     in
     if cnt > 0 then
       Some
-        {
-          id = "ENC-024";
-          severity = Warning;
-          message = "Bidirectional embeddings U+202A–U+202E present";
-          count = cnt;
-        }
+        (mk_result ~id:"ENC-024" ~severity:Warning
+           ~message:"Bidirectional embeddings U+202A–U+202E present" ~count:cnt)
     else None
   in
   { id = "ENC-024"; run; languages = [] }
@@ -286,12 +239,8 @@ let r_enc_001 : rule =
     done;
     if !cnt > 0 then
       Some
-        {
-          id = "ENC-001";
-          severity = Error;
-          message = "Non‑UTF‑8 byte sequence detected";
-          count = !cnt;
-        }
+        (mk_result ~id:"ENC-001" ~severity:Error
+           ~message:"Non‑UTF‑8 byte sequence detected" ~count:!cnt)
     else None
   in
   { id = "ENC-001"; run; languages = [] }
@@ -305,12 +254,9 @@ let r_enc_002 : rule =
     let interior = if at_start then total - 1 else total in
     if interior > 0 then
       Some
-        {
-          id = "ENC-002";
-          severity = Error;
-          message = "Byte‑order mark U+FEFF present in middle of file";
-          count = interior;
-        }
+        (mk_result ~id:"ENC-002" ~severity:Error
+           ~message:"Byte‑order mark U+FEFF present in middle of file"
+           ~count:interior)
     else None
   in
   { id = "ENC-002"; run; languages = [] }
@@ -337,12 +283,8 @@ let r_enc_003 : rule =
     done;
     if !cnt > 0 then
       Some
-        {
-          id = "ENC-003";
-          severity = Warning;
-          message = "LATIN‑1 smart quotes detected";
-          count = !cnt;
-        }
+        (mk_result ~id:"ENC-003" ~severity:Warning
+           ~message:"LATIN‑1 smart quotes detected" ~count:!cnt)
     else None
   in
   { id = "ENC-003"; run; languages = [] }
@@ -368,12 +310,8 @@ let r_enc_004 : rule =
     done;
     if !cnt > 0 then
       Some
-        {
-          id = "ENC-004";
-          severity = Warning;
-          message = "Windows‑1252 characters (– — …) outside UTF‑8";
-          count = !cnt;
-        }
+        (mk_result ~id:"ENC-004" ~severity:Warning
+           ~message:"Windows‑1252 characters (– — …) outside UTF‑8" ~count:!cnt)
     else None
   in
   { id = "ENC-004"; run; languages = [] }
@@ -396,12 +334,8 @@ let r_enc_013 : rule =
     done;
     if !has_crlf && !has_bare_lf then
       Some
-        {
-          id = "ENC-013";
-          severity = Info;
-          message = "Mixed CRLF and LF line endings";
-          count = 1;
-        }
+        (mk_result ~id:"ENC-013" ~severity:Info
+           ~message:"Mixed CRLF and LF line endings" ~count:1)
     else None
   in
   { id = "ENC-013"; run; languages = [] }
@@ -418,12 +352,8 @@ let r_enc_014 : rule =
       if Char.code s.[0] = 0xFE && Char.code s.[1] = 0xFF then incr cnt);
     if !cnt > 0 then
       Some
-        {
-          id = "ENC-014";
-          severity = Error;
-          message = "UTF‑16 byte‑order mark present";
-          count = !cnt;
-        }
+        (mk_result ~id:"ENC-014" ~severity:Error
+           ~message:"UTF‑16 byte‑order mark present" ~count:!cnt)
     else None
   in
   { id = "ENC-014"; run; languages = [] }
@@ -451,12 +381,8 @@ let r_enc_008 : rule =
     done;
     if !cnt > 0 then
       Some
-        {
-          id = "ENC-008";
-          severity = Warning;
-          message = "Private‑use codepoint detected";
-          count = !cnt;
-        }
+        (mk_result ~id:"ENC-008" ~severity:Warning
+           ~message:"Private‑use codepoint detected" ~count:!cnt)
     else None
   in
   { id = "ENC-008"; run; languages = [] }
@@ -480,12 +406,8 @@ let r_enc_009 : rule =
     done;
     if !cnt > 0 then
       Some
-        {
-          id = "ENC-009";
-          severity = Error;
-          message = "Unpaired surrogate code unit";
-          count = !cnt;
-        }
+        (mk_result ~id:"ENC-009" ~severity:Error
+           ~message:"Unpaired surrogate code unit" ~count:!cnt)
     else None
   in
   { id = "ENC-009"; run; languages = [] }
@@ -520,12 +442,8 @@ let r_enc_010 : rule =
     done;
     if !cnt > 0 then
       Some
-        {
-          id = "ENC-010";
-          severity = Info;
-          message = "Non‑canonical NFC form";
-          count = !cnt;
-        }
+        (mk_result ~id:"ENC-010" ~severity:Info
+           ~message:"Non‑canonical NFC form" ~count:!cnt)
     else None
   in
   { id = "ENC-010"; run; languages = [] }
@@ -566,12 +484,8 @@ let r_enc_011 : rule =
     done;
     if !cnt > 0 then
       Some
-        {
-          id = "ENC-011";
-          severity = Warning;
-          message = "Byte sequence resembles MacRoman encoding";
-          count = !cnt;
-        }
+        (mk_result ~id:"ENC-011" ~severity:Warning
+           ~message:"Byte sequence resembles MacRoman encoding" ~count:!cnt)
     else None
   in
   { id = "ENC-011"; run; languages = [] }
@@ -596,12 +510,8 @@ let r_enc_015 : rule =
     let cnt = cnt_micro + cnt_ohm + cnt_angstrom + cnt_long_s in
     if cnt > 0 then
       Some
-        {
-          id = "ENC-015";
-          severity = Warning;
-          message = "Non‑NFKC homoglyph character (Greek μ vs µ)";
-          count = cnt;
-        }
+        (mk_result ~id:"ENC-015" ~severity:Warning
+           ~message:"Non‑NFKC homoglyph character (Greek μ vs µ)" ~count:cnt)
     else None
   in
   { id = "ENC-015"; run; languages = [] }
@@ -624,12 +534,9 @@ let r_enc_016 : rule =
     done;
     if !cnt > 0 then
       Some
-        {
-          id = "ENC-016";
-          severity = Warning;
-          message = "Arabic numerals replaced by Unicode look‑alikes";
-          count = !cnt;
-        }
+        (mk_result ~id:"ENC-016" ~severity:Warning
+           ~message:"Arabic numerals replaced by Unicode look‑alikes"
+           ~count:!cnt)
     else None
   in
   { id = "ENC-016"; run; languages = [] }
@@ -690,12 +597,8 @@ let r_enc_005 : rule =
     done;
     if !cnt > 0 then
       Some
-        {
-          id = "ENC-005";
-          severity = Error;
-          message = "Invalid UTF‑8 continuation byte";
-          count = !cnt;
-        }
+        (mk_result ~id:"ENC-005" ~severity:Error
+           ~message:"Invalid UTF‑8 continuation byte" ~count:!cnt)
     else None
   in
   { id = "ENC-005"; run; languages = [] }
@@ -730,12 +633,8 @@ let r_enc_006 : rule =
     done;
     if !cnt > 0 then
       Some
-        {
-          id = "ENC-006";
-          severity = Error;
-          message = "Overlong UTF‑8 encoding sequence";
-          count = !cnt;
-        }
+        (mk_result ~id:"ENC-006" ~severity:Error
+           ~message:"Overlong UTF‑8 encoding sequence" ~count:!cnt)
     else None
   in
   { id = "ENC-006"; run; languages = [] }
@@ -767,12 +666,9 @@ let r_enc_018 : rule =
     done;
     if !cnt > 0 then
       Some
-        {
-          id = "ENC-018";
-          severity = Info;
-          message = "Non‑breaking hyphen U+2011 present outside URLs";
-          count = !cnt;
-        }
+        (mk_result ~id:"ENC-018" ~severity:Info
+           ~message:"Non‑breaking hyphen U+2011 present outside URLs"
+           ~count:!cnt)
     else None
   in
   { id = "ENC-018"; run; languages = [] }
@@ -826,12 +722,8 @@ let r_enc_019 : rule =
     done;
     if !cnt > 0 then
       Some
-        {
-          id = "ENC-019";
-          severity = Warning;
-          message = "Duplicate combining accents on same base glyph";
-          count = !cnt;
-        }
+        (mk_result ~id:"ENC-019" ~severity:Warning
+           ~message:"Duplicate combining accents on same base glyph" ~count:!cnt)
     else None
   in
   { id = "ENC-019"; run; languages = [] }
@@ -887,12 +779,8 @@ let r_char_005 : rule =
     done;
     if !cnt > 0 then
       Some
-        {
-          id = "CHAR-005";
-          severity = Error;
-          message = "Control characters U+0000–001F present";
-          count = !cnt;
-        }
+        (mk_result ~id:"CHAR-005" ~severity:Error
+           ~message:"Control characters U+0000–001F present" ~count:!cnt)
     else None
   in
   { id = "CHAR-005"; run; languages = [] }
@@ -903,12 +791,8 @@ let r_char_006 : rule =
     let cnt = count_char s '\x08' in
     if cnt > 0 then
       Some
-        {
-          id = "CHAR-006";
-          severity = Error;
-          message = "Backspace U+0008 present";
-          count = cnt;
-        }
+        (mk_result ~id:"CHAR-006" ~severity:Error
+           ~message:"Backspace U+0008 present" ~count:cnt)
     else None
   in
   { id = "CHAR-006"; run; languages = [] }
@@ -919,12 +803,8 @@ let r_char_007 : rule =
     let cnt = count_char s '\x07' in
     if cnt > 0 then
       Some
-        {
-          id = "CHAR-007";
-          severity = Error;
-          message = "Bell/alert U+0007 present";
-          count = cnt;
-        }
+        (mk_result ~id:"CHAR-007" ~severity:Error
+           ~message:"Bell/alert U+0007 present" ~count:cnt)
     else None
   in
   { id = "CHAR-007"; run; languages = [] }
@@ -935,12 +815,8 @@ let r_char_008 : rule =
     let cnt = count_char s '\x0c' in
     if cnt > 0 then
       Some
-        {
-          id = "CHAR-008";
-          severity = Warning;
-          message = "Form feed U+000C present";
-          count = cnt;
-        }
+        (mk_result ~id:"CHAR-008" ~severity:Warning
+           ~message:"Form feed U+000C present" ~count:cnt)
     else None
   in
   { id = "CHAR-008"; run; languages = [] }
@@ -951,12 +827,8 @@ let r_char_009 : rule =
     let cnt = count_char s '\x7f' in
     if cnt > 0 then
       Some
-        {
-          id = "CHAR-009";
-          severity = Warning;
-          message = "Delete U+007F present";
-          count = cnt;
-        }
+        (mk_result ~id:"CHAR-009" ~severity:Warning
+           ~message:"Delete U+007F present" ~count:cnt)
     else None
   in
   { id = "CHAR-009"; run; languages = [] }
@@ -972,12 +844,9 @@ let r_char_013 : rule =
     in
     if cnt > 0 then
       Some
-        {
-          id = "CHAR-013";
-          severity = Warning;
-          message = "Bidirectional isolate chars U+2066–U+2069 present";
-          count = cnt;
-        }
+        (mk_result ~id:"CHAR-013" ~severity:Warning
+           ~message:"Bidirectional isolate chars U+2066–U+2069 present"
+           ~count:cnt)
     else None
   in
   { id = "CHAR-013"; run; languages = [] }
@@ -988,12 +857,8 @@ let r_char_014 : rule =
     let cnt = count_substring s "\xef\xbf\xbd" in
     if cnt > 0 then
       Some
-        {
-          id = "CHAR-014";
-          severity = Warning;
-          message = "Unicode replacement � found – decoding error";
-          count = cnt;
-        }
+        (mk_result ~id:"CHAR-014" ~severity:Warning
+           ~message:"Unicode replacement � found – decoding error" ~count:cnt)
     else None
   in
   { id = "CHAR-014"; run; languages = [] }
@@ -1008,12 +873,9 @@ let r_char_021 : rule =
     let cnt = if starts_with_bom then total - 1 else total in
     if cnt > 0 then
       Some
-        {
-          id = "CHAR-021";
-          severity = Error;
-          message = "Zero‑width no‑break space U+FEFF inside paragraph";
-          count = cnt;
-        }
+        (mk_result ~id:"CHAR-021" ~severity:Error
+           ~message:"Zero‑width no‑break space U+FEFF inside paragraph"
+           ~count:cnt)
     else None
   in
   { id = "CHAR-021"; run; languages = [] }
@@ -1038,12 +900,8 @@ let r_char_015 : rule =
     done;
     if !cnt > 0 then
       Some
-        {
-          id = "CHAR-015";
-          severity = Info;
-          message = "Emoji detected in source";
-          count = !cnt;
-        }
+        (mk_result ~id:"CHAR-015" ~severity:Info
+           ~message:"Emoji detected in source" ~count:!cnt)
     else None
   in
   { id = "CHAR-015"; run; languages = [] }
@@ -1071,12 +929,8 @@ let r_char_017 : rule =
     done;
     if !cnt > 0 then
       Some
-        {
-          id = "CHAR-017";
-          severity = Warning;
-          message = "Full‑width Latin letters detected";
-          count = !cnt;
-        }
+        (mk_result ~id:"CHAR-017" ~severity:Warning
+           ~message:"Full‑width Latin letters detected" ~count:!cnt)
     else None
   in
   { id = "CHAR-017"; run; languages = [] }
@@ -1094,12 +948,8 @@ let r_char_018 : rule =
     in
     if cnt > 0 then
       Some
-        {
-          id = "CHAR-018";
-          severity = Info;
-          message = "Deprecated ligature ﬀ/ﬁ/ﬂ characters present";
-          count = cnt;
-        }
+        (mk_result ~id:"CHAR-018" ~severity:Info
+           ~message:"Deprecated ligature ﬀ/ﬁ/ﬂ characters present" ~count:cnt)
     else None
   in
   { id = "CHAR-018"; run; languages = [] }
@@ -1123,12 +973,9 @@ let r_char_022 : rule =
     done;
     if !cnt > 0 then
       Some
-        {
-          id = "CHAR-022";
-          severity = Warning;
-          message = "Deprecated tag characters U+E0000–E007F present";
-          count = !cnt;
-        }
+        (mk_result ~id:"CHAR-022" ~severity:Warning
+           ~message:"Deprecated tag characters U+E0000–E007F present"
+           ~count:!cnt)
     else None
   in
   { id = "CHAR-022"; run; languages = [] }
@@ -1151,12 +998,8 @@ let r_char_016 : rule =
     in
     if cnt > 0 then
       Some
-        {
-          id = "CHAR-016";
-          severity = Warning;
-          message = "Double‑width CJK punctuation in ASCII context";
-          count = cnt;
-        }
+        (mk_result ~id:"CHAR-016" ~severity:Warning
+           ~message:"Double‑width CJK punctuation in ASCII context" ~count:cnt)
     else None
   in
   { id = "CHAR-016"; run; languages = [] }
@@ -1168,12 +1011,8 @@ let r_char_019 : rule =
     let cnt = count_substring s "\xe2\x88\x92" in
     if cnt > 0 then
       Some
-        {
-          id = "CHAR-019";
-          severity = Info;
-          message = "Unicode minus U+2212 in text mode";
-          count = cnt;
-        }
+        (mk_result ~id:"CHAR-019" ~severity:Info
+           ~message:"Unicode minus U+2212 in text mode" ~count:cnt)
     else None
   in
   { id = "CHAR-019"; run; languages = [] }
@@ -1206,12 +1045,8 @@ let r_char_020 : rule =
     done;
     if !cnt > 0 then
       Some
-        {
-          id = "CHAR-020";
-          severity = Info;
-          message = "Sharp S ß in uppercase context – suggest SS";
-          count = !cnt;
-        }
+        (mk_result ~id:"CHAR-020" ~severity:Info
+           ~message:"Sharp S ß in uppercase context – suggest SS" ~count:!cnt)
     else None
   in
   { id = "CHAR-020"; run; languages = [] }
@@ -1235,12 +1070,8 @@ let r_char_010 : rule =
     done;
     if !cnt > 0 then
       Some
-        {
-          id = "CHAR-010";
-          severity = Info;
-          message = "Right‑to‑left mark U+200F outside RTL context";
-          count = !cnt;
-        }
+        (mk_result ~id:"CHAR-010" ~severity:Info
+           ~message:"Right‑to‑left mark U+200F outside RTL context" ~count:!cnt)
     else None
   in
   { id = "CHAR-010"; run; languages = [] }
@@ -1264,12 +1095,8 @@ let r_char_011 : rule =
     done;
     if !cnt > 0 then
       Some
-        {
-          id = "CHAR-011";
-          severity = Info;
-          message = "Left‑to‑right mark U+200E unnecessary";
-          count = !cnt;
-        }
+        (mk_result ~id:"CHAR-011" ~severity:Info
+           ~message:"Left‑to‑right mark U+200E unnecessary" ~count:!cnt)
     else None
   in
   { id = "CHAR-011"; run; languages = [] }
@@ -1293,12 +1120,9 @@ let r_char_012 : rule =
     done;
     if !cnt > 0 then
       Some
-        {
-          id = "CHAR-012";
-          severity = Info;
-          message = "Zero‑width joiner U+200D outside ligature context";
-          count = !cnt;
-        }
+        (mk_result ~id:"CHAR-012" ~severity:Info
+           ~message:"Zero‑width joiner U+200D outside ligature context"
+           ~count:!cnt)
     else None
   in
   { id = "CHAR-012"; run; languages = [] }
@@ -1333,12 +1157,8 @@ let r_spc_001 : rule =
     let _, matched = any_line_pred s (fun line -> String.length line > 120) in
     if matched > 0 then
       Some
-        {
-          id = "SPC-001";
-          severity = Info;
-          message = "Line longer than 120 characters";
-          count = matched;
-        }
+        (mk_result ~id:"SPC-001" ~severity:Info
+           ~message:"Line longer than 120 characters" ~count:matched)
     else None
   in
   { id = "SPC-001"; run; languages = [] }
@@ -1360,12 +1180,8 @@ let r_spc_002 : rule =
     let _, matched = any_line_pred s is_ws_only in
     if matched > 0 then
       Some
-        {
-          id = "SPC-002";
-          severity = Info;
-          message = "Line containing only whitespace";
-          count = matched;
-        }
+        (mk_result ~id:"SPC-002" ~severity:Info
+           ~message:"Line containing only whitespace" ~count:matched)
     else None
   in
   { id = "SPC-002"; run; languages = [] }
@@ -1387,12 +1203,9 @@ let r_spc_003 : rule =
     let _, matched = any_line_pred s is_mixed_indent in
     if matched > 0 then
       Some
-        {
-          id = "SPC-003";
-          severity = Warning;
-          message = "Hard tab precedes non‑tab text (mixed indent)";
-          count = matched;
-        }
+        (mk_result ~id:"SPC-003" ~severity:Warning
+           ~message:"Hard tab precedes non‑tab text (mixed indent)"
+           ~count:matched)
     else None
   in
   { id = "SPC-003"; run; languages = [] }
@@ -1408,12 +1221,8 @@ let r_spc_004 : rule =
     done;
     if !cnt > 0 then
       Some
-        {
-          id = "SPC-004";
-          severity = Warning;
-          message = "Carriage return U+000D without LF";
-          count = !cnt;
-        }
+        (mk_result ~id:"SPC-004" ~severity:Warning
+           ~message:"Carriage return U+000D without LF" ~count:!cnt)
     else None
   in
   { id = "SPC-004"; run; languages = [] }
@@ -1428,12 +1237,8 @@ let r_spc_005 : rule =
     let _, matched = any_line_pred s ends_with_tab in
     if matched > 0 then
       Some
-        {
-          id = "SPC-005";
-          severity = Info;
-          message = "Trailing tab at end of line";
-          count = matched;
-        }
+        (mk_result ~id:"SPC-005" ~severity:Info
+           ~message:"Trailing tab at end of line" ~count:matched)
     else None
   in
   { id = "SPC-005"; run; languages = [] }
@@ -1458,12 +1263,8 @@ let r_spc_006 : rule =
     let _, matched = any_line_pred s has_mixed_indent in
     if matched > 0 then
       Some
-        {
-          id = "SPC-006";
-          severity = Info;
-          message = "Indentation mixes spaces and tabs";
-          count = matched;
-        }
+        (mk_result ~id:"SPC-006" ~severity:Info
+           ~message:"Indentation mixes spaces and tabs" ~count:matched)
     else None
   in
   { id = "SPC-006"; run; languages = [] }
@@ -1477,12 +1278,8 @@ let r_spc_012 : rule =
     let interior = if at_start then total - 1 else total in
     if interior > 0 then
       Some
-        {
-          id = "SPC-012";
-          severity = Error;
-          message = "BOM not at file start";
-          count = interior;
-        }
+        (mk_result ~id:"SPC-012" ~severity:Error
+           ~message:"BOM not at file start" ~count:interior)
     else None
   in
   { id = "SPC-012"; run; languages = [] }
@@ -1503,12 +1300,8 @@ let r_spc_024 : rule =
     let _, matched = any_line_pred s is_spaces_only_blank in
     if matched > 0 then
       Some
-        {
-          id = "SPC-024";
-          severity = Info;
-          message = "Leading spaces on blank line";
-          count = matched;
-        }
+        (mk_result ~id:"SPC-024" ~severity:Info
+           ~message:"Leading spaces on blank line" ~count:matched)
     else None
   in
   { id = "SPC-024"; run; languages = [] }
@@ -1519,12 +1312,8 @@ let r_spc_028 : rule =
     let cnt = count_substring s "~~" in
     if cnt > 0 then
       Some
-        {
-          id = "SPC-028";
-          severity = Warning;
-          message = "Multiple consecutive ~ NBSPs";
-          count = cnt;
-        }
+        (mk_result ~id:"SPC-028" ~severity:Warning
+           ~message:"Multiple consecutive ~ NBSPs" ~count:cnt)
     else None
   in
   { id = "SPC-028"; run; languages = [] }
@@ -1547,12 +1336,8 @@ let r_spc_007 : rule =
     done;
     if !cnt > 0 then
       Some
-        {
-          id = "SPC-007";
-          severity = Info;
-          message = "Three or more consecutive blank lines";
-          count = !cnt;
-        }
+        (mk_result ~id:"SPC-007" ~severity:Info
+           ~message:"Three or more consecutive blank lines" ~count:!cnt)
     else None
   in
   { id = "SPC-007"; run; languages = [] }
@@ -1582,12 +1367,8 @@ let r_spc_008 : rule =
       lines;
     if !cnt > 0 then
       Some
-        {
-          id = "SPC-008";
-          severity = Info;
-          message = "Paragraph starts with whitespace";
-          count = !cnt;
-        }
+        (mk_result ~id:"SPC-008" ~severity:Info
+           ~message:"Paragraph starts with whitespace" ~count:!cnt)
     else None
   in
   { id = "SPC-008"; run; languages = [] }
@@ -1605,12 +1386,8 @@ let r_spc_009 : rule =
     in
     if matched > 0 then
       Some
-        {
-          id = "SPC-009";
-          severity = Warning;
-          message = "Non‑breaking space ~ at line start";
-          count = matched;
-        }
+        (mk_result ~id:"SPC-009" ~severity:Warning
+           ~message:"Non‑breaking space ~ at line start" ~count:matched)
     else None
   in
   { id = "SPC-009"; run; languages = [] }
@@ -1651,12 +1428,8 @@ let r_spc_013 : rule =
     flush ();
     if !cnt > 0 then
       Some
-        {
-          id = "SPC-013";
-          severity = Info;
-          message = "Whitespace‑only paragraph";
-          count = !cnt;
-        }
+        (mk_result ~id:"SPC-013" ~severity:Info
+           ~message:"Whitespace‑only paragraph" ~count:!cnt)
     else None
   in
   { id = "SPC-013"; run; languages = [] }
@@ -1679,12 +1452,8 @@ let r_spc_014 : rule =
     done;
     if !has_crlf && !has_bare_lf then
       Some
-        {
-          id = "SPC-014";
-          severity = Info;
-          message = "Mixed LF and CRLF within paragraph";
-          count = 1;
-        }
+        (mk_result ~id:"SPC-014" ~severity:Info
+           ~message:"Mixed LF and CRLF within paragraph" ~count:1)
     else None
   in
   { id = "SPC-014"; run; languages = [] }
@@ -1703,12 +1472,8 @@ let r_spc_015 : rule =
     let _, matched = any_line_pred s deep_indent in
     if matched > 0 then
       Some
-        {
-          id = "SPC-015";
-          severity = Info;
-          message = "Indentation exceeds 8 spaces";
-          count = matched;
-        }
+        (mk_result ~id:"SPC-015" ~severity:Info
+           ~message:"Indentation exceeds 8 spaces" ~count:matched)
     else None
   in
   { id = "SPC-015"; run; languages = [] }
@@ -1720,12 +1485,8 @@ let r_spc_016 : rule =
     let cnt = count_substring s " ;" in
     if cnt > 0 then
       Some
-        {
-          id = "SPC-016";
-          severity = Warning;
-          message = "Space before semicolon";
-          count = cnt;
-        }
+        (mk_result ~id:"SPC-016" ~severity:Warning
+           ~message:"Space before semicolon" ~count:cnt)
     else None
   in
   { id = "SPC-016"; run; languages = [] }
@@ -1752,12 +1513,8 @@ let r_spc_017 : rule =
      with Not_found -> ());
     if !cnt > 0 then
       Some
-        {
-          id = "SPC-017";
-          severity = Info;
-          message = "Missing thin space before units (e.g. 5 cm)";
-          count = !cnt;
-        }
+        (mk_result ~id:"SPC-017" ~severity:Info
+           ~message:"Missing thin space before units (e.g. 5 cm)" ~count:!cnt)
     else None
   in
   { id = "SPC-017"; run; languages = [] }
@@ -1775,12 +1532,9 @@ let r_spc_019 : rule =
     let _, matched = any_line_pred s trailing_fw_space in
     if matched > 0 then
       Some
-        {
-          id = "SPC-019";
-          severity = Warning;
-          message = "Trailing full‑width space U+3000 at line end";
-          count = matched;
-        }
+        (mk_result ~id:"SPC-019" ~severity:Warning
+           ~message:"Trailing full‑width space U+3000 at line end"
+           ~count:matched)
     else None
   in
   { id = "SPC-019"; run; languages = [] }
@@ -1792,12 +1546,8 @@ let r_spc_021 : rule =
     let cnt = count_substring s " :" in
     if cnt > 0 then
       Some
-        {
-          id = "SPC-021";
-          severity = Warning;
-          message = "Space before colon";
-          count = cnt;
-        }
+        (mk_result ~id:"SPC-021" ~severity:Warning ~message:"Space before colon"
+           ~count:cnt)
     else None
   in
   { id = "SPC-021"; run; languages = [] }
@@ -1808,12 +1558,8 @@ let r_spc_025 : rule =
     let cnt = count_substring s " \\dots" + count_substring s " \xe2\x80\xa6" in
     if cnt > 0 then
       Some
-        {
-          id = "SPC-025";
-          severity = Info;
-          message = {|Space before ellipsis \dots|};
-          count = cnt;
-        }
+        (mk_result ~id:"SPC-025" ~severity:Info
+           ~message:{|Space before ellipsis \dots|} ~count:cnt)
     else None
   in
   { id = "SPC-025"; run; languages = [] }
@@ -1857,12 +1603,8 @@ let r_spc_026 : rule =
       envs;
     if !cnt > 0 then
       Some
-        {
-          id = "SPC-026";
-          severity = Info;
-          message = "Mixed indentation width at same list depth";
-          count = !cnt;
-        }
+        (mk_result ~id:"SPC-026" ~severity:Info
+           ~message:"Mixed indentation width at same list depth" ~count:!cnt)
     else None
   in
   { id = "SPC-026"; run; languages = [] }
@@ -1878,12 +1620,8 @@ let r_spc_029 : rule =
     let _, matched = any_line_pred s nbsp_indent in
     if matched > 0 then
       Some
-        {
-          id = "SPC-029";
-          severity = Warning;
-          message = "Indentation uses NBSP characters";
-          count = matched;
-        }
+        (mk_result ~id:"SPC-029" ~severity:Warning
+           ~message:"Indentation uses NBSP characters" ~count:matched)
     else None
   in
   { id = "SPC-029"; run; languages = [] }
@@ -1900,12 +1638,8 @@ let r_spc_030 : rule =
     let _, matched = any_line_pred s fw_space_start in
     if matched > 0 then
       Some
-        {
-          id = "SPC-030";
-          severity = Warning;
-          message = "Line starts with full‑width space U+3000";
-          count = matched;
-        }
+        (mk_result ~id:"SPC-030" ~severity:Warning
+           ~message:"Line starts with full‑width space U+3000" ~count:matched)
     else None
   in
   { id = "SPC-030"; run; languages = [] }
@@ -1917,12 +1651,8 @@ let r_spc_031 : rule =
     let cnt = count_substring s ".   " in
     if cnt > 0 then
       Some
-        {
-          id = "SPC-031";
-          severity = Info;
-          message = "Three spaces after period";
-          count = cnt;
-        }
+        (mk_result ~id:"SPC-031" ~severity:Info
+           ~message:"Three spaces after period" ~count:cnt)
     else None
   in
   { id = "SPC-031"; run; languages = [] }
@@ -1954,12 +1684,9 @@ let r_spc_032 : rule =
     let _, matched = any_line_pred s mixed_nbsp_indent in
     if matched > 0 then
       Some
-        {
-          id = "SPC-032";
-          severity = Info;
-          message = "Paragraph indented with mix of NBSP and space";
-          count = matched;
-        }
+        (mk_result ~id:"SPC-032" ~severity:Info
+           ~message:"Paragraph indented with mix of NBSP and space"
+           ~count:matched)
     else None
   in
   { id = "SPC-032"; run; languages = [] }
@@ -1973,12 +1700,9 @@ let r_spc_033 : rule =
     in
     if cnt > 0 then
       Some
-        {
-          id = "SPC-033";
-          severity = Info;
-          message = "No‑break space before em‑dash in English text forbidden";
-          count = cnt;
-        }
+        (mk_result ~id:"SPC-033" ~severity:Info
+           ~message:"No‑break space before em‑dash in English text forbidden"
+           ~count:cnt)
     else None
   in
   { id = "SPC-033"; run; languages = [] }
@@ -1993,12 +1717,9 @@ let r_spc_034 : rule =
     in
     if cnt > 0 then
       Some
-        {
-          id = "SPC-034";
-          severity = Info;
-          message = "Thin‑space before en‑dash in command‑line flags removed";
-          count = cnt;
-        }
+        (mk_result ~id:"SPC-034" ~severity:Info
+           ~message:"Thin‑space before en‑dash in command‑line flags removed"
+           ~count:cnt)
     else None
   in
   { id = "SPC-034"; run; languages = [] }
@@ -2015,12 +1736,8 @@ let r_spc_035 : rule =
     let _, matched = any_line_pred s thin_space_start in
     if matched > 0 then
       Some
-        {
-          id = "SPC-035";
-          severity = Info;
-          message = "Leading thin‑space U+2009 at start of line";
-          count = matched;
-        }
+        (mk_result ~id:"SPC-035" ~severity:Info
+           ~message:"Leading thin‑space U+2009 at start of line" ~count:matched)
     else None
   in
   { id = "SPC-035"; run; languages = [] }
@@ -2044,12 +1761,8 @@ let r_spc_010 : rule =
     let cnt = loop 0 0 in
     if cnt > 0 then
       Some
-        {
-          id = "SPC-010";
-          severity = Info;
-          message = "Sentence spacing uses two spaces after period";
-          count = cnt;
-        }
+        (mk_result ~id:"SPC-010" ~severity:Info
+           ~message:"Sentence spacing uses two spaces after period" ~count:cnt)
     else None
   in
   { id = "SPC-010"; run; languages = [] }
@@ -2069,12 +1782,8 @@ let r_spc_018 : rule =
     let cnt = loop 0 0 in
     if cnt > 0 then
       Some
-        {
-          id = "SPC-018";
-          severity = Info;
-          message = "No space after sentence‑ending period";
-          count = cnt;
-        }
+        (mk_result ~id:"SPC-018" ~severity:Info
+           ~message:"No space after sentence‑ending period" ~count:cnt)
     else None
   in
   { id = "SPC-018"; run; languages = [] }
@@ -2085,12 +1794,8 @@ let r_spc_022 : rule =
     let cnt = count_substring s "\\item\t" in
     if cnt > 0 then
       Some
-        {
-          id = "SPC-022";
-          severity = Info;
-          message = "Tab after bullet in \\itemize";
-          count = cnt;
-        }
+        (mk_result ~id:"SPC-022" ~severity:Info
+           ~message:"Tab after bullet in \\itemize" ~count:cnt)
     else None
   in
   { id = "SPC-022"; run; languages = [] }
@@ -2116,12 +1821,8 @@ let r_spc_027 : rule =
     let cnt = loop 0 0 in
     if cnt > 0 then
       Some
-        {
-          id = "SPC-027";
-          severity = Warning;
-          message = "Trailing whitespace inside \\url{}";
-          count = cnt;
-        }
+        (mk_result ~id:"SPC-027" ~severity:Warning
+           ~message:"Trailing whitespace inside \\url{}" ~count:cnt)
     else None
   in
   { id = "SPC-027"; run; languages = [] }
@@ -2146,12 +1847,8 @@ let r_spc_011 : rule =
     done;
     if !cnt > 0 then
       Some
-        {
-          id = "SPC-011";
-          severity = Warning;
-          message = "Space before newline inside $$…$$ display";
-          count = !cnt;
-        }
+        (mk_result ~id:"SPC-011" ~severity:Warning
+           ~message:"Space before newline inside $$…$$ display" ~count:!cnt)
     else None
   in
   { id = "SPC-011"; run; languages = [] }
@@ -2178,12 +1875,8 @@ let r_spc_020 : rule =
     done;
     if !cnt > 0 then
       Some
-        {
-          id = "SPC-020";
-          severity = Warning;
-          message = "Tab character inside math mode";
-          count = !cnt;
-        }
+        (mk_result ~id:"SPC-020" ~severity:Warning
+           ~message:"Tab character inside math mode" ~count:!cnt)
     else None
   in
   { id = "SPC-020"; run; languages = [] }
@@ -2230,12 +1923,9 @@ let r_spc_023 : rule =
     done;
     if !cnt > 0 then
       Some
-        {
-          id = "SPC-023";
-          severity = Info;
-          message = "Hard space U+00A0 outside French punctuation context";
-          count = !cnt;
-        }
+        (mk_result ~id:"SPC-023" ~severity:Info
+           ~message:"Hard space U+00A0 outside French punctuation context"
+           ~count:!cnt)
     else None
   in
   { id = "SPC-023"; run; languages = [] }
@@ -2328,12 +2018,9 @@ let r_verb_001 : rule =
     done;
     if !cnt > 0 then
       Some
-        {
-          id = "VERB-001";
-          severity = Error;
-          message = "\\verb delimiter reused inside same \\verb block";
-          count = !cnt;
-        }
+        (mk_result ~id:"VERB-001" ~severity:Error
+           ~message:"\\verb delimiter reused inside same \\verb block"
+           ~count:!cnt)
     else None
   in
   { id = "VERB-001"; run; languages = [] }
@@ -2352,12 +2039,8 @@ let r_verb_002 : rule =
       envs;
     if !cnt > 0 then
       Some
-        {
-          id = "VERB-002";
-          severity = Info;
-          message = "Tab inside verbatim – discouraged";
-          count = !cnt;
-        }
+        (mk_result ~id:"VERB-002" ~severity:Info
+           ~message:"Tab inside verbatim – discouraged" ~count:!cnt)
     else None
   in
   { id = "VERB-002"; run; languages = [] }
@@ -2383,12 +2066,8 @@ let r_verb_003 : rule =
       envs;
     if !cnt > 0 then
       Some
-        {
-          id = "VERB-003";
-          severity = Info;
-          message = "Trailing spaces inside verbatim";
-          count = !cnt;
-        }
+        (mk_result ~id:"VERB-003" ~severity:Info
+           ~message:"Trailing spaces inside verbatim" ~count:!cnt)
     else None
   in
   { id = "VERB-003"; run; languages = [] }
@@ -2420,12 +2099,8 @@ let r_verb_004 : rule =
       envs;
     if !cnt > 0 then
       Some
-        {
-          id = "VERB-004";
-          severity = Warning;
-          message = "Non‑ASCII quotes inside verbatim";
-          count = !cnt;
-        }
+        (mk_result ~id:"VERB-004" ~severity:Warning
+           ~message:"Non‑ASCII quotes inside verbatim" ~count:!cnt)
     else None
   in
   { id = "VERB-004"; run; languages = [] }
@@ -2448,12 +2123,8 @@ let r_verb_005 : rule =
       envs;
     if !cnt > 0 then
       Some
-        {
-          id = "VERB-005";
-          severity = Info;
-          message = "Verbatim line > 120 characters";
-          count = !cnt;
-        }
+        (mk_result ~id:"VERB-005" ~severity:Info
+           ~message:"Verbatim line > 120 characters" ~count:!cnt)
     else None
   in
   { id = "VERB-005"; run; languages = [] }
@@ -2497,12 +2168,8 @@ let r_verb_006 : rule =
     done;
     if !cnt > 0 then
       Some
-        {
-          id = "VERB-006";
-          severity = Error;
-          message = "Inline \\verb used for multiline content";
-          count = !cnt;
-        }
+        (mk_result ~id:"VERB-006" ~severity:Error
+           ~message:"Inline \\verb used for multiline content" ~count:!cnt)
     else None
   in
   { id = "VERB-006"; run; languages = [] }
@@ -2534,12 +2201,8 @@ let r_verb_007 : rule =
       envs;
     if !cnt > 0 then
       Some
-        {
-          id = "VERB-007";
-          severity = Error;
-          message = "Nested verbatim environment";
-          count = !cnt;
-        }
+        (mk_result ~id:"VERB-007" ~severity:Error
+           ~message:"Nested verbatim environment" ~count:!cnt)
     else None
   in
   { id = "VERB-007"; run; languages = [] }
@@ -2559,12 +2222,8 @@ let r_verb_008 : rule =
      with Not_found -> ());
     if !cnt > 0 then
       Some
-        {
-          id = "VERB-008";
-          severity = Info;
-          message = "`lstlisting` uses language=none";
-          count = !cnt;
-        }
+        (mk_result ~id:"VERB-008" ~severity:Info
+           ~message:"`lstlisting` uses language=none" ~count:!cnt)
     else None
   in
   { id = "VERB-008"; run; languages = [] }
@@ -2597,12 +2256,8 @@ let r_verb_009 : rule =
     let cnt = !cnt in
     if cnt > 0 then
       Some
-        {
-          id = "VERB-009";
-          severity = Warning;
-          message = "Missing caption in `minted` code block";
-          count = cnt;
-        }
+        (mk_result ~id:"VERB-009" ~severity:Warning
+           ~message:"Missing caption in `minted` code block" ~count:cnt)
     else None
   in
   { id = "VERB-009"; run; languages = [] }
@@ -2623,12 +2278,8 @@ let r_verb_010 : rule =
      with Not_found -> ());
     if !cnt > 0 then
       Some
-        {
-          id = "VERB-010";
-          severity = Info;
-          message = {|Inline code uses back‑ticks instead of \verb|};
-          count = !cnt;
-        }
+        (mk_result ~id:"VERB-010" ~severity:Info
+           ~message:{|Inline code uses back‑ticks instead of \verb|} ~count:!cnt)
     else None
   in
   { id = "VERB-010"; run; languages = [] }
@@ -2766,12 +2417,8 @@ let r_verb_011 : rule =
      with Not_found -> ());
     if !cnt > 0 then
       Some
-        {
-          id = "VERB-011";
-          severity = Warning;
-          message = "Unknown `lstlisting` language";
-          count = !cnt;
-        }
+        (mk_result ~id:"VERB-011" ~severity:Warning
+           ~message:"Unknown `lstlisting` language" ~count:!cnt)
     else None
   in
   { id = "VERB-011"; run; languages = [] }
@@ -2803,12 +2450,8 @@ let r_verb_012 : rule =
      with Not_found -> ());
     if !cnt > 0 then
       Some
-        {
-          id = "VERB-012";
-          severity = Info;
-          message = "`minted` block missing autogobble";
-          count = !cnt;
-        }
+        (mk_result ~id:"VERB-012" ~severity:Info
+           ~message:"`minted` block missing autogobble" ~count:!cnt)
     else None
   in
   { id = "VERB-012"; run; languages = [] }
@@ -2826,12 +2469,8 @@ let r_verb_013 : rule =
       blocks;
     if !cnt > 0 then
       Some
-        {
-          id = "VERB-013";
-          severity = Info;
-          message = "Code line > 120 glyphs";
-          count = !cnt;
-        }
+        (mk_result ~id:"VERB-013" ~severity:Info
+           ~message:"Code line > 120 glyphs" ~count:!cnt)
     else None
   in
   { id = "VERB-013"; run; languages = [] }
@@ -2851,12 +2490,9 @@ let r_verb_015 : rule =
      with Not_found -> ());
     if !cnt > 0 then
       Some
-        {
-          id = "VERB-015";
-          severity = Warning;
-          message = "Verbatim uses catcode changes instead of \\verb";
-          count = !cnt;
-        }
+        (mk_result ~id:"VERB-015" ~severity:Warning
+           ~message:"Verbatim uses catcode changes instead of \\verb"
+           ~count:!cnt)
     else None
   in
   { id = "VERB-015"; run; languages = [] }
@@ -2900,13 +2536,10 @@ let r_verb_016 : rule =
     done;
     if !cnt > 0 then
       Some
-        {
-          id = "VERB-016";
-          severity = Info;
-          message =
-            "`minted` without `escapeinside` while containing back‑ticks";
-          count = !cnt;
-        }
+        (mk_result ~id:"VERB-016" ~severity:Info
+           ~message:
+             "`minted` without `escapeinside` while containing back‑ticks"
+           ~count:!cnt)
     else None
   in
   { id = "VERB-016"; run; languages = [] }
@@ -2948,12 +2581,9 @@ let r_verb_017 : rule =
     done;
     if !cnt > 0 then
       Some
-        {
-          id = "VERB-017";
-          severity = Info;
-          message = "`minted` lacks `linenos` in code block > 20 lines";
-          count = !cnt;
-        }
+        (mk_result ~id:"VERB-017" ~severity:Info
+           ~message:"`minted` lacks `linenos` in code block > 20 lines"
+           ~count:!cnt)
     else None
   in
   { id = "VERB-017"; run; languages = [] }
@@ -2999,12 +2629,8 @@ let r_cjk_001 : rule =
     done;
     if !cnt > 0 then
       Some
-        {
-          id = "CJK-001";
-          severity = Warning;
-          message = "Full‑width comma U+FF0C in ASCII context";
-          count = !cnt;
-        }
+        (mk_result ~id:"CJK-001" ~severity:Warning
+           ~message:"Full‑width comma U+FF0C in ASCII context" ~count:!cnt)
     else None
   in
   { id = "CJK-001"; run; languages = [ "zh"; "ja"; "ko" ] }
@@ -3028,12 +2654,8 @@ let r_cjk_002 : rule =
     done;
     if !cnt > 0 then
       Some
-        {
-          id = "CJK-002";
-          severity = Warning;
-          message = "Full‑width period U+FF0E in ASCII context";
-          count = !cnt;
-        }
+        (mk_result ~id:"CJK-002" ~severity:Warning
+           ~message:"Full‑width period U+FF0E in ASCII context" ~count:!cnt)
     else None
   in
   { id = "CJK-002"; run; languages = [ "zh"; "ja"; "ko" ] }
@@ -3057,12 +2679,9 @@ let r_cjk_010 : rule =
     done;
     if !cnt > 0 then
       Some
-        {
-          id = "CJK-010";
-          severity = Warning;
-          message = "Half‑width CJK punctuation in full‑width context";
-          count = !cnt;
-        }
+        (mk_result ~id:"CJK-010" ~severity:Warning
+           ~message:"Half‑width CJK punctuation in full‑width context"
+           ~count:!cnt)
     else None
   in
   { id = "CJK-010"; run; languages = [ "zh"; "ja"; "ko" ] }
@@ -3086,12 +2705,8 @@ let r_cjk_014 : rule =
     done;
     if !cnt > 0 then
       Some
-        {
-          id = "CJK-014";
-          severity = Info;
-          message = "Inter‑punct U+30FB outside CJK run";
-          count = !cnt;
-        }
+        (mk_result ~id:"CJK-014" ~severity:Info
+           ~message:"Inter‑punct U+30FB outside CJK run" ~count:!cnt)
     else None
   in
   { id = "CJK-014"; run; languages = [ "zh"; "ja"; "ko" ] }
@@ -3117,12 +2732,9 @@ let r_fr_007 : rule =
      with Not_found -> ());
     if !cnt > 0 then
       Some
-        {
-          id = "FR-007";
-          severity = Info;
-          message = {|FR‑BE: thin NB‑space before/after € sign required|};
-          count = !cnt;
-        }
+        (mk_result ~id:"FR-007" ~severity:Info
+           ~message:{|FR‑BE: thin NB‑space before/after € sign required|}
+           ~count:!cnt)
     else None
   in
   { id = "FR-007"; run; languages = [ "fr" ] }
@@ -3152,12 +2764,9 @@ let r_fr_008 : rule =
     in
     if cnt > 0 then
       Some
-        {
-          id = "FR-008";
-          severity = Warning;
-          message = {|French: ligature œ/Œ mandatory in “cœur”, “œuvre”…|};
-          count = cnt;
-        }
+        (mk_result ~id:"FR-008" ~severity:Warning
+           ~message:{|French: ligature œ/Œ mandatory in “cœur”, “œuvre”…|}
+           ~count:cnt)
     else None
   in
   { id = "FR-008"; run; languages = [ "fr" ] }
@@ -3179,12 +2788,9 @@ let r_pt_003 : rule =
      with Not_found -> ());
     if !cnt > 0 then
       Some
-        {
-          id = "PT-003";
-          severity = Info;
-          message = {|pt‑PT: ordinal 1.º/1.ª must use º/ª, not superscript|};
-          count = !cnt;
-        }
+        (mk_result ~id:"PT-003" ~severity:Info
+           ~message:{|pt‑PT: ordinal 1.º/1.ª must use º/ª, not superscript|}
+           ~count:!cnt)
     else None
   in
   { id = "PT-003"; run; languages = [ "pt" ] }
@@ -3196,12 +2802,8 @@ let r_ru_001 : rule =
     let cnt = count_substring s " \xe2\x80\x94" in
     if cnt > 0 then
       Some
-        {
-          id = "RU-001";
-          severity = Info;
-          message = {|RU: NB‑space required before em‑dash|};
-          count = cnt;
-        }
+        (mk_result ~id:"RU-001" ~severity:Info
+           ~message:{|RU: NB‑space required before em‑dash|} ~count:cnt)
     else None
   in
   { id = "RU-001"; run; languages = [ "ru" ] }
@@ -3223,12 +2825,9 @@ let r_pl_001 : rule =
      with Not_found -> ());
     if !cnt > 0 then
       Some
-        {
-          id = "PL-001";
-          severity = Info;
-          message = {|PL: NB‑space before abbreviations “r.”, “nr”, “s.”|};
-          count = !cnt;
-        }
+        (mk_result ~id:"PL-001" ~severity:Info
+           ~message:{|PL: NB‑space before abbreviations “r.”, “nr”, “s.”|}
+           ~count:!cnt)
     else None
   in
   { id = "PL-001"; run; languages = [ "pl" ] }
@@ -3250,12 +2849,8 @@ let r_cs_001 : rule =
      with Not_found -> ());
     if !cnt > 0 then
       Some
-        {
-          id = "CS-001";
-          severity = Info;
-          message = {|CS/SK: thin NB‑space before °C forbidden|};
-          count = !cnt;
-        }
+        (mk_result ~id:"CS-001" ~severity:Info
+           ~message:{|CS/SK: thin NB‑space before °C forbidden|} ~count:!cnt)
     else None
   in
   { id = "CS-001"; run; languages = [ "cs" ] }
@@ -3284,12 +2879,8 @@ let r_cs_002 : rule =
     in
     if has_bare && not has_correct then
       Some
-        {
-          id = "CS-002";
-          severity = Info;
-          message = "CS/SK: date format must be 30.\\,1.\\,2026";
-          count = 1;
-        }
+        (mk_result ~id:"CS-002" ~severity:Info
+           ~message:"CS/SK: date format must be 30.\\,1.\\,2026" ~count:1)
     else None
   in
   { id = "CS-002"; run; languages = [ "cs" ] }
@@ -3315,12 +2906,8 @@ let r_el_001 : rule =
     done;
     if !cnt > 0 then
       Some
-        {
-          id = "EL-001";
-          severity = Warning;
-          message = {|Greek: oxia vs tonos normalisation|};
-          count = !cnt;
-        }
+        (mk_result ~id:"EL-001" ~severity:Warning
+           ~message:{|Greek: oxia vs tonos normalisation|} ~count:!cnt)
     else None
   in
   { id = "EL-001"; run; languages = [ "el" ] }
@@ -3338,12 +2925,8 @@ let r_ro_001 : rule =
     in
     if cnt > 0 then
       Some
-        {
-          id = "RO-001";
-          severity = Warning;
-          message = {|RO: use Ș/ș (S‑comma) not Ş/ş (S‑cedilla)|};
-          count = cnt;
-        }
+        (mk_result ~id:"RO-001" ~severity:Warning
+           ~message:{|RO: use Ș/ș (S‑comma) not Ş/ş (S‑cedilla)|} ~count:cnt)
     else None
   in
   { id = "RO-001"; run; languages = [ "ro" ] }
@@ -3373,12 +2956,9 @@ let r_ar_002 : rule =
     done;
     if !cnt > 0 then
       Some
-        {
-          id = "AR-002";
-          severity = Info;
-          message = {|AR: ASCII hyphen in phone numbers—use \arabicdash|};
-          count = !cnt;
-        }
+        (mk_result ~id:"AR-002" ~severity:Info
+           ~message:{|AR: ASCII hyphen in phone numbers—use \arabicdash|}
+           ~count:!cnt)
     else None
   in
   { id = "AR-002"; run; languages = [ "ar" ] }
@@ -3406,12 +2986,8 @@ let r_he_001 : rule =
     done;
     if !cnt > 0 then
       Some
-        {
-          id = "HE-001";
-          severity = Warning;
-          message = {|HE: apostrophe used instead of geresh U+05F3|};
-          count = !cnt;
-        }
+        (mk_result ~id:"HE-001" ~severity:Warning
+           ~message:{|HE: apostrophe used instead of geresh U+05F3|} ~count:!cnt)
     else None
   in
   { id = "HE-001"; run; languages = [ "he" ] }
@@ -3442,12 +3018,8 @@ let r_zh_001 : rule =
     done;
     if !cnt > 0 then
       Some
-        {
-          id = "ZH-001";
-          severity = Info;
-          message = {|ZH‑Hans: western '.' – use Chinese ‘。’|};
-          count = !cnt;
-        }
+        (mk_result ~id:"ZH-001" ~severity:Info
+           ~message:{|ZH‑Hans: western '.' – use Chinese ‘。’|} ~count:!cnt)
     else None
   in
   { id = "ZH-001"; run; languages = [ "zh" ] }
@@ -3471,12 +3043,9 @@ let r_ja_001 : rule =
     done;
     if !cnt > 0 then
       Some
-        {
-          id = "JA-001";
-          severity = Warning;
-          message = {|JA: half‑width katakana present—use full‑width|};
-          count = !cnt;
-        }
+        (mk_result ~id:"JA-001" ~severity:Warning
+           ~message:{|JA: half‑width katakana present—use full‑width|}
+           ~count:!cnt)
     else None
   in
   { id = "JA-001"; run; languages = [ "ja" ] }
@@ -3488,12 +3057,9 @@ let r_ja_002 : rule =
     let cnt = count_substring s "\xef\xbd\x9e" in
     if cnt > 0 then
       Some
-        {
-          id = "JA-002";
-          severity = Info;
-          message = {|JA: U+FF5E tilde normalise to wave‑dash U+301C|};
-          count = cnt;
-        }
+        (mk_result ~id:"JA-002" ~severity:Info
+           ~message:{|JA: U+FF5E tilde normalise to wave‑dash U+301C|}
+           ~count:cnt)
     else None
   in
   { id = "JA-002"; run; languages = [ "ja" ] }
@@ -3538,12 +3104,9 @@ let r_ko_001 : rule =
     done;
     if !cnt > 0 then
       Some
-        {
-          id = "KO-001";
-          severity = Warning;
-          message = {|KO: Old‑Hangul jamo outside scholarly context|};
-          count = !cnt;
-        }
+        (mk_result ~id:"KO-001" ~severity:Warning
+           ~message:{|KO: Old‑Hangul jamo outside scholarly context|}
+           ~count:!cnt)
     else None
   in
   { id = "KO-001"; run; languages = [ "ko" ] }
@@ -3577,12 +3140,8 @@ let r_hi_001 : rule =
     done;
     if !cnt > 0 then
       Some
-        {
-          id = "HI-001";
-          severity = Info;
-          message = {|HI: ZWJ/ZWNJ misuse next to ख्|};
-          count = !cnt;
-        }
+        (mk_result ~id:"HI-001" ~severity:Info
+           ~message:{|HI: ZWJ/ZWNJ misuse next to ख्|} ~count:!cnt)
     else None
   in
   { id = "HI-001"; run; languages = [ "hi" ] }
@@ -3640,12 +3199,9 @@ let r_cy_001 : rule =
     done;
     if !cnt > 0 then
       Some
-        {
-          id = "CY-001";
-          severity = Info;
-          message = {esc|Cyrillic initials require NB‑space "И.\,И."|esc};
-          count = !cnt;
-        }
+        (mk_result ~id:"CY-001" ~severity:Info
+           ~message:{esc|Cyrillic initials require NB‑space "И.\,И."|esc}
+           ~count:!cnt)
     else None
   in
   { id = "CY-001"; run; languages = [ "ru" ] }
@@ -3657,12 +3213,8 @@ let r_de_006 : rule =
     let cnt = count_substring s "\xc3\x9f" + count_substring s "\xe1\xba\x9e" in
     if cnt > 0 then
       Some
-        {
-          id = "DE-006";
-          severity = Info;
-          message = {|Swiss DE: glyph ß is prohibited—use “ss”|};
-          count = cnt;
-        }
+        (mk_result ~id:"DE-006" ~severity:Info
+           ~message:{|Swiss DE: glyph ß is prohibited—use “ss”|} ~count:cnt)
     else None
   in
   { id = "DE-006"; run; languages = [ "de" ] }
@@ -3689,13 +3241,10 @@ let r_nl_001 : rule =
     done;
     if !cnt > 0 then
       Some
-        {
-          id = "NL-001";
-          severity = Info;
-          message =
-            {|NL: digraph IJ/ij—capitalise both letters at sentence start|};
-          count = !cnt;
-        }
+        (mk_result ~id:"NL-001" ~severity:Info
+           ~message:
+             {|NL: digraph IJ/ij—capitalise both letters at sentence start|}
+           ~count:!cnt)
     else None
   in
   { id = "NL-001"; run; languages = [ "nl" ] }
@@ -3716,12 +3265,8 @@ let r_nl_002 : rule =
     in
     if has_single && has_german then
       Some
-        {
-          id = "NL-002";
-          severity = Info;
-          message = {|NL: quotes must be uniform (‘…’ or „…‟)|};
-          count = 1;
-        }
+        (mk_result ~id:"NL-002" ~severity:Info
+           ~message:{|NL: quotes must be uniform (‘…’ or „…‟)|} ~count:1)
     else None
   in
   { id = "NL-002"; run; languages = [ "nl" ] }
@@ -3738,12 +3283,8 @@ let r_pl_002 : rule =
     (* If guillemets present but no German quotes, it's wrong *)
     if has_guill && not has_german then
       Some
-        {
-          id = "PL-002";
-          severity = Info;
-          message = {|PL: primary quotes „…”, nested »…« only|};
-          count = 1;
-        }
+        (mk_result ~id:"PL-002" ~severity:Info
+           ~message:{|PL: primary quotes „…”, nested »…« only|} ~count:1)
     else None
   in
   { id = "PL-002"; run; languages = [ "pl" ] }
@@ -3770,12 +3311,9 @@ let r_pt_001 : rule =
     in
     if cnt > 0 then
       Some
-        {
-          id = "PT-001";
-          severity = Warning;
-          message = {|pt‑BR: pre‑2009 spellings “acção”, “óptimo” forbidden|};
-          count = cnt;
-        }
+        (mk_result ~id:"PT-001" ~severity:Warning
+           ~message:{|pt‑BR: pre‑2009 spellings “acção”, “óptimo” forbidden|}
+           ~count:cnt)
     else None
   in
   { id = "PT-001"; run; languages = [ "pt" ] }
@@ -3799,12 +3337,8 @@ let r_ru_002 : rule =
       in
       if cnt > 0 then
         Some
-          {
-            id = "RU-002";
-            severity = Info;
-            message = {|RU: letter ё must be preserved where needed|};
-            count = cnt;
-          }
+          (mk_result ~id:"RU-002" ~severity:Info
+             ~message:{|RU: letter ё must be preserved where needed|} ~count:cnt)
       else None
   in
   { id = "RU-002"; run; languages = [ "ru" ] }
@@ -3839,12 +3373,8 @@ let r_tr_001 : rule =
       done;
       if !cnt > 0 then
         Some
-          {
-            id = "TR-001";
-            severity = Warning;
-            message = {|TR: dotless/dotted I mapping error|};
-            count = !cnt;
-          }
+          (mk_result ~id:"TR-001" ~severity:Warning
+             ~message:{|TR: dotless/dotted I mapping error|} ~count:!cnt)
       else None)
     else None
   in
@@ -3869,12 +3399,8 @@ let r_zh_002 : rule =
     in
     if (has_cjk_corner || has_cjk_white) && has_western then
       Some
-        {
-          id = "ZH-002";
-          severity = Info;
-          message = {|ZH‑Hant: quotes must be 「…」 or 『…』 consistently|};
-          count = 1;
-        }
+        (mk_result ~id:"ZH-002" ~severity:Info
+           ~message:{|ZH‑Hant: quotes must be 「…」 or 『…』 consistently|} ~count:1)
     else None
   in
   { id = "ZH-002"; run; languages = [ "zh" ] }
@@ -3924,12 +3450,8 @@ let r_verb_014 : rule =
     done;
     if !cnt > 0 then
       Some
-        {
-          id = "VERB-014";
-          severity = Warning;
-          message = {|Code block inside caption|};
-          count = !cnt;
-        }
+        (mk_result ~id:"VERB-014" ~severity:Warning
+           ~message:{|Code block inside caption|} ~count:!cnt)
     else None
   in
   { id = "VERB-014"; run; languages = [] }
@@ -3940,12 +3462,8 @@ let r_math_064 : rule =
     let cnt = count_substring s "\\eqalign" in
     if cnt > 0 then
       Some
-        {
-          id = "MATH-064";
-          severity = Warning;
-          message = {esc|Use of \eqalign – obsolete|esc};
-          count = cnt;
-        }
+        (mk_result ~id:"MATH-064" ~severity:Warning
+           ~message:{esc|Use of \eqalign – obsolete|esc} ~count:cnt)
     else None
   in
   { id = "MATH-064"; run; languages = [] }
@@ -3956,12 +3474,9 @@ let r_math_102 : rule =
     let cnt = count_substring s "\\begin{eqnarray}" in
     if cnt > 0 then
       Some
-        {
-          id = "MATH-102";
-          severity = Warning;
-          message = {|Legacy eqnarray (un‑starred) environment present|};
-          count = cnt;
-        }
+        (mk_result ~id:"MATH-102" ~severity:Warning
+           ~message:{|Legacy eqnarray (un‑starred) environment present|}
+           ~count:cnt)
     else None
   in
   { id = "MATH-102"; run; languages = [] }
@@ -3975,12 +3490,8 @@ let r_math_107 : rule =
     let has_leqslant = count_substring s "\\leqslant" > 0 in
     if has_le && has_leqslant then
       Some
-        {
-          id = "MATH-107";
-          severity = Info;
-          message = {|Mix of \le and \leqslant within same document|};
-          count = 1;
-        }
+        (mk_result ~id:"MATH-107" ~severity:Info
+           ~message:{|Mix of \le and \leqslant within same document|} ~count:1)
     else None
   in
   { id = "MATH-107"; run; languages = [] }
@@ -3992,12 +3503,8 @@ let r_l3_008 : rule =
     let has_provides = count_substring s "\\ProvidesExplPackage" > 0 in
     if has_expl3 && not has_provides then
       Some
-        {
-          id = "L3-008";
-          severity = Warning;
-          message = {|Expl3 module lacks \ProvidesExplPackage|};
-          count = 1;
-        }
+        (mk_result ~id:"L3-008" ~severity:Warning
+           ~message:{|Expl3 module lacks \ProvidesExplPackage|} ~count:1)
     else None
   in
   { id = "L3-008"; run; languages = [] }
@@ -4009,12 +3516,8 @@ let r_l3_010 : rule =
     let has_off = count_substring s "\\ExplSyntaxOff" > 0 in
     if has_on && not has_off then
       Some
-        {
-          id = "L3-010";
-          severity = Info;
-          message = {|\ExplSyntaxOff missing at end of file|};
-          count = 1;
-        }
+        (mk_result ~id:"L3-010" ~severity:Info
+           ~message:{|\ExplSyntaxOff missing at end of file|} ~count:1)
     else None
   in
   { id = "L3-010"; run; languages = [] }
@@ -4034,12 +3537,9 @@ let r_ref_011 : rule =
     in
     if has_autoref && (not has_hyperref) && not has_cleveref then
       Some
-        {
-          id = "REF-011";
-          severity = Error;
-          message = {|\autoref used without hyperref/cleveref loaded|};
-          count = count_substring s "\\autoref";
-        }
+        (mk_result ~id:"REF-011" ~severity:Error
+           ~message:{|\autoref used without hyperref/cleveref loaded|}
+           ~count:(count_substring s "\\autoref"))
     else None
   in
   { id = "REF-011"; run; languages = [] }
@@ -4096,12 +3596,8 @@ let r_typo_050 : rule =
       let sc_count = total - tc_count in
       if tc_count > 0 && sc_count > 0 then
         Some
-          {
-            id = "TYPO-050";
-            severity = Info;
-            message = {|Inconsistent title‑case capitalisation|};
-            count = 1;
-          }
+          (mk_result ~id:"TYPO-050" ~severity:Info
+             ~message:{|Inconsistent title‑case capitalisation|} ~count:1)
       else None
   in
   { id = "TYPO-050"; run; languages = [] }

--- a/latex-parse/src/validators_l0_typo.ml
+++ b/latex-parse/src/validators_l0_typo.ml
@@ -9,12 +9,9 @@ let r_typo_001 : rule =
     let cnt = count_char s '"' in
     if cnt > 0 then
       Some
-        {
-          id = "TYPO-001";
-          severity = Error;
-          message = {|ASCII straight quotes (" … ") must be curly quotes|};
-          count = cnt;
-        }
+        (mk_result ~id:"TYPO-001" ~severity:Error
+           ~message:{|ASCII straight quotes (" … ") must be curly quotes|}
+           ~count:cnt)
     else None
   in
   { id = "TYPO-001"; run; languages = [] }
@@ -38,23 +35,15 @@ let r_typo_002 : rule =
         in
         if cnt > 0 then
           Some
-            {
-              id = "TYPO-002";
-              severity = Warning;
-              message = "Double hyphen -- should be en‑dash –";
-              count = cnt;
-            }
+            (mk_result ~id:"TYPO-002" ~severity:Warning
+               ~message:"Double hyphen -- should be en‑dash –" ~count:cnt)
         else None
     | _ ->
         let cnt = count_substring s "--" in
         if cnt > 0 then
           Some
-            {
-              id = "TYPO-002";
-              severity = Warning;
-              message = "Double hyphen -- should be en‑dash –";
-              count = cnt;
-            }
+            (mk_result ~id:"TYPO-002" ~severity:Warning
+               ~message:"Double hyphen -- should be en‑dash –" ~count:cnt)
         else None
   in
   { id = "TYPO-002"; run; languages = [] }
@@ -78,23 +67,15 @@ let r_typo_003 : rule =
         in
         if cnt > 0 then
           Some
-            {
-              id = "TYPO-003";
-              severity = Warning;
-              message = "Triple hyphen --- should be em‑dash —";
-              count = cnt;
-            }
+            (mk_result ~id:"TYPO-003" ~severity:Warning
+               ~message:"Triple hyphen --- should be em‑dash —" ~count:cnt)
         else None
     | _ ->
         let cnt = count_substring s "---" in
         if cnt > 0 then
           Some
-            {
-              id = "TYPO-003";
-              severity = Warning;
-              message = "Triple hyphen --- should be em‑dash —";
-              count = cnt;
-            }
+            (mk_result ~id:"TYPO-003" ~severity:Warning
+               ~message:"Triple hyphen --- should be em‑dash —" ~count:cnt)
         else None
   in
   { id = "TYPO-003"; run; languages = [] }
@@ -104,13 +85,10 @@ let r_typo_004 : rule =
     let cnt = count_substring s "``" + count_substring s "''" in
     if cnt > 0 then
       Some
-        {
-          id = "TYPO-004";
-          severity = Warning;
-          message =
-            "TeX double back‑tick ``…'' not allowed; use opening curly quotes";
-          count = cnt;
-        }
+        (mk_result ~id:"TYPO-004" ~severity:Warning
+           ~message:
+             "TeX double back‑tick ``…'' not allowed; use opening curly quotes"
+           ~count:cnt)
     else None
   in
   { id = "TYPO-004"; run; languages = [] }
@@ -121,12 +99,8 @@ let r_typo_005 : rule =
     let cnt = count_substring s "..." in
     if cnt > 0 then
       Some
-        {
-          id = "TYPO-005";
-          severity = Warning;
-          message = "Ellipsis typed as three periods ...; use \\dots";
-          count = cnt;
-        }
+        (mk_result ~id:"TYPO-005" ~severity:Warning
+           ~message:"Ellipsis typed as three periods ...; use \\dots" ~count:cnt)
     else None
   in
   { id = "TYPO-005"; run; languages = [] }
@@ -136,12 +110,8 @@ let r_typo_006 : rule =
     let cnt = count_char s '\t' in
     if cnt > 0 then
       Some
-        {
-          id = "TYPO-006";
-          severity = Error;
-          message = "Tab character U+0009 forbidden";
-          count = cnt;
-        }
+        (mk_result ~id:"TYPO-006" ~severity:Error
+           ~message:"Tab character U+0009 forbidden" ~count:cnt)
     else None
   in
   { id = "TYPO-006"; run; languages = [] }
@@ -166,12 +136,8 @@ let r_typo_007 : rule =
         in
         if cnt > 0 then
           Some
-            {
-              id = "TYPO-007";
-              severity = Info;
-              message = "Trailing spaces at end of line";
-              count = cnt;
-            }
+            (mk_result ~id:"TYPO-007" ~severity:Info
+               ~message:"Trailing spaces at end of line" ~count:cnt)
         else None
     | _ ->
         let _total, matched =
@@ -184,12 +150,8 @@ let r_typo_007 : rule =
         in
         if matched > 0 then
           Some
-            {
-              id = "TYPO-007";
-              severity = Info;
-              message = "Trailing spaces at end of line";
-              count = matched;
-            }
+            (mk_result ~id:"TYPO-007" ~severity:Info
+               ~message:"Trailing spaces at end of line" ~count:matched)
         else None
   in
   { id = "TYPO-007"; run; languages = [] }
@@ -214,23 +176,17 @@ let r_typo_008 : rule =
         in
         if cnt > 0 then
           Some
-            {
-              id = "TYPO-008";
-              severity = Info;
-              message = "Multiple consecutive blank lines (> 2) in source";
-              count = cnt;
-            }
+            (mk_result ~id:"TYPO-008" ~severity:Info
+               ~message:"Multiple consecutive blank lines (> 2) in source"
+               ~count:cnt)
         else None
     | _ ->
         let cnt = count_substring s "\n\n\n" in
         if cnt > 0 then
           Some
-            {
-              id = "TYPO-008";
-              severity = Info;
-              message = "Multiple consecutive blank lines (> 2) in source";
-              count = cnt;
-            }
+            (mk_result ~id:"TYPO-008" ~severity:Info
+               ~message:"Multiple consecutive blank lines (> 2) in source"
+               ~count:cnt)
         else None
   in
   { id = "TYPO-008"; run; languages = [] }
@@ -243,12 +199,9 @@ let r_typo_009 : rule =
     let cnt = starts + count_substring s "\n~" in
     if cnt > 0 then
       Some
-        {
-          id = "TYPO-009";
-          severity = Warning;
-          message = "Non‑breaking space ~ used incorrectly at line start";
-          count = cnt;
-        }
+        (mk_result ~id:"TYPO-009" ~severity:Warning
+           ~message:"Non‑breaking space ~ used incorrectly at line start"
+           ~count:cnt)
     else None
   in
   { id = "TYPO-009"; run; languages = [] }
@@ -276,12 +229,8 @@ let r_typo_010 : rule =
         in
         if cnt > 0 then
           Some
-            {
-              id = "TYPO-010";
-              severity = Info;
-              message = "Space before punctuation , . ; : ? !";
-              count = cnt;
-            }
+            (mk_result ~id:"TYPO-010" ~severity:Info
+               ~message:"Space before punctuation , . ; : ? !" ~count:cnt)
         else None
     | _ ->
         let combos = [ " ,"; " ."; " ;"; " :"; " ?"; " !" ] in
@@ -290,12 +239,8 @@ let r_typo_010 : rule =
         in
         if cnt > 0 then
           Some
-            {
-              id = "TYPO-010";
-              severity = Info;
-              message = "Space before punctuation , . ; : ? !";
-              count = cnt;
-            }
+            (mk_result ~id:"TYPO-010" ~severity:Info
+               ~message:"Space before punctuation , . ; : ? !" ~count:cnt)
         else None
   in
   { id = "TYPO-010"; run; languages = [] }
@@ -315,13 +260,10 @@ let r_typo_011 : rule =
      with Not_found -> ());
     if !cnt > 0 then
       Some
-        {
-          id = "TYPO-011";
-          severity = Info;
-          message =
-            {|Missing thin space (\,) before differential d in integrals|};
-          count = !cnt;
-        }
+        (mk_result ~id:"TYPO-011" ~severity:Info
+           ~message:
+             {|Missing thin space (\,) before differential d in integrals|}
+           ~count:!cnt)
     else None
   in
   { id = "TYPO-011"; run; languages = [] }
@@ -341,13 +283,10 @@ let r_typo_012 : rule =
      with Not_found -> ());
     if !cnt > 0 then
       Some
-        {
-          id = "TYPO-012";
-          severity = Warning;
-          message =
-            {|Straight apostrophe ' used for minutes/feet; use ^\prime or ′|};
-          count = !cnt;
-        }
+        (mk_result ~id:"TYPO-012" ~severity:Warning
+           ~message:
+             {|Straight apostrophe ' used for minutes/feet; use ^\prime or ′|}
+           ~count:!cnt)
     else None
   in
   { id = "TYPO-012"; run; languages = [] }
@@ -367,12 +306,8 @@ let r_typo_013 : rule =
     done;
     if !cnt > 0 then
       Some
-        {
-          id = "TYPO-013";
-          severity = Warning;
-          message = {|ASCII back‑tick ` used as opening quote|};
-          count = !cnt;
-        }
+        (mk_result ~id:"TYPO-013" ~severity:Warning
+           ~message:{|ASCII back‑tick ` used as opening quote|} ~count:!cnt)
     else None
   in
   { id = "TYPO-013"; run; languages = [] }
@@ -383,12 +318,8 @@ let r_typo_014 : rule =
     let cnt = count_substring s " %" in
     if cnt > 0 then
       Some
-        {
-          id = "TYPO-014";
-          severity = Info;
-          message = {|Space before percent sign \%|};
-          count = cnt;
-        }
+        (mk_result ~id:"TYPO-014" ~severity:Info
+           ~message:{|Space before percent sign \%|} ~count:cnt)
     else None
   in
   { id = "TYPO-014"; run; languages = [] }
@@ -399,12 +330,8 @@ let r_typo_015 : rule =
     let cnt = count_substring s "\\%\\%" in
     if cnt > 0 then
       Some
-        {
-          id = "TYPO-015";
-          severity = Warning;
-          message = {|Double \% in source; likely stray percent|};
-          count = cnt;
-        }
+        (mk_result ~id:"TYPO-015" ~severity:Warning
+           ~message:{|Double \% in source; likely stray percent|} ~count:cnt)
     else None
   in
   { id = "TYPO-015"; run; languages = [] }
@@ -425,12 +352,9 @@ let r_typo_016 : rule =
     let cnt = !cnt in
     if cnt > 0 then
       Some
-        {
-          id = "TYPO-016";
-          severity = Info;
-          message = {|Non‑breaking space ~ missing before \cite / \ref|};
-          count = cnt;
-        }
+        (mk_result ~id:"TYPO-016" ~severity:Info
+           ~message:{|Non‑breaking space ~ missing before \cite / \ref|}
+           ~count:cnt)
     else None
   in
   { id = "TYPO-016"; run; languages = [] }
@@ -450,12 +374,9 @@ let r_typo_017 : rule =
      with Not_found -> ());
     if !cnt > 0 then
       Some
-        {
-          id = "TYPO-017";
-          severity = Info;
-          message = {|TeX accent commands (\'{e}) in text; prefer UTF‑8 é|};
-          count = !cnt;
-        }
+        (mk_result ~id:"TYPO-017" ~severity:Info
+           ~message:{|TeX accent commands (\'{e}) in text; prefer UTF‑8 é|}
+           ~count:!cnt)
     else None
   in
   { id = "TYPO-017"; run; languages = [] }
@@ -466,12 +387,8 @@ let r_typo_018 : rule =
     let cnt = count_substring s "  " in
     if cnt > 0 then
       Some
-        {
-          id = "TYPO-018";
-          severity = Info;
-          message = "Multiple consecutive spaces in text";
-          count = cnt;
-        }
+        (mk_result ~id:"TYPO-018" ~severity:Info
+           ~message:"Multiple consecutive spaces in text" ~count:cnt)
     else None
   in
   { id = "TYPO-018"; run; languages = [] }
@@ -509,12 +426,8 @@ let r_typo_021 : rule =
      with Not_found -> ());
     if !cnt > 0 then
       Some
-        {
-          id = "TYPO-021";
-          severity = Info;
-          message = "Capital letter after ellipsis without space";
-          count = !cnt;
-        }
+        (mk_result ~id:"TYPO-021" ~severity:Info
+           ~message:"Capital letter after ellipsis without space" ~count:!cnt)
     else None
   in
   { id = "TYPO-021"; run; languages = [] }
@@ -528,12 +441,8 @@ let r_typo_022 : rule =
     in
     if cnt > 0 then
       Some
-        {
-          id = "TYPO-022";
-          severity = Info;
-          message = "Space before closing punctuation ) ] }";
-          count = cnt;
-        }
+        (mk_result ~id:"TYPO-022" ~severity:Info
+           ~message:"Space before closing punctuation ) ] }" ~count:cnt)
     else None
   in
   { id = "TYPO-022"; run; languages = [] }
@@ -588,12 +497,9 @@ let r_typo_023 : rule =
     done;
     if !cnt > 0 then
       Some
-        {
-          id = "TYPO-023";
-          severity = Error;
-          message = {|ASCII ampersand & outside tabular env; use \&|};
-          count = !cnt;
-        }
+        (mk_result ~id:"TYPO-023" ~severity:Error
+           ~message:{|ASCII ampersand & outside tabular env; use \&|}
+           ~count:!cnt)
     else None
   in
   { id = "TYPO-023"; run; languages = [] }
@@ -614,12 +520,8 @@ let r_typo_024 : rule =
     in
     if cnt > 0 then
       Some
-        {
-          id = "TYPO-024";
-          severity = Info;
-          message = "Dangling dash at line end";
-          count = cnt;
-        }
+        (mk_result ~id:"TYPO-024" ~severity:Info
+           ~message:"Dangling dash at line end" ~count:cnt)
     else None
   in
   { id = "TYPO-024"; run; languages = [] }
@@ -639,12 +541,8 @@ let r_typo_025 : rule =
      with Not_found -> ());
     if !cnt > 0 then
       Some
-        {
-          id = "TYPO-025";
-          severity = Warning;
-          message = {|Space before en‑dash in number range|};
-          count = !cnt;
-        }
+        (mk_result ~id:"TYPO-025" ~severity:Warning
+           ~message:{|Space before en‑dash in number range|} ~count:!cnt)
     else None
   in
   { id = "TYPO-025"; run; languages = [] }
@@ -664,12 +562,8 @@ let r_typo_026 : rule =
      with Not_found -> ());
     if !cnt > 0 then
       Some
-        {
-          id = "TYPO-026";
-          severity = Warning;
-          message = {|Wrong dash in page range – should use --|};
-          count = !cnt;
-        }
+        (mk_result ~id:"TYPO-026" ~severity:Warning
+           ~message:{|Wrong dash in page range – should use --|} ~count:!cnt)
     else None
   in
   { id = "TYPO-026"; run; languages = [] }
@@ -680,12 +574,8 @@ let r_typo_027 : rule =
     let cnt = count_substring s "!!" in
     if cnt > 0 then
       Some
-        {
-          id = "TYPO-027";
-          severity = Info;
-          message = {|Multiple exclamation marks ‼|};
-          count = cnt;
-        }
+        (mk_result ~id:"TYPO-027" ~severity:Info
+           ~message:{|Multiple exclamation marks ‼|} ~count:cnt)
     else None
   in
   { id = "TYPO-027"; run; languages = [] }
@@ -698,12 +588,8 @@ let r_typo_028 : rule =
     let cnt = cnt / 2 in
     if cnt > 0 then
       Some
-        {
-          id = "TYPO-028";
-          severity = Error;
-          message = {|Use of ``$$'' display math delimiter|};
-          count = cnt;
-        }
+        (mk_result ~id:"TYPO-028" ~severity:Error
+           ~message:{|Use of ``$$'' display math delimiter|} ~count:cnt)
     else None
   in
   { id = "TYPO-028"; run; languages = [] }
@@ -723,12 +609,8 @@ let r_typo_029 : rule =
      with Not_found -> ());
     if !cnt > 0 then
       Some
-        {
-          id = "TYPO-029";
-          severity = Info;
-          message = {|Non‑breaking space after \ref missing|};
-          count = !cnt;
-        }
+        (mk_result ~id:"TYPO-029" ~severity:Info
+           ~message:{|Non‑breaking space after \ref missing|} ~count:!cnt)
     else None
   in
   { id = "TYPO-029"; run; languages = [] }
@@ -760,12 +642,8 @@ let r_typo_032 : rule =
      with Not_found -> ());
     if !cnt > 0 then
       Some
-        {
-          id = "TYPO-032";
-          severity = Warning;
-          message = {|Comma before \cite|};
-          count = !cnt;
-        }
+        (mk_result ~id:"TYPO-032" ~severity:Warning
+           ~message:{|Comma before \cite|} ~count:!cnt)
     else None
   in
   { id = "TYPO-032"; run; languages = [] }
@@ -776,12 +654,8 @@ let r_typo_033 : rule =
     let cnt = count_substring s "et.al" in
     if cnt > 0 then
       Some
-        {
-          id = "TYPO-033";
-          severity = Warning;
-          message = "Abbreviation et.al without space";
-          count = cnt;
-        }
+        (mk_result ~id:"TYPO-033" ~severity:Warning
+           ~message:"Abbreviation et.al without space" ~count:cnt)
     else None
   in
   { id = "TYPO-033"; run; languages = [] }
@@ -833,12 +707,9 @@ let r_typo_034 : rule =
     let cnt = count_substring s " \\footnote" in
     if cnt > 0 then
       Some
-        {
-          id = "TYPO-034";
-          severity = Info;
-          message = {|Spurious space before footnote command \footnote|};
-          count = cnt;
-        }
+        (mk_result ~id:"TYPO-034" ~severity:Info
+           ~message:{|Spurious space before footnote command \footnote|}
+           ~count:cnt)
     else None
   in
   { id = "TYPO-034"; run; languages = [] }
@@ -854,12 +725,8 @@ let r_typo_035 : rule =
     in
     if cnt > 0 then
       Some
-        {
-          id = "TYPO-035";
-          severity = Warning;
-          message = "French punctuation requires NBSP before ; : ! ?";
-          count = cnt;
-        }
+        (mk_result ~id:"TYPO-035" ~severity:Warning
+           ~message:"French punctuation requires NBSP before ; : ! ?" ~count:cnt)
     else None
   in
   { id = "TYPO-035"; run; languages = [] }
@@ -881,12 +748,9 @@ let r_typo_036 : rule =
     let cnt = loop 0 0 in
     if cnt > 0 then
       Some
-        {
-          id = "TYPO-036";
-          severity = Info;
-          message = "Suspicious consecutive capitalised words (shouting)";
-          count = cnt;
-        }
+        (mk_result ~id:"TYPO-036" ~severity:Info
+           ~message:"Suspicious consecutive capitalised words (shouting)"
+           ~count:cnt)
     else None
   in
   { id = "TYPO-036"; run; languages = [] }
@@ -897,12 +761,8 @@ let r_typo_037 : rule =
     let cnt = count_substring s " ," in
     if cnt > 0 then
       Some
-        {
-          id = "TYPO-037";
-          severity = Info;
-          message = "Space before comma";
-          count = cnt;
-        }
+        (mk_result ~id:"TYPO-037" ~severity:Info ~message:"Space before comma"
+           ~count:cnt)
     else None
   in
   { id = "TYPO-037"; run; languages = [] }
@@ -921,12 +781,8 @@ let r_typo_038 : rule =
     let cnt = loop 0 0 in
     if cnt > 0 then
       Some
-        {
-          id = "TYPO-038";
-          severity = Info;
-          message = {|E‑mail address not in \href|};
-          count = cnt;
-        }
+        (mk_result ~id:"TYPO-038" ~severity:Info
+           ~message:{|E‑mail address not in \href|} ~count:cnt)
     else None
   in
   { id = "TYPO-038"; run; languages = [] }
@@ -941,12 +797,8 @@ let r_typo_041 : rule =
     in
     if cnt > 0 then
       Some
-        {
-          id = "TYPO-041";
-          severity = Info;
-          message = {|Incorrect spacing around \ldots|};
-          count = cnt;
-        }
+        (mk_result ~id:"TYPO-041" ~severity:Info
+           ~message:{|Incorrect spacing around \ldots|} ~count:cnt)
     else None
   in
   { id = "TYPO-041"; run; languages = [] }
@@ -957,12 +809,8 @@ let r_typo_042 : rule =
     let cnt = count_substring s "??" in
     if cnt > 0 then
       Some
-        {
-          id = "TYPO-042";
-          severity = Info;
-          message = "Multiple consecutive question marks ??";
-          count = cnt;
-        }
+        (mk_result ~id:"TYPO-042" ~severity:Info
+           ~message:"Multiple consecutive question marks ??" ~count:cnt)
     else None
   in
   { id = "TYPO-042"; run; languages = [] }
@@ -978,12 +826,8 @@ let r_typo_043 : rule =
     in
     if cnt > 0 then
       Some
-        {
-          id = "TYPO-043";
-          severity = Warning;
-          message = "Smart quotes inside verbatim detected";
-          count = cnt;
-        }
+        (mk_result ~id:"TYPO-043" ~severity:Warning
+           ~message:"Smart quotes inside verbatim detected" ~count:cnt)
     else None
   in
   { id = "TYPO-043"; run; languages = [] }
@@ -1135,12 +979,8 @@ let r_typo_044 : rule =
       first_use;
     if !cnt > 0 then
       Some
-        {
-          id = "TYPO-044";
-          severity = Info;
-          message = "Acronym not defined on first use";
-          count = !cnt;
-        }
+        (mk_result ~id:"TYPO-044" ~severity:Info
+           ~message:"Acronym not defined on first use" ~count:!cnt)
     else None
   in
   { id = "TYPO-044"; run; languages = [] }
@@ -1156,12 +996,8 @@ let r_typo_048 : rule =
     in
     if cnt > 0 then
       Some
-        {
-          id = "TYPO-048";
-          severity = Info;
-          message = "En‑dash used as minus sign in text";
-          count = cnt;
-        }
+        (mk_result ~id:"TYPO-048" ~severity:Info
+           ~message:"En‑dash used as minus sign in text" ~count:cnt)
     else None
   in
   { id = "TYPO-048"; run; languages = [] }
@@ -1172,12 +1008,9 @@ let r_typo_051 : rule =
     let cnt = count_substring s "\xe2\x80\x89" in
     if cnt > 0 then
       Some
-        {
-          id = "TYPO-051";
-          severity = Warning;
-          message = {|Figure space U+2009 used instead of \thinspace macro|};
-          count = cnt;
-        }
+        (mk_result ~id:"TYPO-051" ~severity:Warning
+           ~message:{|Figure space U+2009 used instead of \thinspace macro|}
+           ~count:cnt)
     else None
   in
   { id = "TYPO-051"; run; languages = [] }
@@ -1193,12 +1026,9 @@ let r_typo_052 : rule =
     in
     if cnt > 0 then
       Some
-        {
-          id = "TYPO-052";
-          severity = Warning;
-          message = "Unescaped < or > in text; use \\textless / \\textgreater";
-          count = cnt;
-        }
+        (mk_result ~id:"TYPO-052" ~severity:Warning
+           ~message:"Unescaped < or > in text; use \\textless / \\textgreater"
+           ~count:cnt)
     else None
   in
   { id = "TYPO-052"; run; languages = [] }
@@ -1209,12 +1039,9 @@ let r_typo_053 : rule =
     let cnt = count_substring s "\xe2\x8b\xaf" in
     if cnt > 0 then
       Some
-        {
-          id = "TYPO-053";
-          severity = Warning;
-          message = {|Unicode ⋯ (U+22EF) leader forbidden; use \dots instead|};
-          count = cnt;
-        }
+        (mk_result ~id:"TYPO-053" ~severity:Warning
+           ~message:{|Unicode ⋯ (U+22EF) leader forbidden; use \dots instead|}
+           ~count:cnt)
     else None
   in
   { id = "TYPO-053"; run; languages = [] }
@@ -1233,12 +1060,9 @@ let r_typo_054 : rule =
     let cnt = loop 0 0 in
     if cnt > 0 then
       Some
-        {
-          id = "TYPO-054";
-          severity = Info;
-          message = "Hair‑space required after en‑dash in word–word ranges";
-          count = cnt;
-        }
+        (mk_result ~id:"TYPO-054" ~severity:Info
+           ~message:"Hair‑space required after en‑dash in word–word ranges"
+           ~count:cnt)
     else None
   in
   { id = "TYPO-054"; run; languages = [] }
@@ -1249,12 +1073,9 @@ let r_typo_055 : rule =
     let cnt = count_substring s "\\,\\," in
     if cnt > 0 then
       Some
-        {
-          id = "TYPO-055";
-          severity = Info;
-          message = {|Consecutive thin‑spaces (\,\,) prohibited; collapse|};
-          count = cnt;
-        }
+        (mk_result ~id:"TYPO-055" ~severity:Info
+           ~message:{|Consecutive thin‑spaces (\,\,) prohibited; collapse|}
+           ~count:cnt)
     else None
   in
   { id = "TYPO-055"; run; languages = [] }
@@ -1273,12 +1094,9 @@ let r_typo_057 : rule =
     let cnt = loop 0 0 in
     if cnt > 0 then
       Some
-        {
-          id = "TYPO-057";
-          severity = Info;
-          message = {|Missing thin‑space before °C/°F or \si{\celsius}|};
-          count = cnt;
-        }
+        (mk_result ~id:"TYPO-057" ~severity:Info
+           ~message:{|Missing thin‑space before °C/°F or \si{\celsius}|}
+           ~count:cnt)
     else None
   in
   { id = "TYPO-057"; run; languages = [] }
@@ -1290,12 +1108,9 @@ let r_typo_061 : rule =
     let cnt = count_substring s "\xc3\x97" in
     if cnt > 0 then
       Some
-        {
-          id = "TYPO-061";
-          severity = Info;
-          message = {|Unicode × (U+00D7) in text; prefer \times via math mode|};
-          count = cnt;
-        }
+        (mk_result ~id:"TYPO-061" ~severity:Info
+           ~message:{|Unicode × (U+00D7) in text; prefer \times via math mode|}
+           ~count:cnt)
     else None
   in
   { id = "TYPO-061"; run; languages = [] }
@@ -1306,12 +1121,8 @@ let r_typo_063 : rule =
     let cnt = count_substring s "\xe2\x80\x91" in
     if cnt > 0 then
       Some
-        {
-          id = "TYPO-063";
-          severity = Info;
-          message = "Non‑breaking hyphen U+2011 found inside URL";
-          count = cnt;
-        }
+        (mk_result ~id:"TYPO-063" ~severity:Info
+           ~message:"Non‑breaking hyphen U+2011 found inside URL" ~count:cnt)
     else None
   in
   { id = "TYPO-063"; run; languages = [] }
@@ -1330,12 +1141,8 @@ let r_typo_039 : rule =
     let cnt = loop 0 0 in
     if cnt > 0 then
       Some
-        {
-          id = "TYPO-039";
-          severity = Info;
-          message = "URL split across lines without \\url{}";
-          count = cnt;
-        }
+        (mk_result ~id:"TYPO-039" ~severity:Info
+           ~message:"URL split across lines without \\url{}" ~count:cnt)
     else None
   in
   { id = "TYPO-039"; run; languages = [] }
@@ -1356,12 +1163,8 @@ let r_typo_040 : rule =
     let cnt = loop 0 0 in
     if cnt > 0 then
       Some
-        {
-          id = "TYPO-040";
-          severity = Info;
-          message = "Math in text mode $…$ exceeds 80 characters";
-          count = cnt;
-        }
+        (mk_result ~id:"TYPO-040" ~severity:Info
+           ~message:"Math in text mode $…$ exceeds 80 characters" ~count:cnt)
     else None
   in
   { id = "TYPO-040"; run; languages = [] }
@@ -1385,12 +1188,8 @@ let r_typo_045 : rule =
     in
     if cnt > 0 then
       Some
-        {
-          id = "TYPO-045";
-          severity = Warning;
-          message = "Non‑ASCII punctuation in math mode (‘ ’ “ ”)";
-          count = cnt;
-        }
+        (mk_result ~id:"TYPO-045" ~severity:Warning
+           ~message:"Non‑ASCII punctuation in math mode (‘ ’ “ ”)" ~count:cnt)
     else None
   in
   { id = "TYPO-045"; run; languages = [] }
@@ -1403,12 +1202,9 @@ let r_typo_046 : rule =
     in
     if cnt > 0 then
       Some
-        {
-          id = "TYPO-046";
-          severity = Info;
-          message = "Use of $begin:math:text$ … $end:math:text$ instead of $…$";
-          count = cnt;
-        }
+        (mk_result ~id:"TYPO-046" ~severity:Info
+           ~message:"Use of $begin:math:text$ … $end:math:text$ instead of $…$"
+           ~count:cnt)
     else None
   in
   { id = "TYPO-046"; run; languages = [] }
@@ -1419,12 +1215,9 @@ let r_typo_047 : rule =
     let cnt = count_substring s "\\section*" in
     if cnt > 0 then
       Some
-        {
-          id = "TYPO-047";
-          severity = Info;
-          message = "Starred \\section* used where numbered section expected";
-          count = cnt;
-        }
+        (mk_result ~id:"TYPO-047" ~severity:Info
+           ~message:"Starred \\section* used where numbered section expected"
+           ~count:cnt)
     else None
   in
   { id = "TYPO-047"; run; languages = [] }
@@ -1437,12 +1230,8 @@ let r_typo_049 : rule =
     in
     if cnt > 0 then
       Some
-        {
-          id = "TYPO-049";
-          severity = Info;
-          message = "Space after opening quote";
-          count = cnt;
-        }
+        (mk_result ~id:"TYPO-049" ~severity:Info
+           ~message:"Space after opening quote" ~count:cnt)
     else None
   in
   { id = "TYPO-049"; run; languages = [] }
@@ -1461,12 +1250,8 @@ let r_typo_056 : rule =
     let cnt = loop 0 0 in
     if cnt > 0 then
       Some
-        {
-          id = "TYPO-056";
-          severity = Warning;
-          message = "Legacy TeX accents present despite UTF‑8 input";
-          count = cnt;
-        }
+        (mk_result ~id:"TYPO-056" ~severity:Warning
+           ~message:"Legacy TeX accents present despite UTF‑8 input" ~count:cnt)
     else None
   in
   { id = "TYPO-056"; run; languages = [] }
@@ -1485,12 +1270,9 @@ let r_typo_058 : rule =
     in
     if cnt > 0 then
       Some
-        {
-          id = "TYPO-058";
-          severity = Warning;
-          message = "Greek homograph letters used in Latin words (ϲ,ɑ,ᴦ…)";
-          count = cnt;
-        }
+        (mk_result ~id:"TYPO-058" ~severity:Warning
+           ~message:"Greek homograph letters used in Latin words (ϲ,ɑ,ᴦ…)"
+           ~count:cnt)
     else None
   in
   { id = "TYPO-058"; run; languages = [] }
@@ -1544,13 +1326,10 @@ let r_typo_060 : rule =
     in
     if cnt > 0 then
       Some
-        {
-          id = "TYPO-060";
-          severity = Warning;
-          message =
-            {|Smart quotes present inside \lstlisting / verbatim environments|};
-          count = cnt;
-        }
+        (mk_result ~id:"TYPO-060" ~severity:Warning
+           ~message:
+             {|Smart quotes present inside \lstlisting / verbatim environments|}
+           ~count:cnt)
     else None
   in
   { id = "TYPO-060"; run; languages = [] }

--- a/latex-parse/src/validators_l1.ml
+++ b/latex-parse/src/validators_l1.ml
@@ -15,14 +15,11 @@ let l1_mod_001_rule : rule =
     in
     if cnt > 0 then
       Some
-        {
-          id = "MOD-001";
-          severity = Warning;
-          message =
-            "Legacy font commands (\\bf/\\it/...) present; prefer \
-             \\textbf/\\emph";
-          count = cnt;
-        }
+        (mk_result ~id:"MOD-001" ~severity:Warning
+           ~message:
+             "Legacy font commands (\\bf/\\it/...) present; prefer \
+              \\textbf/\\emph"
+           ~count:cnt)
     else None
   in
   { id = "MOD-001"; run; languages = [] }
@@ -40,13 +37,10 @@ let l1_exp_001_rule : rule =
     in
     if cnt > 0 then
       Some
-        {
-          id = "EXP-001";
-          severity = Info;
-          message =
-            "Incomplete expansion: catalogue commands remain post-expansion";
-          count = cnt;
-        }
+        (mk_result ~id:"EXP-001" ~severity:Info
+           ~message:
+             "Incomplete expansion: catalogue commands remain post-expansion"
+           ~count:cnt)
     else None
   in
   { id = "EXP-001"; run; languages = [] }
@@ -57,12 +51,9 @@ let l1_mod_002_rule : rule =
     let legacy = [ "bf" ] and modern = [ "textbf" ] in
     if has_mixed_in_paragraphs s ~legacy ~modern then
       Some
-        {
-          id = "MOD-002";
-          severity = Warning;
-          message = "Mixed legacy and modern bold commands in same paragraph";
-          count = 1;
-        }
+        (mk_result ~id:"MOD-002" ~severity:Warning
+           ~message:"Mixed legacy and modern bold commands in same paragraph"
+           ~count:1)
     else None
   in
   { id = "MOD-002"; run; languages = [] }
@@ -73,12 +64,9 @@ let l1_mod_003_rule : rule =
     let legacy = [ "it" ] and modern = [ "emph"; "textit" ] in
     if has_mixed_in_paragraphs s ~legacy ~modern then
       Some
-        {
-          id = "MOD-003";
-          severity = Warning;
-          message = "Mixed legacy and modern italic commands in same paragraph";
-          count = 1;
-        }
+        (mk_result ~id:"MOD-003" ~severity:Warning
+           ~message:"Mixed legacy and modern italic commands in same paragraph"
+           ~count:1)
     else None
   in
   { id = "MOD-003"; run; languages = [] }
@@ -90,12 +78,9 @@ let l1_mod_004_rule : rule =
     let legacy = [ "rm" ] and modern = [ "textrm" ] in
     if has_mixed_in_paragraphs s ~legacy ~modern then
       Some
-        {
-          id = "MOD-004";
-          severity = Warning;
-          message = "Mixed legacy and modern roman commands in same paragraph";
-          count = 1;
-        }
+        (mk_result ~id:"MOD-004" ~severity:Warning
+           ~message:"Mixed legacy and modern roman commands in same paragraph"
+           ~count:1)
     else None
   in
   { id = "MOD-004"; run; languages = [] }
@@ -106,13 +91,10 @@ let l1_mod_005_rule : rule =
     let legacy = [ "tt" ] and modern = [ "texttt" ] in
     if has_mixed_in_paragraphs s ~legacy ~modern then
       Some
-        {
-          id = "MOD-005";
-          severity = Warning;
-          message =
-            "Mixed legacy and modern typewriter commands in same paragraph";
-          count = 1;
-        }
+        (mk_result ~id:"MOD-005" ~severity:Warning
+           ~message:
+             "Mixed legacy and modern typewriter commands in same paragraph"
+           ~count:1)
     else None
   in
   { id = "MOD-005"; run; languages = [] }
@@ -123,13 +105,10 @@ let l1_mod_006_rule : rule =
     let legacy = [ "sf" ] and modern = [ "textsf" ] in
     if has_mixed_in_paragraphs s ~legacy ~modern then
       Some
-        {
-          id = "MOD-006";
-          severity = Warning;
-          message =
-            "Mixed legacy and modern sans-serif commands in same paragraph";
-          count = 1;
-        }
+        (mk_result ~id:"MOD-006" ~severity:Warning
+           ~message:
+             "Mixed legacy and modern sans-serif commands in same paragraph"
+           ~count:1)
     else None
   in
   { id = "MOD-006"; run; languages = [] }
@@ -140,13 +119,10 @@ let l1_mod_007_rule : rule =
     let legacy = [ "sc" ] and modern = [ "textsc" ] in
     if has_mixed_in_paragraphs s ~legacy ~modern then
       Some
-        {
-          id = "MOD-007";
-          severity = Warning;
-          message =
-            "Mixed legacy and modern small-caps commands in same paragraph";
-          count = 1;
-        }
+        (mk_result ~id:"MOD-007" ~severity:Warning
+           ~message:
+             "Mixed legacy and modern small-caps commands in same paragraph"
+           ~count:1)
     else None
   in
   { id = "MOD-007"; run; languages = [] }
@@ -158,12 +134,9 @@ let l1_mod_008_rule : rule =
     let legacy = [ "bfseries" ] and modern = [ "textbf" ] in
     if has_mixed_in_paragraphs s ~legacy ~modern then
       Some
-        {
-          id = "MOD-008";
-          severity = Warning;
-          message = "Mixed NFSS bfseries and inline \\textbf in same paragraph";
-          count = 1;
-        }
+        (mk_result ~id:"MOD-008" ~severity:Warning
+           ~message:"Mixed NFSS bfseries and inline \\textbf in same paragraph"
+           ~count:1)
     else None
   in
   { id = "MOD-008"; run; languages = [] }
@@ -175,13 +148,10 @@ let l1_mod_009_rule : rule =
     let legacy = [ "itshape" ] and modern = [ "textit"; "emph" ] in
     if has_mixed_in_paragraphs s ~legacy ~modern then
       Some
-        {
-          id = "MOD-009";
-          severity = Warning;
-          message =
-            "Mixed NFSS itshape and inline \\textit/\\emph in same paragraph";
-          count = 1;
-        }
+        (mk_result ~id:"MOD-009" ~severity:Warning
+           ~message:
+             "Mixed NFSS itshape and inline \\textit/\\emph in same paragraph"
+           ~count:1)
     else None
   in
   { id = "MOD-009"; run; languages = [] }
@@ -192,12 +162,9 @@ let l1_mod_010_rule : rule =
     let legacy = [ "sffamily" ] and modern = [ "textsf" ] in
     if has_mixed_in_paragraphs s ~legacy ~modern then
       Some
-        {
-          id = "MOD-010";
-          severity = Warning;
-          message = "Mixed NFSS sffamily and inline \\textsf in same paragraph";
-          count = 1;
-        }
+        (mk_result ~id:"MOD-010" ~severity:Warning
+           ~message:"Mixed NFSS sffamily and inline \\textsf in same paragraph"
+           ~count:1)
     else None
   in
   { id = "MOD-010"; run; languages = [] }
@@ -208,12 +175,9 @@ let l1_mod_011_rule : rule =
     let legacy = [ "ttfamily" ] and modern = [ "texttt" ] in
     if has_mixed_in_paragraphs s ~legacy ~modern then
       Some
-        {
-          id = "MOD-011";
-          severity = Warning;
-          message = "Mixed NFSS ttfamily and inline \\texttt in same paragraph";
-          count = 1;
-        }
+        (mk_result ~id:"MOD-011" ~severity:Warning
+           ~message:"Mixed NFSS ttfamily and inline \\texttt in same paragraph"
+           ~count:1)
     else None
   in
   { id = "MOD-011"; run; languages = [] }
@@ -224,12 +188,9 @@ let l1_mod_012_rule : rule =
     let legacy = [ "rmfamily" ] and modern = [ "textrm" ] in
     if has_mixed_in_paragraphs s ~legacy ~modern then
       Some
-        {
-          id = "MOD-012";
-          severity = Warning;
-          message = "Mixed NFSS rmfamily and inline \\textrm in same paragraph";
-          count = 1;
-        }
+        (mk_result ~id:"MOD-012" ~severity:Warning
+           ~message:"Mixed NFSS rmfamily and inline \\textrm in same paragraph"
+           ~count:1)
     else None
   in
   { id = "MOD-012"; run; languages = [] }
@@ -240,12 +201,9 @@ let l1_mod_013_rule : rule =
     let legacy = [ "scshape" ] and modern = [ "textsc" ] in
     if has_mixed_in_paragraphs s ~legacy ~modern then
       Some
-        {
-          id = "MOD-013";
-          severity = Warning;
-          message = "Mixed NFSS scshape and inline \\textsc in same paragraph";
-          count = 1;
-        }
+        (mk_result ~id:"MOD-013" ~severity:Warning
+           ~message:"Mixed NFSS scshape and inline \\textsc in same paragraph"
+           ~count:1)
     else None
   in
   { id = "MOD-013"; run; languages = [] }
@@ -255,14 +213,11 @@ let l1_mod_020_rule : rule =
     let names = extract_command_names _s in
     if has_global_mixing names [ "bfseries" ] [ "textbf" ] then
       Some
-        {
-          id = "MOD-020";
-          severity = Info;
-          message =
-            "Global mix: NFSS bfseries and inline \\textbf appear in different \
-             paragraphs";
-          count = 1;
-        }
+        (mk_result ~id:"MOD-020" ~severity:Info
+           ~message:
+             "Global mix: NFSS bfseries and inline \\textbf appear in \
+              different paragraphs"
+           ~count:1)
     else None
   in
   { id = "MOD-020"; run; languages = [] }
@@ -272,14 +227,11 @@ let l1_mod_021_rule : rule =
     let names = extract_command_names _s in
     if has_global_mixing names [ "itshape" ] [ "textit"; "emph" ] then
       Some
-        {
-          id = "MOD-021";
-          severity = Info;
-          message =
-            "Global mix: NFSS itshape and inline \\textit/\\emph appear in \
-             different paragraphs";
-          count = 1;
-        }
+        (mk_result ~id:"MOD-021" ~severity:Info
+           ~message:
+             "Global mix: NFSS itshape and inline \\textit/\\emph appear in \
+              different paragraphs"
+           ~count:1)
     else None
   in
   { id = "MOD-021"; run; languages = [] }
@@ -289,14 +241,11 @@ let l1_mod_022_rule : rule =
     let names = extract_command_names _s in
     if has_global_mixing names [ "rmfamily" ] [ "textrm" ] then
       Some
-        {
-          id = "MOD-022";
-          severity = Info;
-          message =
-            "Global mix: NFSS rmfamily and inline \\textrm appear in different \
-             paragraphs";
-          count = 1;
-        }
+        (mk_result ~id:"MOD-022" ~severity:Info
+           ~message:
+             "Global mix: NFSS rmfamily and inline \\textrm appear in \
+              different paragraphs"
+           ~count:1)
     else None
   in
   { id = "MOD-022"; run; languages = [] }
@@ -306,14 +255,11 @@ let l1_mod_023_rule : rule =
     let names = extract_command_names _s in
     if has_global_mixing names [ "sffamily" ] [ "textsf" ] then
       Some
-        {
-          id = "MOD-023";
-          severity = Info;
-          message =
-            "Global mix: NFSS sffamily and inline \\textsf appear in different \
-             paragraphs";
-          count = 1;
-        }
+        (mk_result ~id:"MOD-023" ~severity:Info
+           ~message:
+             "Global mix: NFSS sffamily and inline \\textsf appear in \
+              different paragraphs"
+           ~count:1)
     else None
   in
   { id = "MOD-023"; run; languages = [] }
@@ -323,14 +269,11 @@ let l1_mod_024_rule : rule =
     let names = extract_command_names _s in
     if has_global_mixing names [ "ttfamily" ] [ "texttt" ] then
       Some
-        {
-          id = "MOD-024";
-          severity = Info;
-          message =
-            "Global mix: NFSS ttfamily and inline \\texttt appear in different \
-             paragraphs";
-          count = 1;
-        }
+        (mk_result ~id:"MOD-024" ~severity:Info
+           ~message:
+             "Global mix: NFSS ttfamily and inline \\texttt appear in \
+              different paragraphs"
+           ~count:1)
     else None
   in
   { id = "MOD-024"; run; languages = [] }
@@ -360,12 +303,9 @@ let l1_delim_001_rule : rule =
     let imbalance = abs (!opens - !closes) in
     if imbalance > 0 then
       Some
-        {
-          id = "DELIM-001";
-          severity = Error;
-          message = "Unmatched delimiters { … } after macro expansion";
-          count = imbalance;
-        }
+        (mk_result ~id:"DELIM-001" ~severity:Error
+           ~message:"Unmatched delimiters { … } after macro expansion"
+           ~count:imbalance)
     else None
   in
   { id = "DELIM-001"; run; languages = [] }
@@ -394,12 +334,8 @@ let l1_delim_002_rule : rule =
     done;
     if !cnt > 0 then
       Some
-        {
-          id = "DELIM-002";
-          severity = Error;
-          message = "Extra closing } detected";
-          count = !cnt;
-        }
+        (mk_result ~id:"DELIM-002" ~severity:Error
+           ~message:"Extra closing } detected" ~count:!cnt)
     else None
   in
   { id = "DELIM-002"; run; languages = [] }
@@ -417,12 +353,8 @@ let l1_delim_003_rule : rule =
       math_segs;
     if !cnt > 0 then
       Some
-        {
-          id = "DELIM-003";
-          severity = Error;
-          message = "Unmatched \\left without \\right";
-          count = !cnt;
-        }
+        (mk_result ~id:"DELIM-003" ~severity:Error
+           ~message:"Unmatched \\left without \\right" ~count:!cnt)
     else None
   in
   { id = "DELIM-003"; run; languages = [] }
@@ -440,12 +372,8 @@ let l1_delim_004_rule : rule =
       math_segs;
     if !cnt > 0 then
       Some
-        {
-          id = "DELIM-004";
-          severity = Error;
-          message = "Unmatched \\right without \\left";
-          count = !cnt;
-        }
+        (mk_result ~id:"DELIM-004" ~severity:Error
+           ~message:"Unmatched \\right without \\left" ~count:!cnt)
     else None
   in
   { id = "DELIM-004"; run; languages = [] }
@@ -501,12 +429,9 @@ let l1_delim_005_rule : rule =
       math_segs;
     if !cnt > 0 then
       Some
-        {
-          id = "DELIM-005";
-          severity = Info;
-          message = {|Mismatched parenthesis sizing (\big vs \Bigg)|};
-          count = !cnt;
-        }
+        (mk_result ~id:"DELIM-005" ~severity:Info
+           ~message:{|Mismatched parenthesis sizing (\big vs \Bigg)|}
+           ~count:!cnt)
     else None
   in
   { id = "DELIM-005"; run; languages = [] }
@@ -581,12 +506,8 @@ let l1_delim_006_rule : rule =
     done;
     if !cnt > 0 then
       Some
-        {
-          id = "DELIM-006";
-          severity = Info;
-          message = {|\big delimiters used outside display math|};
-          count = !cnt;
-        }
+        (mk_result ~id:"DELIM-006" ~severity:Info
+           ~message:{|\big delimiters used outside display math|} ~count:!cnt)
     else None
   in
   { id = "DELIM-006"; run; languages = [] }
@@ -605,12 +526,9 @@ let l1_delim_007_rule : rule =
       math_segs;
     if !cnt > 0 then
       Some
-        {
-          id = "DELIM-007";
-          severity = Error;
-          message = {|Angle bracket \langle without matching \rangle|};
-          count = !cnt;
-        }
+        (mk_result ~id:"DELIM-007" ~severity:Error
+           ~message:{|Angle bracket \langle without matching \rangle|}
+           ~count:!cnt)
     else None
   in
   { id = "DELIM-007"; run; languages = [] }
@@ -634,12 +552,8 @@ let l1_delim_008_rule : rule =
       math_segs;
     if !cnt > 0 then
       Some
-        {
-          id = "DELIM-008";
-          severity = Info;
-          message = {|Empty \left. … \right. pair — redundant|};
-          count = !cnt;
-        }
+        (mk_result ~id:"DELIM-008" ~severity:Info
+           ~message:{|Empty \left. … \right. pair — redundant|} ~count:!cnt)
     else None
   in
   { id = "DELIM-008"; run; languages = [] }
@@ -672,12 +586,8 @@ let l1_delim_009_rule : rule =
       math_segs;
     if !cnt > 0 then
       Some
-        {
-          id = "DELIM-009";
-          severity = Warning;
-          message = "Nested delimiters: { … ( … ) … }";
-          count = !cnt;
-        }
+        (mk_result ~id:"DELIM-009" ~severity:Warning
+           ~message:"Nested delimiters: { … ( … ) … }" ~count:!cnt)
     else None
   in
   { id = "DELIM-009"; run; languages = [] }
@@ -751,12 +661,8 @@ let l1_delim_010_rule : rule =
       math_envs;
     if !cnt > 0 then
       Some
-        {
-          id = "DELIM-010";
-          severity = Info;
-          message = {|Display math uses \big instead of \Big|};
-          count = !cnt;
-        }
+        (mk_result ~id:"DELIM-010" ~severity:Info
+           ~message:{|Display math uses \big instead of \Big|} ~count:!cnt)
     else None
   in
   { id = "DELIM-010"; run; languages = [] }
@@ -778,12 +684,9 @@ let l1_delim_011_rule : rule =
       math_segs;
     if !cnt > 0 then
       Some
-        {
-          id = "DELIM-011";
-          severity = Warning;
-          message = {|\middle delimiter used without symmetric pair|};
-          count = !cnt;
-        }
+        (mk_result ~id:"DELIM-011" ~severity:Warning
+           ~message:{|\middle delimiter used without symmetric pair|}
+           ~count:!cnt)
     else None
   in
   { id = "DELIM-011"; run; languages = [] }
@@ -816,12 +719,8 @@ let l1_script_001_rule : rule =
       math_segs;
     if !cnt > 0 then
       Some
-        {
-          id = "SCRIPT-001";
-          severity = Warning;
-          message = "Multi‑char subscript without braces";
-          count = !cnt;
-        }
+        (mk_result ~id:"SCRIPT-001" ~severity:Warning
+           ~message:"Multi‑char subscript without braces" ~count:!cnt)
     else None
   in
   { id = "SCRIPT-001"; run; languages = [] }
@@ -853,12 +752,9 @@ let l1_script_002_rule : rule =
       math_segs;
     if !cnt > 0 then
       Some
-        {
-          id = "SCRIPT-002";
-          severity = Info;
-          message = {|Superscript dash typed ‘‑’ not \textsuperscript{--}|};
-          count = !cnt;
-        }
+        (mk_result ~id:"SCRIPT-002" ~severity:Info
+           ~message:{|Superscript dash typed ‘‑’ not \textsuperscript{--}|}
+           ~count:!cnt)
     else None
   in
   { id = "SCRIPT-002"; run; languages = [] }
@@ -873,12 +769,8 @@ let l1_script_003_rule : rule =
     List.iter (fun seg -> cnt := !cnt + count_re_matches re seg) math_segs;
     if !cnt > 0 then
       Some
-        {
-          id = "SCRIPT-003";
-          severity = Warning;
-          message = "Comma‑separated superscripts lack braces";
-          count = !cnt;
-        }
+        (mk_result ~id:"SCRIPT-003" ~severity:Warning
+           ~message:"Comma‑separated superscripts lack braces" ~count:!cnt)
     else None
   in
   { id = "SCRIPT-003"; run; languages = [] }
@@ -893,12 +785,8 @@ let l1_script_004_rule : rule =
     List.iter (fun seg -> cnt := !cnt + count_re_matches re seg) math_segs;
     if !cnt > 0 then
       Some
-        {
-          id = "SCRIPT-004";
-          severity = Info;
-          message = "Subscript after prime notation mis‑ordered";
-          count = !cnt;
-        }
+        (mk_result ~id:"SCRIPT-004" ~severity:Info
+           ~message:"Subscript after prime notation mis‑ordered" ~count:!cnt)
     else None
   in
   { id = "SCRIPT-004"; run; languages = [] }
@@ -942,12 +830,8 @@ let l1_script_005_rule : rule =
       math_segs;
     if !cnt > 0 then
       Some
-        {
-          id = "SCRIPT-005";
-          severity = Info;
-          message = {|Superscript uses letter l instead of \ell|};
-          count = !cnt;
-        }
+        (mk_result ~id:"SCRIPT-005" ~severity:Info
+           ~message:{|Superscript uses letter l instead of \ell|} ~count:!cnt)
     else None
   in
   { id = "SCRIPT-005"; run; languages = [] }
@@ -964,12 +848,8 @@ let l1_script_006_rule : rule =
       math_segs;
     if !cnt > 0 then
       Some
-        {
-          id = "SCRIPT-006";
-          severity = Info;
-          message = {|Degree symbol typed ° instead of ^\circ|};
-          count = !cnt;
-        }
+        (mk_result ~id:"SCRIPT-006" ~severity:Info
+           ~message:{|Degree symbol typed ° instead of ^\circ|} ~count:!cnt)
     else None
   in
   { id = "SCRIPT-006"; run; languages = [] }
@@ -1034,12 +914,8 @@ let l1_script_007_rule : rule =
       math_segs;
     if !cnt > 0 then
       Some
-        {
-          id = "SCRIPT-007";
-          severity = Warning;
-          message = {|Subscript text not wrapped in \text{}|};
-          count = !cnt;
-        }
+        (mk_result ~id:"SCRIPT-007" ~severity:Warning
+           ~message:{|Subscript text not wrapped in \text{}|} ~count:!cnt)
     else None
   in
   { id = "SCRIPT-007"; run; languages = [] }
@@ -1063,12 +939,9 @@ let l1_script_008_rule : rule =
       math_segs;
     if !cnt > 0 then
       Some
-        {
-          id = "SCRIPT-008";
-          severity = Info;
-          message = {|Chemical formula lacks \mathrm{} in subscript|};
-          count = !cnt;
-        }
+        (mk_result ~id:"SCRIPT-008" ~severity:Info
+           ~message:{|Chemical formula lacks \mathrm{} in subscript|}
+           ~count:!cnt)
     else None
   in
   { id = "SCRIPT-008"; run; languages = [] }
@@ -1084,12 +957,8 @@ let l1_script_009_rule : rule =
     List.iter (fun seg -> cnt := !cnt + count_re_matches re seg) math_segs;
     if !cnt > 0 then
       Some
-        {
-          id = "SCRIPT-009";
-          severity = Info;
-          message = "Isotope superscript mass number missing";
-          count = !cnt;
-        }
+        (mk_result ~id:"SCRIPT-009" ~severity:Info
+           ~message:"Isotope superscript mass number missing" ~count:!cnt)
     else None
   in
   { id = "SCRIPT-009"; run; languages = [] }
@@ -1106,12 +975,8 @@ let l1_script_010_rule : rule =
       inline_segs;
     if !cnt > 0 then
       Some
-        {
-          id = "SCRIPT-010";
-          severity = Info;
-          message = {|Use of \limits on inline operator|};
-          count = !cnt;
-        }
+        (mk_result ~id:"SCRIPT-010" ~severity:Info
+           ~message:{|Use of \limits on inline operator|} ~count:!cnt)
     else None
   in
   { id = "SCRIPT-010"; run; languages = [] }
@@ -1142,12 +1007,8 @@ let l1_script_011_rule : rule =
       math_segs;
     if !cnt > 0 then
       Some
-        {
-          id = "SCRIPT-011";
-          severity = Warning;
-          message = "Nested superscript three levels deep";
-          count = !cnt;
-        }
+        (mk_result ~id:"SCRIPT-011" ~severity:Warning
+           ~message:"Nested superscript three levels deep" ~count:!cnt)
     else None
   in
   { id = "SCRIPT-011"; run; languages = [] }
@@ -1161,12 +1022,8 @@ let l1_script_012_rule : rule =
     List.iter (fun seg -> cnt := !cnt + count_re_matches re seg) math_segs;
     if !cnt > 0 then
       Some
-        {
-          id = "SCRIPT-012";
-          severity = Info;
-          message = "Prime notation f''' (> 3) – prefer ^{(n)}";
-          count = !cnt;
-        }
+        (mk_result ~id:"SCRIPT-012" ~severity:Info
+           ~message:"Prime notation f''' (> 3) – prefer ^{(n)}" ~count:!cnt)
     else None
   in
   { id = "SCRIPT-012"; run; languages = [] }
@@ -1181,12 +1038,8 @@ let l1_script_013_rule : rule =
     List.iter (fun seg -> cnt := !cnt + count_re_matches re seg) math_segs;
     if !cnt > 0 then
       Some
-        {
-          id = "SCRIPT-013";
-          severity = Info;
-          message = "Plus/minus typed in subscript";
-          count = !cnt;
-        }
+        (mk_result ~id:"SCRIPT-013" ~severity:Info
+           ~message:"Plus/minus typed in subscript" ~count:!cnt)
     else None
   in
   { id = "SCRIPT-013"; run; languages = [] }
@@ -1218,12 +1071,8 @@ let l1_script_014_rule : rule =
       math_segs;
     if !cnt > 0 then
       Some
-        {
-          id = "SCRIPT-014";
-          severity = Info;
-          message = "Logarithm base subscript italic";
-          count = !cnt;
-        }
+        (mk_result ~id:"SCRIPT-014" ~severity:Info
+           ~message:"Logarithm base subscript italic" ~count:!cnt)
     else None
   in
   { id = "SCRIPT-014"; run; languages = [] }
@@ -1238,12 +1087,8 @@ let l1_script_015_rule : rule =
     List.iter (fun seg -> cnt := !cnt + count_re_matches re seg) math_segs;
     if !cnt > 0 then
       Some
-        {
-          id = "SCRIPT-015";
-          severity = Info;
-          message = "Time derivative dot mis‑aligned";
-          count = !cnt;
-        }
+        (mk_result ~id:"SCRIPT-015" ~severity:Info
+           ~message:"Time derivative dot mis‑aligned" ~count:!cnt)
     else None
   in
   { id = "SCRIPT-015"; run; languages = [] }
@@ -1308,12 +1153,8 @@ let l1_script_016_rule : rule =
       math_segs;
     if !cnt > 0 then
       Some
-        {
-          id = "SCRIPT-016";
-          severity = Info;
-          message = {|Prime on Greek letter typed '' not ^\prime|};
-          count = !cnt;
-        }
+        (mk_result ~id:"SCRIPT-016" ~severity:Info
+           ~message:{|Prime on Greek letter typed '' not ^\prime|} ~count:!cnt)
     else None
   in
   { id = "SCRIPT-016"; run; languages = [] }
@@ -1339,12 +1180,9 @@ let l1_script_017_rule : rule =
     (* Fire only if both orderings are used *)
     if !sub_sup_count > 0 && !sup_sub_count > 0 then
       Some
-        {
-          id = "SCRIPT-017";
-          severity = Info;
-          message = "Inconsistent order of sub/superscripts";
-          count = min !sub_sup_count !sup_sub_count;
-        }
+        (mk_result ~id:"SCRIPT-017" ~severity:Info
+           ~message:"Inconsistent order of sub/superscripts"
+           ~count:(min !sub_sup_count !sup_sub_count))
     else None
   in
   { id = "SCRIPT-017"; run; languages = [] }
@@ -1372,12 +1210,8 @@ let l1_script_018_rule : rule =
       math_segs;
     if !cnt > 0 then
       Some
-        {
-          id = "SCRIPT-018";
-          severity = Warning;
-          message = "Degree symbol in superscript without braces";
-          count = !cnt;
-        }
+        (mk_result ~id:"SCRIPT-018" ~severity:Warning
+           ~message:"Degree symbol in superscript without braces" ~count:!cnt)
     else None
   in
   { id = "SCRIPT-018"; run; languages = [] }
@@ -1409,12 +1243,8 @@ let l1_script_019_rule : rule =
       math_segs;
     if !cnt > 0 then
       Some
-        {
-          id = "SCRIPT-019";
-          severity = Info;
-          message = {|Double prime '' instead of ^{\prime\prime}|};
-          count = !cnt;
-        }
+        (mk_result ~id:"SCRIPT-019" ~severity:Info
+           ~message:{|Double prime '' instead of ^{\prime\prime}|} ~count:!cnt)
     else None
   in
   { id = "SCRIPT-019"; run; languages = [] }
@@ -1477,12 +1307,8 @@ let l1_script_020_rule : rule =
       math_segs;
     if !cnt > 0 then
       Some
-        {
-          id = "SCRIPT-020";
-          severity = Info;
-          message = {|Subscript text italic instead of \mathrm|};
-          count = !cnt;
-        }
+        (mk_result ~id:"SCRIPT-020" ~severity:Info
+           ~message:{|Subscript text italic instead of \mathrm|} ~count:!cnt)
     else None
   in
   { id = "SCRIPT-020"; run; languages = [] }
@@ -1499,12 +1325,9 @@ let l1_script_021_rule : rule =
     List.iter (fun seg -> cnt := !cnt + count_re_matches re seg) math_segs;
     if !cnt > 0 then
       Some
-        {
-          id = "SCRIPT-021";
-          severity = Warning;
-          message = "Sub‑sup order not canonical (a_{b}^{c} vs a^{c}_{b})";
-          count = !cnt;
-        }
+        (mk_result ~id:"SCRIPT-021" ~severity:Warning
+           ~message:"Sub‑sup order not canonical (a_{b}^{c} vs a^{c}_{b})"
+           ~count:!cnt)
     else None
   in
   { id = "SCRIPT-021"; run; languages = [] }
@@ -1519,12 +1342,8 @@ let l1_script_022_rule : rule =
     List.iter (fun seg -> cnt := !cnt + count_re_matches re seg) math_segs;
     if !cnt > 0 then
       Some
-        {
-          id = "SCRIPT-022";
-          severity = Info;
-          message = "Superscript prime stacked > 3 – prefer ^{(n)}";
-          count = !cnt;
-        }
+        (mk_result ~id:"SCRIPT-022" ~severity:Info
+           ~message:"Superscript prime stacked > 3 – prefer ^{(n)}" ~count:!cnt)
     else None
   in
   { id = "SCRIPT-022"; run; languages = [] }
@@ -1550,12 +1369,8 @@ let l1_ref_001_rule : rule =
     in
     if cnt > 0 then
       Some
-        {
-          id = "REF-001";
-          severity = Error;
-          message = {|Undefined \ref / \eqref label after expansion|};
-          count = cnt;
-        }
+        (mk_result ~id:"REF-001" ~severity:Error
+           ~message:{|Undefined \ref / \eqref label after expansion|} ~count:cnt)
     else None
   in
   { id = "REF-001"; run; languages = [] }
@@ -1593,12 +1408,8 @@ let l1_ref_002_rule : rule =
     in
     if cnt > 0 then
       Some
-        {
-          id = "REF-002";
-          severity = Error;
-          message = "Duplicate label name";
-          count = cnt;
-        }
+        (mk_result ~id:"REF-002" ~severity:Error ~message:"Duplicate label name"
+           ~count:cnt)
     else None
   in
   { id = "REF-002"; run; languages = [] }
@@ -1611,12 +1422,8 @@ let l1_ref_003_rule : rule =
     List.iter (fun lbl -> if String.contains lbl ' ' then incr cnt) labels;
     if !cnt > 0 then
       Some
-        {
-          id = "REF-003";
-          severity = Warning;
-          message = "Label contains spaces";
-          count = !cnt;
-        }
+        (mk_result ~id:"REF-003" ~severity:Warning
+           ~message:"Label contains spaces" ~count:!cnt)
     else None
   in
   { id = "REF-003"; run; languages = [] }
@@ -1638,12 +1445,8 @@ let l1_ref_004_rule : rule =
     List.iter (fun lbl -> if has_upper lbl then incr cnt) labels;
     if !cnt > 0 then
       Some
-        {
-          id = "REF-004";
-          severity = Info;
-          message = "Label contains uppercase letters";
-          count = !cnt;
-        }
+        (mk_result ~id:"REF-004" ~severity:Info
+           ~message:"Label contains uppercase letters" ~count:!cnt)
     else None
   in
   { id = "REF-004"; run; languages = [] }
@@ -1682,12 +1485,8 @@ let l1_ref_005_rule : rule =
     List.iter (fun lbl -> if not (has_prefix lbl) then incr cnt) labels;
     if !cnt > 0 then
       Some
-        {
-          id = "REF-005";
-          severity = Info;
-          message = "Label not prefixed fig:/tab:/eq:/sec:";
-          count = !cnt;
-        }
+        (mk_result ~id:"REF-005" ~severity:Info
+           ~message:"Label not prefixed fig:/tab:/eq:/sec:" ~count:!cnt)
     else None
   in
   { id = "REF-005"; run; languages = [] }
@@ -1699,12 +1498,8 @@ let l1_ref_006_rule : rule =
     let cnt = count_re_matches re s in
     if cnt > 0 then
       Some
-        {
-          id = "REF-006";
-          severity = Info;
-          message = {|Page reference uses \ref not \pageref|};
-          count = cnt;
-        }
+        (mk_result ~id:"REF-006" ~severity:Info
+           ~message:{|Page reference uses \ref not \pageref|} ~count:cnt)
     else None
   in
   { id = "REF-006"; run; languages = [] }
@@ -1716,12 +1511,8 @@ let l1_ref_007_rule : rule =
     let cnt = count_re_matches re s in
     if cnt > 0 then
       Some
-        {
-          id = "REF-007";
-          severity = Error;
-          message = "Cite key contains whitespace";
-          count = cnt;
-        }
+        (mk_result ~id:"REF-007" ~severity:Error
+           ~message:"Cite key contains whitespace" ~count:cnt)
     else None
   in
   { id = "REF-007"; run; languages = [] }
@@ -1772,12 +1563,9 @@ let l1_ref_009_rule : rule =
     in
     if cnt > 0 then
       Some
-        {
-          id = "REF-009";
-          severity = Info;
-          message = "Reference appears before label definition (forward ref)";
-          count = cnt;
-        }
+        (mk_result ~id:"REF-009" ~severity:Info
+           ~message:"Reference appears before label definition (forward ref)"
+           ~count:cnt)
     else None
   in
   { id = "REF-009"; run; languages = [] }
@@ -1800,12 +1588,8 @@ let l1_chem_001_rule : rule =
       math_segs;
     if !cnt > 0 then
       Some
-        {
-          id = "CHEM-001";
-          severity = Warning;
-          message = {|Missing \ce{} wrapper for chemical formula|};
-          count = !cnt;
-        }
+        (mk_result ~id:"CHEM-001" ~severity:Warning
+           ~message:{|Missing \ce{} wrapper for chemical formula|} ~count:!cnt)
     else None
   in
   { id = "CHEM-001"; run; languages = [] }
@@ -1820,12 +1604,8 @@ let l1_chem_002_rule : rule =
     List.iter (fun seg -> cnt := !cnt + count_re_matches re seg) math_segs;
     if !cnt > 0 then
       Some
-        {
-          id = "CHEM-002";
-          severity = Warning;
-          message = "Oxidation‑state superscript missing braces";
-          count = !cnt;
-        }
+        (mk_result ~id:"CHEM-002" ~severity:Warning
+           ~message:"Oxidation‑state superscript missing braces" ~count:!cnt)
     else None
   in
   { id = "CHEM-002"; run; languages = [] }
@@ -1844,12 +1624,9 @@ let l1_chem_003_rule : rule =
       math_segs;
     if !cnt > 0 then
       Some
-        {
-          id = "CHEM-003";
-          severity = Warning;
-          message = "Isotope mass number subscripted, not superscripted";
-          count = !cnt;
-        }
+        (mk_result ~id:"CHEM-003" ~severity:Warning
+           ~message:"Isotope mass number subscripted, not superscripted"
+           ~count:!cnt)
     else None
   in
   { id = "CHEM-003"; run; languages = [] }
@@ -1863,12 +1640,8 @@ let l1_chem_004_rule : rule =
     List.iter (fun seg -> cnt := !cnt + count_re_matches re seg) math_segs;
     if !cnt > 0 then
       Some
-        {
-          id = "CHEM-004";
-          severity = Info;
-          message = "Charge written ^- instead of ^{-}";
-          count = !cnt;
-        }
+        (mk_result ~id:"CHEM-004" ~severity:Info
+           ~message:"Charge written ^- instead of ^{-}" ~count:!cnt)
     else None
   in
   { id = "CHEM-004"; run; languages = [] }
@@ -1889,12 +1662,8 @@ let l1_chem_005_rule : rule =
       math_segs;
     if !cnt > 0 then
       Some
-        {
-          id = "CHEM-005";
-          severity = Info;
-          message = {|Chemical arrow typed '->' not \rightarrow|};
-          count = !cnt;
-        }
+        (mk_result ~id:"CHEM-005" ~severity:Info
+           ~message:{|Chemical arrow typed '->' not \rightarrow|} ~count:!cnt)
     else None
   in
   { id = "CHEM-005"; run; languages = [] }
@@ -1943,12 +1712,8 @@ let l1_chem_006_rule : rule =
     done;
     if !cnt > 0 then
       Some
-        {
-          id = "CHEM-006";
-          severity = Warning;
-          message = {|Stoichiometry coefficient inside \ce missing|};
-          count = !cnt;
-        }
+        (mk_result ~id:"CHEM-006" ~severity:Warning
+           ~message:{|Stoichiometry coefficient inside \ce missing|} ~count:!cnt)
     else None
   in
   { id = "CHEM-006"; run; languages = [] }
@@ -1988,12 +1753,8 @@ let l1_chem_007_rule : rule =
       math_segs;
     if !cnt > 0 then
       Some
-        {
-          id = "CHEM-007";
-          severity = Info;
-          message = {|Reaction conditions not in \text above arrow|};
-          count = !cnt;
-        }
+        (mk_result ~id:"CHEM-007" ~severity:Info
+           ~message:{|Reaction conditions not in \text above arrow|} ~count:!cnt)
     else None
   in
   { id = "CHEM-007"; run; languages = [] }
@@ -2016,12 +1777,8 @@ let l1_chem_008_rule : rule =
       math_segs;
     if !cnt > 0 then
       Some
-        {
-          id = "CHEM-008";
-          severity = Info;
-          message = {|State symbols (aq) not wrapped in \text|};
-          count = !cnt;
-        }
+        (mk_result ~id:"CHEM-008" ~severity:Info
+           ~message:{|State symbols (aq) not wrapped in \text|} ~count:!cnt)
     else None
   in
   { id = "CHEM-008"; run; languages = [] }
@@ -2040,12 +1797,8 @@ let l1_chem_009_rule : rule =
       math_segs;
     if !cnt > 0 then
       Some
-        {
-          id = "CHEM-009";
-          severity = Warning;
-          message = "Equilibrium arrow typed as '<>'";
-          count = !cnt;
-        }
+        (mk_result ~id:"CHEM-009" ~severity:Warning
+           ~message:"Equilibrium arrow typed as '<>'" ~count:!cnt)
     else None
   in
   { id = "CHEM-009"; run; languages = [] }
@@ -2098,12 +1851,9 @@ let l1_cmd_007_rule : rule =
      with Not_found -> ());
     if !cnt > 0 then
       Some
-        {
-          id = "CMD-007";
-          severity = Info;
-          message = "Optional argument not used inside definition body";
-          count = !cnt;
-        }
+        (mk_result ~id:"CMD-007" ~severity:Info
+           ~message:"Optional argument not used inside definition body"
+           ~count:!cnt)
     else None
   in
   { id = "CMD-007"; run; languages = [] }
@@ -2127,12 +1877,8 @@ let l1_cmd_010_rule : rule =
       lines;
     if !cnt > 0 then
       Some
-        {
-          id = "CMD-010";
-          severity = Info;
-          message = "More than three successive macro renewals";
-          count = !cnt;
-        }
+        (mk_result ~id:"CMD-010" ~severity:Info
+           ~message:"More than three successive macro renewals" ~count:!cnt)
     else None
   in
   { id = "CMD-010"; run; languages = [] }
@@ -2171,12 +1917,9 @@ let l1_font_001_rule : rule =
     done;
     if !cnt > 0 then
       Some
-        {
-          id = "FONT-001";
-          severity = Info;
-          message = "Small‑caps applied to all‑caps word (ineffective)";
-          count = !cnt;
-        }
+        (mk_result ~id:"FONT-001" ~severity:Info
+           ~message:"Small‑caps applied to all‑caps word (ineffective)"
+           ~count:!cnt)
     else None
   in
   { id = "FONT-001"; run; languages = [] }
@@ -2197,12 +1940,9 @@ let l1_font_004_rule : rule =
       math_segs;
     if !cnt > 0 then
       Some
-        {
-          id = "FONT-004";
-          severity = Info;
-          message = {|Font change inside math via \textit not \mathit|};
-          count = !cnt;
-        }
+        (mk_result ~id:"FONT-004" ~severity:Info
+           ~message:{|Font change inside math via \textit not \mathit|}
+           ~count:!cnt)
     else None
   in
   { id = "FONT-004"; run; languages = [] }
@@ -2214,12 +1954,9 @@ let l1_rtl_003_rule : rule =
     let closes = count_substring s "\\endR" in
     if opens <> closes && (opens > 0 || closes > 0) then
       Some
-        {
-          id = "RTL-003";
-          severity = Error;
-          message = {|Unbalanced \beginR / \endR primitives|};
-          count = abs (opens - closes);
-        }
+        (mk_result ~id:"RTL-003" ~severity:Error
+           ~message:{|Unbalanced \beginR / \endR primitives|}
+           ~count:(abs (opens - closes)))
     else None
   in
   { id = "RTL-003"; run; languages = [ "ar"; "he" ] }
@@ -2239,12 +1976,8 @@ let l1_rtl_004_rule : rule =
       math_segs;
     if !cnt > 0 then
       Some
-        {
-          id = "RTL-004";
-          severity = Warning;
-          message = "RTL punctuation not mirrored in math";
-          count = !cnt;
-        }
+        (mk_result ~id:"RTL-004" ~severity:Warning
+           ~message:"RTL punctuation not mirrored in math" ~count:!cnt)
     else None
   in
   { id = "RTL-004"; run; languages = [ "ar"; "he" ] }
@@ -2260,12 +1993,8 @@ let l1_cjk_008_rule : rule =
       math_segs;
     if !cnt > 0 then
       Some
-        {
-          id = "CJK-008";
-          severity = Warning;
-          message = "Full‑width space U+3000 inside math mode";
-          count = !cnt;
-        }
+        (mk_result ~id:"CJK-008" ~severity:Warning
+           ~message:"Full‑width space U+3000 inside math mode" ~count:!cnt)
     else None
   in
   { id = "CJK-008"; run; languages = [ "zh"; "ja"; "ko" ] }
@@ -2281,12 +2010,8 @@ let l1_cjk_015_rule : rule =
       math_segs;
     if !cnt > 0 then
       Some
-        {
-          id = "CJK-015";
-          severity = Warning;
-          message = "Chinese comma U+3001 inside math mode";
-          count = !cnt;
-        }
+        (mk_result ~id:"CJK-015" ~severity:Warning
+           ~message:"Chinese comma U+3001 inside math mode" ~count:!cnt)
     else None
   in
   { id = "CJK-015"; run; languages = [ "zh"; "ja"; "ko" ] }
@@ -2300,12 +2025,9 @@ let l1_typo_059_rule : rule =
     List.iter (fun seg -> cnt := !cnt + count_re_matches re seg) math_segs;
     if !cnt > 0 then
       Some
-        {
-          id = "TYPO-059";
-          severity = Info;
-          message = "Punctuation inside math must be typed with spacing macros";
-          count = !cnt;
-        }
+        (mk_result ~id:"TYPO-059" ~severity:Info
+           ~message:"Punctuation inside math must be typed with spacing macros"
+           ~count:!cnt)
     else None
   in
   { id = "TYPO-059"; run; languages = [] }
@@ -2333,12 +2055,9 @@ let l1_pt_002_rule : rule =
       List.iter (fun seg -> cnt := !cnt + count_re_matches re_num seg) math_segs;
       if !cnt > 0 then
         Some
-          {
-            id = "PT-002";
-            severity = Info;
-            message = "pt‑BR: decimal comma and thousand dot enforcement";
-            count = !cnt;
-          }
+          (mk_result ~id:"PT-002" ~severity:Info
+             ~message:"pt‑BR: decimal comma and thousand dot enforcement"
+             ~count:!cnt)
       else None)
     else None
   in
@@ -2382,12 +2101,9 @@ let l1_l3_001_rule : rule =
     in
     if has_expl3 && has_2e then
       Some
-        {
-          id = "L3-001";
-          severity = Info;
-          message = {|LaTeX3 \tl_new:N in preamble mixed with 2e macros|};
-          count = 1;
-        }
+        (mk_result ~id:"L3-001" ~severity:Info
+           ~message:{|LaTeX3 \tl_new:N in preamble mixed with 2e macros|}
+           ~count:1)
     else None
   in
   { id = "L3-001"; run; languages = [] }
@@ -2413,12 +2129,9 @@ let l1_l3_002_rule : rule =
       let cnt = count_re_matches re_expl3_decl body in
       if cnt > 0 then
         Some
-          {
-            id = "L3-002";
-            severity = Warning;
-            message = {|Expl3 variable declared after \begin{document}|};
-            count = cnt;
-          }
+          (mk_result ~id:"L3-002" ~severity:Warning
+             ~message:{|Expl3 variable declared after \begin{document}|}
+             ~count:cnt)
       else None
   in
   { id = "L3-002"; run; languages = [] }
@@ -2449,12 +2162,8 @@ let l1_l3_003_rule : rule =
     in
     if has_expl3 && has_etoolbox then
       Some
-        {
-          id = "L3-003";
-          severity = Warning;
-          message = "Expl3 and etoolbox patch macros combined";
-          count = 1;
-        }
+        (mk_result ~id:"L3-003" ~severity:Warning
+           ~message:"Expl3 and etoolbox patch macros combined" ~count:1)
     else None
   in
   { id = "L3-003"; run; languages = [] }
@@ -2466,12 +2175,8 @@ let l1_l3_004_rule : rule =
     let cnt = count_re_matches re s in
     if cnt > 0 then
       Some
-        {
-          id = "L3-004";
-          severity = Info;
-          message = {|Undocumented \__module_internal:N used|};
-          count = cnt;
-        }
+        (mk_result ~id:"L3-004" ~severity:Info
+           ~message:{|Undocumented \__module_internal:N used|} ~count:cnt)
     else None
   in
   { id = "L3-004"; run; languages = [] }
@@ -2499,12 +2204,8 @@ let l1_l3_005_rule : rule =
       in
       if not has_guard then
         Some
-          {
-            id = "L3-005";
-            severity = Error;
-            message = {|Missing \ExplSyntaxOn guard around expl3 code|};
-            count = 1;
-          }
+          (mk_result ~id:"L3-005" ~severity:Error
+             ~message:{|Missing \ExplSyntaxOn guard around expl3 code|} ~count:1)
       else None
   in
   { id = "L3-005"; run; languages = [] }
@@ -2542,12 +2243,8 @@ let l1_l3_006_rule : rule =
        with Not_found -> ());
       if !cnt > 0 then
         Some
-          {
-            id = "L3-006";
-            severity = Warning;
-            message = "Expl3 variable clobbers package macro name";
-            count = !cnt;
-          }
+          (mk_result ~id:"L3-006" ~severity:Warning
+             ~message:"Expl3 variable clobbers package macro name" ~count:!cnt)
       else None
   in
   { id = "L3-006"; run; languages = [] }
@@ -2571,12 +2268,9 @@ let l1_l3_007_rule : rule =
       let cnt = count_re_matches re_camel s in
       if cnt > 0 then
         Some
-          {
-            id = "L3-007";
-            severity = Info;
-            message = "Mix of camelCase and snake_case in expl3 names";
-            count = cnt;
-          }
+          (mk_result ~id:"L3-007" ~severity:Info
+             ~message:"Mix of camelCase and snake_case in expl3 names"
+             ~count:cnt)
       else None
   in
   { id = "L3-007"; run; languages = [] }
@@ -2600,12 +2294,8 @@ let l1_l3_009_rule : rule =
     in
     if cnt > 0 then
       Some
-        {
-          id = "L3-009";
-          severity = Info;
-          message = "LaTeX3 function deprecated _n: variant used";
-          count = cnt;
-        }
+        (mk_result ~id:"L3-009" ~severity:Info
+           ~message:"LaTeX3 function deprecated _n: variant used" ~count:cnt)
     else None
   in
   { id = "L3-009"; run; languages = [] }
@@ -2652,12 +2342,9 @@ let l1_l3_011_rule : rule =
       in
       if cnt > 0 then
         Some
-          {
-            id = "L3-011";
-            severity = Warning;
-            message = "Engine‑branch uses pdfTeX primitive in Lua/XeTeX path";
-            count = cnt;
-          }
+          (mk_result ~id:"L3-011" ~severity:Warning
+             ~message:"Engine‑branch uses pdfTeX primitive in Lua/XeTeX path"
+             ~count:cnt)
       else None
   in
   { id = "L3-011"; run; languages = [] }
@@ -2732,12 +2419,8 @@ let l1_cmd_001_rule : rule =
     in
     if cnt > 0 then
       Some
-        {
-          id = "CMD-001";
-          severity = Info;
-          message = {|Command \newcommand defined but never used|};
-          count = cnt;
-        }
+        (mk_result ~id:"CMD-001" ~severity:Info
+           ~message:{|Command \newcommand defined but never used|} ~count:cnt)
     else None
   in
   { id = "CMD-001"; run; languages = [] }
@@ -2796,12 +2479,8 @@ let l1_cmd_003_rule : rule =
      with Not_found -> ());
     if !cnt > 0 then
       Some
-        {
-          id = "CMD-003";
-          severity = Warning;
-          message = "User macro name clashes with package macro";
-          count = !cnt;
-        }
+        (mk_result ~id:"CMD-003" ~severity:Warning
+           ~message:"User macro name clashes with package macro" ~count:!cnt)
     else None
   in
   { id = "CMD-003"; run; languages = [] }

--- a/latex-parse/src/validators_l1_expl3.ml
+++ b/latex-parse/src/validators_l1_expl3.ml
@@ -46,13 +46,10 @@ let r_char_004 : rule =
     done;
     if !cnt > 0 then
       Some
-        {
-          id = "CHAR-004";
-          severity = Info;
-          message =
-            "Private-use Unicode (U+E000\xe2\x80\x93F8FF) codepoint found";
-          count = !cnt;
-        }
+        (mk_result ~id:"CHAR-004" ~severity:Info
+           ~message:
+             "Private-use Unicode (U+E000\xe2\x80\x93F8FF) codepoint found"
+           ~count:!cnt)
     else None
   in
   mk_rule "CHAR-004" run
@@ -91,13 +88,10 @@ let r_math_006 : rule =
       math_segs;
     if !cnt > 0 then
       Some
-        {
-          id = "MATH-006";
-          severity = Info;
-          message =
-            {|Bra-ket notation: \langle...\rangle without \mid or | separator|};
-          count = !cnt;
-        }
+        (mk_result ~id:"MATH-006" ~severity:Info
+           ~message:
+             {|Bra-ket notation: \langle...\rangle without \mid or | separator|}
+           ~count:!cnt)
     else None
   in
   mk_rule "MATH-006" run
@@ -136,12 +130,9 @@ let r_l3_001 : rule =
     in
     if has_expl3 && has_2e then
       Some
-        {
-          id = "L3-001";
-          severity = Info;
-          message = {|LaTeX3 \tl_new:N in preamble mixed with 2e macros|};
-          count = 1;
-        }
+        (mk_result ~id:"L3-001" ~severity:Info
+           ~message:{|LaTeX3 \tl_new:N in preamble mixed with 2e macros|}
+           ~count:1)
     else None
   in
   mk_rule "L3-001" run
@@ -167,12 +158,9 @@ let r_l3_002 : rule =
       let cnt = count_re_matches re_expl3_decl body in
       if cnt > 0 then
         Some
-          {
-            id = "L3-002";
-            severity = Warning;
-            message = {|Expl3 variable declared after \begin{document}|};
-            count = cnt;
-          }
+          (mk_result ~id:"L3-002" ~severity:Warning
+             ~message:{|Expl3 variable declared after \begin{document}|}
+             ~count:cnt)
       else None
   in
   mk_rule "L3-002" run
@@ -203,12 +191,8 @@ let r_l3_003 : rule =
     in
     if has_expl3 && has_etoolbox then
       Some
-        {
-          id = "L3-003";
-          severity = Warning;
-          message = "Expl3 and etoolbox patch macros combined";
-          count = 1;
-        }
+        (mk_result ~id:"L3-003" ~severity:Warning
+           ~message:"Expl3 and etoolbox patch macros combined" ~count:1)
     else None
   in
   mk_rule "L3-003" run
@@ -220,12 +204,8 @@ let r_l3_004 : rule =
     let cnt = count_re_matches re s in
     if cnt > 0 then
       Some
-        {
-          id = "L3-004";
-          severity = Info;
-          message = {|Undocumented \__module_internal:N used|};
-          count = cnt;
-        }
+        (mk_result ~id:"L3-004" ~severity:Info
+           ~message:{|Undocumented \__module_internal:N used|} ~count:cnt)
     else None
   in
   mk_rule "L3-004" run
@@ -253,12 +233,8 @@ let r_l3_005 : rule =
       in
       if not has_guard then
         Some
-          {
-            id = "L3-005";
-            severity = Error;
-            message = {|Missing \ExplSyntaxOn guard around expl3 code|};
-            count = 1;
-          }
+          (mk_result ~id:"L3-005" ~severity:Error
+             ~message:{|Missing \ExplSyntaxOn guard around expl3 code|} ~count:1)
       else None
   in
   mk_rule "L3-005" run
@@ -282,12 +258,9 @@ let r_l3_007 : rule =
       let cnt = count_re_matches re_camel s in
       if cnt > 0 then
         Some
-          {
-            id = "L3-007";
-            severity = Info;
-            message = "Mix of camelCase and snake_case in expl3 names";
-            count = cnt;
-          }
+          (mk_result ~id:"L3-007" ~severity:Info
+             ~message:"Mix of camelCase and snake_case in expl3 names"
+             ~count:cnt)
       else None
   in
   mk_rule "L3-007" run
@@ -317,12 +290,8 @@ let r_l3_008 : rule =
     in
     if has_expl3 && not has_provides then
       Some
-        {
-          id = "L3-008";
-          severity = Warning;
-          message = {|Expl3 module lacks \ProvidesExplPackage|};
-          count = 1;
-        }
+        (mk_result ~id:"L3-008" ~severity:Warning
+           ~message:{|Expl3 module lacks \ProvidesExplPackage|} ~count:1)
     else None
   in
   mk_rule "L3-008" run
@@ -346,12 +315,8 @@ let r_l3_009 : rule =
     in
     if cnt > 0 then
       Some
-        {
-          id = "L3-009";
-          severity = Info;
-          message = "LaTeX3 function deprecated _n: variant used";
-          count = cnt;
-        }
+        (mk_result ~id:"L3-009" ~severity:Info
+           ~message:"LaTeX3 function deprecated _n: variant used" ~count:cnt)
     else None
   in
   mk_rule "L3-009" run
@@ -377,12 +342,9 @@ let r_l3_010 : rule =
     let off_count = count_m off_re s in
     if on_count > 0 && on_count > off_count then
       Some
-        {
-          id = "L3-010";
-          severity = Info;
-          message = {|\ExplSyntaxOff missing at end of file|};
-          count = on_count - off_count;
-        }
+        (mk_result ~id:"L3-010" ~severity:Info
+           ~message:{|\ExplSyntaxOff missing at end of file|}
+           ~count:(on_count - off_count))
     else None
   in
   mk_rule "L3-010" run
@@ -437,13 +399,11 @@ let r_l3_011 : rule =
       in
       if cnt > 0 then
         Some
-          {
-            id = "L3-011";
-            severity = Warning;
-            message =
-              "Engine\xe2\x80\x91branch uses pdfTeX primitive in Lua/XeTeX path";
-            count = cnt;
-          }
+          (mk_result ~id:"L3-011" ~severity:Warning
+             ~message:
+               "Engine\xe2\x80\x91branch uses pdfTeX primitive in Lua/XeTeX \
+                path"
+             ~count:cnt)
       else None
   in
   mk_rule "L3-011" run

--- a/latex-parse/src/validators_l1_math.ml
+++ b/latex-parse/src/validators_l1_math.ml
@@ -78,12 +78,9 @@ let l1_math_009_rule : rule =
       math_segs;
     if !cnt > 0 then
       Some
-        {
-          id = "MATH-009";
-          severity = Warning;
-          message = {|Bare ‘sin/log/exp’ in math; use \sin, \log, \exp|};
-          count = !cnt;
-        }
+        (mk_result ~id:"MATH-009" ~severity:Warning
+           ~message:{|Bare ‘sin/log/exp’ in math; use \sin, \log, \exp|}
+           ~count:!cnt)
     else None
   in
   { id = "MATH-009"; run; languages = [] }
@@ -99,12 +96,9 @@ let l1_math_010_rule : rule =
       math_segs;
     if !cnt > 0 then
       Some
-        {
-          id = "MATH-010";
-          severity = Warning;
-          message = {|Division symbol ÷ used; prefer \frac or solidus|};
-          count = !cnt;
-        }
+        (mk_result ~id:"MATH-010" ~severity:Warning
+           ~message:{|Division symbol ÷ used; prefer \frac or solidus|}
+           ~count:!cnt)
     else None
   in
   { id = "MATH-010"; run; languages = [] }
@@ -123,12 +117,9 @@ let l1_math_011_rule : rule =
       math_segs;
     if !vec_count > 0 && !mathbf_count > 0 then
       Some
-        {
-          id = "MATH-011";
-          severity = Info;
-          message = "Vector notation inconsistent within equation";
-          count = min !vec_count !mathbf_count;
-        }
+        (mk_result ~id:"MATH-011" ~severity:Info
+           ~message:"Vector notation inconsistent within equation"
+           ~count:(min !vec_count !mathbf_count))
     else None
   in
   { id = "MATH-011"; run; languages = [] }
@@ -208,12 +199,9 @@ let l1_math_012_rule : rule =
       math_segs;
     if !cnt > 0 then
       Some
-        {
-          id = "MATH-012";
-          severity = Warning;
-          message = {|Multi‑letter function not in roman (\operatorname{})|};
-          count = !cnt;
-        }
+        (mk_result ~id:"MATH-012" ~severity:Warning
+           ~message:{|Multi‑letter function not in roman (\operatorname{})|}
+           ~count:!cnt)
     else None
   in
   { id = "MATH-012"; run; languages = [] }
@@ -254,12 +242,8 @@ let l1_math_013_rule : rule =
       math_segs;
     if !cnt > 0 then
       Some
-        {
-          id = "MATH-013";
-          severity = Info;
-          message = "Differential d not typeset roman";
-          count = !cnt;
-        }
+        (mk_result ~id:"MATH-013" ~severity:Info
+           ~message:"Differential d not typeset roman" ~count:!cnt)
     else None
   in
   { id = "MATH-013"; run; languages = [] }
@@ -281,12 +265,8 @@ let l1_math_014_rule : rule =
       inline_segs;
     if !cnt > 0 then
       Some
-        {
-          id = "MATH-014";
-          severity = Info;
-          message = {|Inline \frac in running text|};
-          count = !cnt;
-        }
+        (mk_result ~id:"MATH-014" ~severity:Info
+           ~message:{|Inline \frac in running text|} ~count:!cnt)
     else None
   in
   { id = "MATH-014"; run; languages = [] }
@@ -301,12 +281,8 @@ let l1_math_015_rule : rule =
       math_segs;
     if !cnt > 0 then
       Some
-        {
-          id = "MATH-015";
-          severity = Warning;
-          message = {|\stackrel used; prefer \overset|};
-          count = !cnt;
-        }
+        (mk_result ~id:"MATH-015" ~severity:Warning
+           ~message:{|\stackrel used; prefer \overset|} ~count:!cnt)
     else None
   in
   { id = "MATH-015"; run; languages = [] }
@@ -321,12 +297,8 @@ let l1_math_016_rule : rule =
     List.iter (fun seg -> cnt := !cnt + count_re_matches re seg) math_segs;
     if !cnt > 0 then
       Some
-        {
-          id = "MATH-016";
-          severity = Warning;
-          message = "Nested subscripts without braces";
-          count = !cnt;
-        }
+        (mk_result ~id:"MATH-016" ~severity:Warning
+           ~message:"Nested subscripts without braces" ~count:!cnt)
     else None
   in
   { id = "MATH-016"; run; languages = [] }
@@ -414,12 +386,8 @@ let l1_math_017_rule : rule =
       math_segs;
     if !cnt > 0 then
       Some
-        {
-          id = "MATH-017";
-          severity = Error;
-          message = {|Mismatched \left\{ … \right] pair|};
-          count = !cnt;
-        }
+        (mk_result ~id:"MATH-017" ~severity:Error
+           ~message:{|Mismatched \left\{ … \right] pair|} ~count:!cnt)
     else None
   in
   { id = "MATH-017"; run; languages = [] }
@@ -433,12 +401,8 @@ let l1_math_018_rule : rule =
     List.iter (fun seg -> cnt := !cnt + count_re_matches re seg) math_segs;
     if !cnt > 0 then
       Some
-        {
-          id = "MATH-018";
-          severity = Info;
-          message = "π written numerically as 3.14";
-          count = !cnt;
-        }
+        (mk_result ~id:"MATH-018" ~severity:Info
+           ~message:"π written numerically as 3.14" ~count:!cnt)
     else None
   in
   { id = "MATH-018"; run; languages = [] }
@@ -456,12 +420,8 @@ let l1_math_019_rule : rule =
     List.iter (fun seg -> cnt := !cnt + count_re_matches re seg) inline_segs;
     if !cnt > 0 then
       Some
-        {
-          id = "MATH-019";
-          severity = Warning;
-          message = "Inline stacked ^_ order wrong";
-          count = !cnt;
-        }
+        (mk_result ~id:"MATH-019" ~severity:Warning
+           ~message:"Inline stacked ^_ order wrong" ~count:!cnt)
     else None
   in
   { id = "MATH-019"; run; languages = [] }
@@ -476,12 +436,8 @@ let l1_math_020_rule : rule =
     List.iter (fun seg -> cnt := !cnt + count_re_matches re seg) math_segs;
     if !cnt > 0 then
       Some
-        {
-          id = "MATH-020";
-          severity = Info;
-          message = {|Missing \cdot between coefficient and vector|};
-          count = !cnt;
-        }
+        (mk_result ~id:"MATH-020" ~severity:Info
+           ~message:{|Missing \cdot between coefficient and vector|} ~count:!cnt)
     else None
   in
   { id = "MATH-020"; run; languages = [] }
@@ -517,12 +473,9 @@ let l1_math_021_rule : rule =
       math_segs;
     if !cnt > 0 then
       Some
-        {
-          id = "MATH-021";
-          severity = Info;
-          message = {|Absolute value bars ‘|x|’ instead of \lvert … \rvert|};
-          count = !cnt;
-        }
+        (mk_result ~id:"MATH-021" ~severity:Info
+           ~message:{|Absolute value bars ‘|x|’ instead of \lvert … \rvert|}
+           ~count:!cnt)
     else None
   in
   { id = "MATH-021"; run; languages = [] }
@@ -538,12 +491,8 @@ let l1_math_022_rule : rule =
       math_segs;
     if !cnt > 0 then
       Some
-        {
-          id = "MATH-022";
-          severity = Info;
-          message = {|Bold math italic without \bm or \mathbf|};
-          count = !cnt;
-        }
+        (mk_result ~id:"MATH-022" ~severity:Info
+           ~message:{|Bold math italic without \bm or \mathbf|} ~count:!cnt)
     else None
   in
   { id = "MATH-022"; run; languages = [] }
@@ -573,12 +522,9 @@ let l1_math_025_rule : rule =
      with Not_found -> ());
     if !cnt > 0 then
       Some
-        {
-          id = "MATH-025";
-          severity = Info;
-          message = "align environment with one column – use equation";
-          count = !cnt;
-        }
+        (mk_result ~id:"MATH-025" ~severity:Info
+           ~message:"align environment with one column – use equation"
+           ~count:!cnt)
     else None
   in
   { id = "MATH-025"; run; languages = [] }
@@ -605,12 +551,9 @@ let l1_math_028_rule : rule =
        if tail = ba then incr cnt);
     if !cnt > 0 then
       Some
-        {
-          id = "MATH-028";
-          severity = Info;
-          message = "Array environment inside math lacks {c} alignment";
-          count = !cnt;
-        }
+        (mk_result ~id:"MATH-028" ~severity:Info
+           ~message:"Array environment inside math lacks {c} alignment"
+           ~count:!cnt)
     else None
   in
   { id = "MATH-028"; run; languages = [] }
@@ -631,12 +574,8 @@ let l1_math_029_rule : rule =
      with Not_found -> ());
     if !cnt > 0 then
       Some
-        {
-          id = "MATH-029";
-          severity = Warning;
-          message = "Use of eqnarray* instead of align*";
-          count = !cnt;
-        }
+        (mk_result ~id:"MATH-029" ~severity:Warning
+           ~message:"Use of eqnarray* instead of align*" ~count:!cnt)
     else None
   in
   { id = "MATH-029"; run; languages = [] }
@@ -652,12 +591,8 @@ let l1_math_030_rule : rule =
       inline_segs;
     if !cnt > 0 then
       Some
-        {
-          id = "MATH-030";
-          severity = Info;
-          message = {|Overuse of \displaystyle in inline math|};
-          count = !cnt;
-        }
+        (mk_result ~id:"MATH-030" ~severity:Info
+           ~message:{|Overuse of \displaystyle in inline math|} ~count:!cnt)
     else None
   in
   { id = "MATH-030"; run; languages = [] }
@@ -675,12 +610,9 @@ let l1_math_031_rule : rule =
       math_segs;
     if !cnt > 0 then
       Some
-        {
-          id = "MATH-031";
-          severity = Info;
-          message = {|Operator spacing error: missing \; before \text|};
-          count = !cnt;
-        }
+        (mk_result ~id:"MATH-031" ~severity:Info
+           ~message:{|Operator spacing error: missing \; before \text|}
+           ~count:!cnt)
     else None
   in
   { id = "MATH-031"; run; languages = [] }
@@ -692,12 +624,8 @@ let l1_math_033_rule : rule =
     let cnt = count_substring text_parts "\\pm" in
     if cnt > 0 then
       Some
-        {
-          id = "MATH-033";
-          severity = Info;
-          message = {|Use of \pm where ± symbol required in text|};
-          count = cnt;
-        }
+        (mk_result ~id:"MATH-033" ~severity:Info
+           ~message:{|Use of \pm where ± symbol required in text|} ~count:cnt)
     else None
   in
   { id = "MATH-033"; run; languages = [] }
@@ -751,12 +679,9 @@ let l1_math_034_rule : rule =
       math_segs;
     if !cnt > 0 then
       Some
-        {
-          id = "MATH-034";
-          severity = Info;
-          message = {|Spacing before differential in integral missing \,|};
-          count = !cnt;
-        }
+        (mk_result ~id:"MATH-034" ~severity:Info
+           ~message:{|Spacing before differential in integral missing \,|}
+           ~count:!cnt)
     else None
   in
   { id = "MATH-034"; run; languages = [] }
@@ -771,12 +696,9 @@ let l1_math_035_rule : rule =
     List.iter (fun seg -> cnt := !cnt + count_re_matches re seg) math_segs;
     if !cnt > 0 then
       Some
-        {
-          id = "MATH-035";
-          severity = Warning;
-          message = "Multiple subscripts stacked vertically without braces";
-          count = !cnt;
-        }
+        (mk_result ~id:"MATH-035" ~severity:Warning
+           ~message:"Multiple subscripts stacked vertically without braces"
+           ~count:!cnt)
     else None
   in
   { id = "MATH-035"; run; languages = [] }
@@ -791,12 +713,8 @@ let l1_math_036_rule : rule =
     List.iter (fun seg -> cnt := !cnt + count_re_matches re seg) math_segs;
     if !cnt > 0 then
       Some
-        {
-          id = "MATH-036";
-          severity = Info;
-          message = {|Superfluous \mathrm{} around single letter|};
-          count = !cnt;
-        }
+        (mk_result ~id:"MATH-036" ~severity:Info
+           ~message:{|Superfluous \mathrm{} around single letter|} ~count:!cnt)
     else None
   in
   { id = "MATH-036"; run; languages = [] }
@@ -812,12 +730,8 @@ let l1_math_037_rule : rule =
       math_segs;
     if !cnt > 0 then
       Some
-        {
-          id = "MATH-037";
-          severity = Info;
-          message = "xfrac package fraction used outside text mode";
-          count = !cnt;
-        }
+        (mk_result ~id:"MATH-037" ~severity:Info
+           ~message:"xfrac package fraction used outside text mode" ~count:!cnt)
     else None
   in
   { id = "MATH-037"; run; languages = [] }
@@ -883,12 +797,8 @@ let l1_math_038_rule : rule =
       math_segs;
     if !cnt > 0 then
       Some
-        {
-          id = "MATH-038";
-          severity = Warning;
-          message = {|Nested \frac three levels deep|};
-          count = !cnt;
-        }
+        (mk_result ~id:"MATH-038" ~severity:Warning
+           ~message:{|Nested \frac three levels deep|} ~count:!cnt)
     else None
   in
   { id = "MATH-038"; run; languages = [] }
@@ -907,12 +817,8 @@ let l1_math_039_rule : rule =
       math_segs;
     if !cnt > 0 then
       Some
-        {
-          id = "MATH-039";
-          severity = Warning;
-          message = {|Stacked relational operators without \atop|};
-          count = !cnt;
-        }
+        (mk_result ~id:"MATH-039" ~severity:Warning
+           ~message:{|Stacked relational operators without \atop|} ~count:!cnt)
     else None
   in
   { id = "MATH-039"; run; languages = [] }
@@ -927,12 +833,9 @@ let l1_math_040_rule : rule =
     List.iter (fun seg -> cnt := !cnt + count_re_matches re seg) math_segs;
     if !cnt > 0 then
       Some
-        {
-          id = "MATH-040";
-          severity = Info;
-          message = {|Ellipsis \ldots used between vertical alignment|};
-          count = !cnt;
-        }
+        (mk_result ~id:"MATH-040" ~severity:Info
+           ~message:{|Ellipsis \ldots used between vertical alignment|}
+           ~count:!cnt)
     else None
   in
   { id = "MATH-040"; run; languages = [] }
@@ -951,12 +854,9 @@ let l1_math_041_rule : rule =
       inline_segs;
     if !cnt > 0 then
       Some
-        {
-          id = "MATH-041";
-          severity = Info;
-          message = {|Integral limits written inline; use \displaystyle \int|};
-          count = !cnt;
-        }
+        (mk_result ~id:"MATH-041" ~severity:Info
+           ~message:{|Integral limits written inline; use \displaystyle \int|}
+           ~count:!cnt)
     else None
   in
   { id = "MATH-041"; run; languages = [] }
@@ -971,12 +871,8 @@ let l1_math_042_rule : rule =
     List.iter (fun seg -> cnt := !cnt + count_re_matches re seg) math_segs;
     if !cnt > 0 then
       Some
-        {
-          id = "MATH-042";
-          severity = Info;
-          message = {|Missing \, between numbers and units in math|};
-          count = !cnt;
-        }
+        (mk_result ~id:"MATH-042" ~severity:Info
+           ~message:{|Missing \, between numbers and units in math|} ~count:!cnt)
     else None
   in
   { id = "MATH-042"; run; languages = [] }
@@ -996,12 +892,9 @@ let l1_math_043_rule : rule =
       math_segs;
     if !cnt > 0 then
       Some
-        {
-          id = "MATH-043";
-          severity = Warning;
-          message = {|Use of \text instead of \operatorname for function|};
-          count = !cnt;
-        }
+        (mk_result ~id:"MATH-043" ~severity:Warning
+           ~message:{|Use of \text instead of \operatorname for function|}
+           ~count:!cnt)
     else None
   in
   { id = "MATH-043"; run; languages = [] }
@@ -1016,12 +909,9 @@ let l1_math_044_rule : rule =
     List.iter (fun seg -> cnt := !cnt + count_re_matches re seg) math_segs;
     if !cnt > 0 then
       Some
-        {
-          id = "MATH-044";
-          severity = Warning;
-          message = {|Binary relation typed as text char (e.g. < for \le)|};
-          count = !cnt;
-        }
+        (mk_result ~id:"MATH-044" ~severity:Warning
+           ~message:{|Binary relation typed as text char (e.g. < for \le)|}
+           ~count:!cnt)
     else None
   in
   { id = "MATH-044"; run; languages = [] }
@@ -1063,12 +953,9 @@ let l1_math_045_rule : rule =
     (* Only flag if document mixes upright and italic for the same class *)
     if !has_upright && !bare_cnt > 0 then
       Some
-        {
-          id = "MATH-045";
-          severity = Info;
-          message = {|Math italic capital Greek without \mathrm|};
-          count = !bare_cnt;
-        }
+        (mk_result ~id:"MATH-045" ~severity:Info
+           ~message:{|Math italic capital Greek without \mathrm|}
+           ~count:!bare_cnt)
     else None
   in
   { id = "MATH-045"; run; languages = [] }
@@ -1083,12 +970,9 @@ let l1_math_046_rule : rule =
     List.iter (fun seg -> cnt := !cnt + count_re_matches re seg) math_segs;
     if !cnt > 0 then
       Some
-        {
-          id = "MATH-046";
-          severity = Info;
-          message = {|Ellipsis \ldots used on relation axis; prefer \cdots|};
-          count = !cnt;
-        }
+        (mk_result ~id:"MATH-046" ~severity:Info
+           ~message:{|Ellipsis \ldots used on relation axis; prefer \cdots|}
+           ~count:!cnt)
     else None
   in
   { id = "MATH-046"; run; languages = [] }
@@ -1102,12 +986,8 @@ let l1_math_047_rule : rule =
     List.iter (fun seg -> cnt := !cnt + count_re_matches re seg) math_segs;
     if !cnt > 0 then
       Some
-        {
-          id = "MATH-047";
-          severity = Error;
-          message = "Double superscript without braces a^b^c";
-          count = !cnt;
-        }
+        (mk_result ~id:"MATH-047" ~severity:Error
+           ~message:"Double superscript without braces a^b^c" ~count:!cnt)
     else None
   in
   { id = "MATH-047"; run; languages = [] }
@@ -1122,12 +1002,8 @@ let l1_math_048_rule : rule =
     List.iter (fun seg -> cnt := !cnt + count_re_matches re seg) math_segs;
     if !cnt > 0 then
       Some
-        {
-          id = "MATH-048";
-          severity = Info;
-          message = {|Boldface digits via \mathbf in math – avoid|};
-          count = !cnt;
-        }
+        (mk_result ~id:"MATH-048" ~severity:Info
+           ~message:{|Boldface digits via \mathbf in math – avoid|} ~count:!cnt)
     else None
   in
   { id = "MATH-048"; run; languages = [] }
@@ -1151,12 +1027,8 @@ let l1_math_049_rule : rule =
       math_segs;
     if !cnt > 0 then
       Some
-        {
-          id = "MATH-049";
-          severity = Info;
-          message = {|Spacing around \times missing|};
-          count = !cnt;
-        }
+        (mk_result ~id:"MATH-049" ~severity:Info
+           ~message:{|Spacing around \times missing|} ~count:!cnt)
     else None
   in
   { id = "MATH-049"; run; languages = [] }
@@ -1171,12 +1043,8 @@ let l1_math_050_rule : rule =
     List.iter (fun seg -> cnt := !cnt + count_re_matches re seg) math_segs;
     if !cnt > 0 then
       Some
-        {
-          id = "MATH-050";
-          severity = Warning;
-          message = {|Circumflex accent ^\hat on multi‑letter|};
-          count = !cnt;
-        }
+        (mk_result ~id:"MATH-050" ~severity:Warning
+           ~message:{|Circumflex accent ^\hat on multi‑letter|} ~count:!cnt)
     else None
   in
   { id = "MATH-050"; run; languages = [] }
@@ -1241,12 +1109,8 @@ let l1_math_051_rule : rule =
       math_segs;
     if !cnt > 0 then
       Some
-        {
-          id = "MATH-051";
-          severity = Warning;
-          message = {|Radical \sqrt nested two levels|};
-          count = !cnt;
-        }
+        (mk_result ~id:"MATH-051" ~severity:Warning
+           ~message:{|Radical \sqrt nested two levels|} ~count:!cnt)
     else None
   in
   { id = "MATH-051"; run; languages = [] }
@@ -1288,12 +1152,8 @@ let l1_math_052_rule : rule =
       math_segs;
     if !cnt > 0 then
       Some
-        {
-          id = "MATH-052";
-          severity = Warning;
-          message = {|\over brace used; prefer \frac|};
-          count = !cnt;
-        }
+        (mk_result ~id:"MATH-052" ~severity:Warning
+           ~message:{|\over brace used; prefer \frac|} ~count:!cnt)
     else None
   in
   { id = "MATH-052"; run; languages = [] }
@@ -1322,12 +1182,8 @@ let l1_math_053_rule : rule =
       math_segs;
     if !cnt > 0 then
       Some
-        {
-          id = "MATH-053";
-          severity = Info;
-          message = {|Space after \left( at line start|};
-          count = !cnt;
-        }
+        (mk_result ~id:"MATH-053" ~severity:Info
+           ~message:{|Space after \left( at line start|} ~count:!cnt)
     else None
   in
   { id = "MATH-053"; run; languages = [] }
@@ -1345,12 +1201,9 @@ let l1_math_055_rule : rule =
     List.iter (fun seg -> cnt := !cnt + count_re_matches re seg) math_segs;
     if !cnt > 0 then
       Some
-        {
-          id = "MATH-055";
-          severity = Info;
-          message = {|Math font change \mathcal for single character only|};
-          count = !cnt;
-        }
+        (mk_result ~id:"MATH-055" ~severity:Info
+           ~message:{|Math font change \mathcal for single character only|}
+           ~count:!cnt)
     else None
   in
   { id = "MATH-055"; run; languages = [] }
@@ -1415,12 +1268,8 @@ let l1_math_057_rule : rule =
       math_segs;
     if !cnt > 0 then
       Some
-        {
-          id = "MATH-057";
-          severity = Error;
-          message = "Empty fraction numerator or denominator";
-          count = !cnt;
-        }
+        (mk_result ~id:"MATH-057" ~severity:Error
+           ~message:"Empty fraction numerator or denominator" ~count:!cnt)
     else None
   in
   { id = "MATH-057"; run; languages = [] }
@@ -1434,12 +1283,8 @@ let l1_math_058_rule : rule =
     List.iter (fun seg -> cnt := !cnt + count_re_matches re seg) math_segs;
     if !cnt > 0 then
       Some
-        {
-          id = "MATH-058";
-          severity = Info;
-          message = "Nested \\text inside \\text";
-          count = !cnt;
-        }
+        (mk_result ~id:"MATH-058" ~severity:Info
+           ~message:"Nested \\text inside \\text" ~count:!cnt)
     else None
   in
   { id = "MATH-058"; run; languages = [] }
@@ -1454,12 +1299,8 @@ let l1_math_065_rule : rule =
       math_segs;
     if !cnt > 0 then
       Some
-        {
-          id = "MATH-065";
-          severity = Info;
-          message = {|Manual spacing \hspace in math detected|};
-          count = !cnt;
-        }
+        (mk_result ~id:"MATH-065" ~severity:Info
+           ~message:{|Manual spacing \hspace in math detected|} ~count:!cnt)
     else None
   in
   { id = "MATH-065"; run; languages = [] }
@@ -1479,12 +1320,9 @@ let l1_math_066_rule : rule =
       math_segs;
     if !cnt > 0 then
       Some
-        {
-          id = "MATH-066";
-          severity = Info;
-          message = {|\phantom used; suggest \hphantom or \vphantom|};
-          count = !cnt;
-        }
+        (mk_result ~id:"MATH-066" ~severity:Info
+           ~message:{|\phantom used; suggest \hphantom or \vphantom|}
+           ~count:!cnt)
     else None
   in
   { id = "MATH-066"; run; languages = [] }
@@ -1498,12 +1336,8 @@ let l1_math_068_rule : rule =
     List.iter (fun seg -> cnt := !cnt + count_re_matches re seg) math_segs;
     if !cnt > 0 then
       Some
-        {
-          id = "MATH-068";
-          severity = Info;
-          message = "Spacing around \\mid missing";
-          count = !cnt;
-        }
+        (mk_result ~id:"MATH-068" ~severity:Info
+           ~message:"Spacing around \\mid missing" ~count:!cnt)
     else None
   in
   { id = "MATH-068"; run; languages = [] }
@@ -1522,12 +1356,8 @@ let l1_math_069_rule : rule =
       math_segs;
     if !cnt > 0 then
       Some
-        {
-          id = "MATH-069";
-          severity = Info;
-          message = "Bold sans‑serif math font used";
-          count = !cnt;
-        }
+        (mk_result ~id:"MATH-069" ~severity:Info
+           ~message:"Bold sans‑serif math font used" ~count:!cnt)
     else None
   in
   { id = "MATH-069"; run; languages = [] }
@@ -1544,12 +1374,8 @@ let l1_math_071_rule : rule =
       math_segs;
     if !cnt > 0 then
       Some
-        {
-          id = "MATH-071";
-          severity = Info;
-          message = {|Overuse of \cancel in equations|};
-          count = !cnt;
-        }
+        (mk_result ~id:"MATH-071" ~severity:Info
+           ~message:{|Overuse of \cancel in equations|} ~count:!cnt)
     else None
   in
   { id = "MATH-071"; run; languages = [] }
@@ -1562,12 +1388,9 @@ let l1_math_078_rule : rule =
     List.iter (fun seg -> cnt := !cnt + count_substring seg "-->") math_segs;
     if !cnt > 0 then
       Some
-        {
-          id = "MATH-078";
-          severity = Info;
-          message = {|Long arrow typed as --> instead of \longrightarrow|};
-          count = !cnt;
-        }
+        (mk_result ~id:"MATH-078" ~severity:Info
+           ~message:{|Long arrow typed as --> instead of \longrightarrow|}
+           ~count:!cnt)
     else None
   in
   { id = "MATH-078"; run; languages = [] }
@@ -1616,12 +1439,9 @@ let l1_math_079_rule : rule =
       display_envs;
     if !cnt > 0 then
       Some
-        {
-          id = "MATH-079";
-          severity = Info;
-          message = {|\displaystyle inside display math – redundant|};
-          count = !cnt;
-        }
+        (mk_result ~id:"MATH-079" ~severity:Info
+           ~message:{|\displaystyle inside display math – redundant|}
+           ~count:!cnt)
     else None
   in
   { id = "MATH-079"; run; languages = [] }
@@ -1634,12 +1454,9 @@ let l1_math_082_rule : rule =
     List.iter (fun seg -> cnt := !cnt + count_substring seg "\\!\\!") math_segs;
     if !cnt > 0 then
       Some
-        {
-          id = "MATH-082";
-          severity = Warning;
-          message = {|Negative thin space \! misused twice consecutively|};
-          count = !cnt;
-        }
+        (mk_result ~id:"MATH-082" ~severity:Warning
+           ~message:{|Negative thin space \! misused twice consecutively|}
+           ~count:!cnt)
     else None
   in
   { id = "MATH-082"; run; languages = [] }
@@ -1654,12 +1471,8 @@ let l1_math_085_rule : rule =
       math_segs;
     if !cnt > 0 then
       Some
-        {
-          id = "MATH-085";
-          severity = Info;
-          message = {|Use of \eqcirc – rarely acceptable|};
-          count = !cnt;
-        }
+        (mk_result ~id:"MATH-085" ~severity:Info
+           ~message:{|Use of \eqcirc – rarely acceptable|} ~count:!cnt)
     else None
   in
   { id = "MATH-085"; run; languages = [] }
@@ -1672,12 +1485,9 @@ let l1_math_094_rule : rule =
     List.iter (fun seg -> cnt := !cnt + count_substring seg "\\kern") math_segs;
     if !cnt > 0 then
       Some
-        {
-          id = "MATH-094";
-          severity = Info;
-          message = {|Manual \kern in math detected – typographic smell|};
-          count = !cnt;
-        }
+        (mk_result ~id:"MATH-094" ~severity:Info
+           ~message:{|Manual \kern in math detected – typographic smell|}
+           ~count:!cnt)
     else None
   in
   { id = "MATH-094"; run; languages = [] }
@@ -1726,12 +1536,9 @@ let l1_math_105_rule : rule =
       display_envs;
     if !cnt > 0 then
       Some
-        {
-          id = "MATH-105";
-          severity = Info;
-          message = {|\textstyle used inside display math — redundant|};
-          count = !cnt;
-        }
+        (mk_result ~id:"MATH-105" ~severity:Info
+           ~message:{|\textstyle used inside display math — redundant|}
+           ~count:!cnt)
     else None
   in
   { id = "MATH-105"; run; languages = [] }
@@ -1757,12 +1564,8 @@ let l1_math_056_rule : rule =
       math_segs;
     if !cnt > 0 then
       Some
-        {
-          id = "MATH-056";
-          severity = Info;
-          message = "\\operatorname duplicated for same function";
-          count = !cnt;
-        }
+        (mk_result ~id:"MATH-056" ~severity:Info
+           ~message:"\\operatorname duplicated for same function" ~count:!cnt)
     else None
   in
   { id = "MATH-056"; run; languages = [] }
@@ -1776,12 +1579,9 @@ let l1_math_059_rule : rule =
     List.iter (fun seg -> cnt := !cnt + count_re_matches re seg) math_segs;
     if !cnt > 0 then
       Some
-        {
-          id = "MATH-059";
-          severity = Warning;
-          message = {|Math accent \bar on group expression needs braces|};
-          count = !cnt;
-        }
+        (mk_result ~id:"MATH-059" ~severity:Warning
+           ~message:{|Math accent \bar on group expression needs braces|}
+           ~count:!cnt)
     else None
   in
   { id = "MATH-059"; run; languages = [] }
@@ -1802,12 +1602,8 @@ let l1_math_060_rule : rule =
       math_segs;
     if !cnt > 0 then
       Some
-        {
-          id = "MATH-060";
-          severity = Info;
-          message = "Differential d typeset italic";
-          count = !cnt;
-        }
+        (mk_result ~id:"MATH-060" ~severity:Info
+           ~message:"Differential d typeset italic" ~count:!cnt)
     else None
   in
   { id = "MATH-060"; run; languages = [] }
@@ -1821,12 +1617,8 @@ let l1_math_061_rule : rule =
     List.iter (fun seg -> cnt := !cnt + count_re_matches re seg) math_segs;
     if !cnt > 0 then
       Some
-        {
-          id = "MATH-061";
-          severity = Warning;
-          message = {|Log base missing braces in \log_10x|};
-          count = !cnt;
-        }
+        (mk_result ~id:"MATH-061" ~severity:Warning
+           ~message:{|Log base missing braces in \log_10x|} ~count:!cnt)
     else None
   in
   { id = "MATH-061"; run; languages = [] }
@@ -1881,12 +1673,8 @@ let l1_math_067_rule : rule =
       math_segs;
     if !cnt > 0 then
       Some
-        {
-          id = "MATH-067";
-          severity = Warning;
-          message = "Stacked limits on non‑operator";
-          count = !cnt;
-        }
+        (mk_result ~id:"MATH-067" ~severity:Warning
+           ~message:"Stacked limits on non‑operator" ~count:!cnt)
     else None
   in
   { id = "MATH-067"; run; languages = [] }
@@ -1905,12 +1693,8 @@ let l1_math_070_rule : rule =
       math_segs;
     if !cnt > 0 then
       Some
-        {
-          id = "MATH-070";
-          severity = Info;
-          message = {|Multiline subscripts lack \substack|};
-          count = !cnt;
-        }
+        (mk_result ~id:"MATH-070" ~severity:Info
+           ~message:{|Multiline subscripts lack \substack|} ~count:!cnt)
     else None
   in
   { id = "MATH-070"; run; languages = [] }
@@ -1924,12 +1708,8 @@ let l1_math_073_rule : rule =
     List.iter (fun seg -> cnt := !cnt + count_re_matches re seg) math_segs;
     if !cnt > 0 then
       Some
-        {
-          id = "MATH-073";
-          severity = Warning;
-          message = {|xcolor macro \color used inside math|};
-          count = !cnt;
-        }
+        (mk_result ~id:"MATH-073" ~severity:Warning
+           ~message:{|xcolor macro \color used inside math|} ~count:!cnt)
     else None
   in
   { id = "MATH-073"; run; languages = [] }
@@ -1983,12 +1763,9 @@ let l1_math_077_rule : rule =
       non_align_envs;
     if !cnt > 0 then
       Some
-        {
-          id = "MATH-077";
-          severity = Error;
-          message = "Alignment point & outside alignment environment";
-          count = !cnt;
-        }
+        (mk_result ~id:"MATH-077" ~severity:Error
+           ~message:"Alignment point & outside alignment environment"
+           ~count:!cnt)
     else None
   in
   { id = "MATH-077"; run; languages = [] }
@@ -2032,12 +1809,9 @@ let l1_math_081_rule : rule =
       math_segs;
     if !cnt > 0 then
       Some
-        {
-          id = "MATH-081";
-          severity = Info;
-          message = {|Improper kerning f(x) – suggest f\!\left(x\right)|};
-          count = !cnt;
-        }
+        (mk_result ~id:"MATH-081" ~severity:Info
+           ~message:{|Improper kerning f(x) – suggest f\!\left(x\right)|}
+           ~count:!cnt)
     else None
   in
   { id = "MATH-081"; run; languages = [] }
@@ -2056,12 +1830,8 @@ let l1_math_084_rule : rule =
       inline_segs;
     if !cnt > 0 then
       Some
-        {
-          id = "MATH-084";
-          severity = Info;
-          message = {|Displaystyle \sum in inline math|};
-          count = !cnt;
-        }
+        (mk_result ~id:"MATH-084" ~severity:Info
+           ~message:{|Displaystyle \sum in inline math|} ~count:!cnt)
     else None
   in
   { id = "MATH-084"; run; languages = [] }
@@ -2076,12 +1846,8 @@ let l1_math_086_rule : rule =
       math_segs;
     if !cnt > 0 then
       Some
-        {
-          id = "MATH-086";
-          severity = Warning;
-          message = {|Nested root \sqrt{\sqrt{…}} depth > 2|};
-          count = !cnt;
-        }
+        (mk_result ~id:"MATH-086" ~severity:Warning
+           ~message:{|Nested root \sqrt{\sqrt{…}} depth > 2|} ~count:!cnt)
     else None
   in
   { id = "MATH-086"; run; languages = [] }
@@ -2096,12 +1862,9 @@ let l1_math_090_rule : rule =
       math_segs;
     if !cnt > 0 then
       Some
-        {
-          id = "MATH-090";
-          severity = Warning;
-          message = {|Nested \frac depth > 3 – suggest \dfrac + \smash|};
-          count = !cnt;
-        }
+        (mk_result ~id:"MATH-090" ~severity:Warning
+           ~message:{|Nested \frac depth > 3 – suggest \dfrac + \smash|}
+           ~count:!cnt)
     else None
   in
   { id = "MATH-090"; run; languages = [] }
@@ -2164,12 +1927,9 @@ let l1_math_093_rule : rule =
       math_segs;
     if !cnt > 0 then
       Some
-        {
-          id = "MATH-093";
-          severity = Info;
-          message = {|Multi‑letter italic variable should be \mathit{}|};
-          count = !cnt;
-        }
+        (mk_result ~id:"MATH-093" ~severity:Info
+           ~message:{|Multi‑letter italic variable should be \mathit{}|}
+           ~count:!cnt)
     else None
   in
   { id = "MATH-093"; run; languages = [] }
@@ -2188,12 +1948,8 @@ let l1_math_098_rule : rule =
       math_segs;
     if !cnt > 0 then
       Some
-        {
-          id = "MATH-098";
-          severity = Info;
-          message = {|Too many \qquad (> 2) in single line|};
-          count = !cnt;
-        }
+        (mk_result ~id:"MATH-098" ~severity:Info
+           ~message:{|Too many \qquad (> 2) in single line|} ~count:!cnt)
     else None
   in
   { id = "MATH-098"; run; languages = [] }
@@ -2266,12 +2022,8 @@ let l1_math_072_rule : rule =
       math_segs;
     if !cnt > 0 then
       Some
-        {
-          id = "MATH-072";
-          severity = Warning;
-          message = "Unknown math operator name";
-          count = !cnt;
-        }
+        (mk_result ~id:"MATH-072" ~severity:Warning
+           ~message:"Unknown math operator name" ~count:!cnt)
     else None
   in
   { id = "MATH-072"; run; languages = [] }
@@ -2290,12 +2042,8 @@ let l1_math_074_rule : rule =
       math_segs;
     if !cnt > 0 then
       Some
-        {
-          id = "MATH-074";
-          severity = Warning;
-          message = "TikZ node inside math without math mode set";
-          count = !cnt;
-        }
+        (mk_result ~id:"MATH-074" ~severity:Warning
+           ~message:"TikZ node inside math without math mode set" ~count:!cnt)
     else None
   in
   { id = "MATH-074"; run; languages = [] }
@@ -2309,12 +2057,8 @@ let l1_math_087_rule : rule =
     List.iter (fun seg -> cnt := !cnt + count_re_matches re seg) math_segs;
     if !cnt > 0 then
       Some
-        {
-          id = "MATH-087";
-          severity = Info;
-          message = {|Maths uses fake bold via \mathbf on digits|};
-          count = !cnt;
-        }
+        (mk_result ~id:"MATH-087" ~severity:Info
+           ~message:{|Maths uses fake bold via \mathbf on digits|} ~count:!cnt)
     else None
   in
   { id = "MATH-087"; run; languages = [] }
@@ -2328,12 +2072,8 @@ let l1_math_088_rule : rule =
     List.iter (fun seg -> cnt := !cnt + count_re_matches re seg) math_segs;
     if !cnt > 0 then
       Some
-        {
-          id = "MATH-088";
-          severity = Info;
-          message = {|Bare \partial lacks thin‑space before/after|};
-          count = !cnt;
-        }
+        (mk_result ~id:"MATH-088" ~severity:Info
+           ~message:{|Bare \partial lacks thin‑space before/after|} ~count:!cnt)
     else None
   in
   { id = "MATH-088"; run; languages = [] }
@@ -2391,12 +2131,9 @@ let l1_math_091_rule : rule =
       math_segs;
     if !cnt > 0 then
       Some
-        {
-          id = "MATH-091";
-          severity = Info;
-          message = {|\operatorname{det} used – predefined \det exists|};
-          count = !cnt;
-        }
+        (mk_result ~id:"MATH-091" ~severity:Info
+           ~message:{|\operatorname{det} used – predefined \det exists|}
+           ~count:!cnt)
     else None
   in
   { id = "MATH-091"; run; languages = [] }
@@ -2410,12 +2147,8 @@ let l1_math_092_rule : rule =
     List.iter (fun seg -> cnt := !cnt + count_re_matches re seg) inline_segs;
     if !cnt > 0 then
       Some
-        {
-          id = "MATH-092";
-          severity = Info;
-          message = "\\sum with explicit limits in inline math";
-          count = !cnt;
-        }
+        (mk_result ~id:"MATH-092" ~severity:Info
+           ~message:"\\sum with explicit limits in inline math" ~count:!cnt)
     else None
   in
   { id = "MATH-092"; run; languages = [] }
@@ -2429,12 +2162,8 @@ let l1_math_095_rule : rule =
     List.iter (fun seg -> cnt := !cnt + count_re_matches re seg) math_segs;
     if !cnt > 0 then
       Some
-        {
-          id = "MATH-095";
-          severity = Warning;
-          message = {|Log base typeset without braces (\log_10x)|};
-          count = !cnt;
-        }
+        (mk_result ~id:"MATH-095" ~severity:Warning
+           ~message:{|Log base typeset without braces (\log_10x)|} ~count:!cnt)
     else None
   in
   { id = "MATH-095"; run; languages = [] }
@@ -2489,12 +2218,8 @@ let l1_math_096_rule : rule =
       math_segs;
     if !cnt > 0 then
       Some
-        {
-          id = "MATH-096";
-          severity = Info;
-          message = {|Bold Greek via \mathbf – use \boldsymbol|};
-          count = !cnt;
-        }
+        (mk_result ~id:"MATH-096" ~severity:Info
+           ~message:{|Bold Greek via \mathbf – use \boldsymbol|} ~count:!cnt)
     else None
   in
   { id = "MATH-096"; run; languages = [] }
@@ -2512,12 +2237,8 @@ let l1_math_097_rule : rule =
       math_segs;
     if !cnt > 0 then
       Some
-        {
-          id = "MATH-097";
-          severity = Info;
-          message = {|Arrow '=>' typed instead of \implies|};
-          count = !cnt;
-        }
+        (mk_result ~id:"MATH-097" ~severity:Info
+           ~message:{|Arrow '=>' typed instead of \implies|} ~count:!cnt)
     else None
   in
   { id = "MATH-097"; run; languages = [] }
@@ -2536,12 +2257,8 @@ let l1_math_099_rule : rule =
       inline_segs;
     if !cnt > 0 then
       Some
-        {
-          id = "MATH-099";
-          severity = Info;
-          message = {|Large operator (\bigcup) used inline|};
-          count = !cnt;
-        }
+        (mk_result ~id:"MATH-099" ~severity:Info
+           ~message:{|Large operator (\bigcup) used inline|} ~count:!cnt)
     else None
   in
   { id = "MATH-099"; run; languages = [] }
@@ -2554,12 +2271,9 @@ let l1_math_101_rule : rule =
     List.iter (fun seg -> cnt := !cnt + count_substring seg "\\over") math_segs;
     if !cnt > 0 then
       Some
-        {
-          id = "MATH-101";
-          severity = Warning;
-          message = {|Deprecated \over primitive used; replace with \frac|};
-          count = !cnt;
-        }
+        (mk_result ~id:"MATH-101" ~severity:Warning
+           ~message:{|Deprecated \over primitive used; replace with \frac|}
+           ~count:!cnt)
     else None
   in
   { id = "MATH-101"; run; languages = [] }
@@ -2577,13 +2291,10 @@ let l1_math_104_rule : rule =
       math_segs;
     if !cnt > 0 then
       Some
-        {
-          id = "MATH-104";
-          severity = Info;
-          message =
-            {|Paired delimiters repeated without \DeclarePairedDelimiter|};
-          count = !cnt;
-        }
+        (mk_result ~id:"MATH-104" ~severity:Info
+           ~message:
+             {|Paired delimiters repeated without \DeclarePairedDelimiter|}
+           ~count:!cnt)
     else None
   in
   { id = "MATH-104"; run; languages = [] }
@@ -2596,12 +2307,8 @@ let l1_math_106_rule : rule =
     List.iter (fun seg -> cnt := !cnt + count_substring seg "\\not=") math_segs;
     if !cnt > 0 then
       Some
-        {
-          id = "MATH-106";
-          severity = Info;
-          message = {|Misuse of \not=; prefer \neq|};
-          count = !cnt;
-        }
+        (mk_result ~id:"MATH-106" ~severity:Info
+           ~message:{|Misuse of \not=; prefer \neq|} ~count:!cnt)
     else None
   in
   { id = "MATH-106"; run; languages = [] }
@@ -2616,12 +2323,9 @@ let l1_math_108_rule : rule =
       math_segs;
     if !cnt > 0 then
       Some
-        {
-          id = "MATH-108";
-          severity = Info;
-          message = {|Scalar product uses • (⋅) directly; require \cdot|};
-          count = !cnt;
-        }
+        (mk_result ~id:"MATH-108" ~severity:Info
+           ~message:{|Scalar product uses • (⋅) directly; require \cdot|}
+           ~count:!cnt)
     else None
   in
   { id = "MATH-108"; run; languages = [] }

--- a/latex-parse/src/validators_l2.ml
+++ b/latex-parse/src/validators_l2.ml
@@ -16,12 +16,8 @@ let r_fig_001 : rule =
     in
     if cnt > 0 then
       Some
-        {
-          id = "FIG-001";
-          severity = Warning;
-          message = "Figure without caption";
-          count = cnt;
-        }
+        (mk_result ~id:"FIG-001" ~severity:Warning
+           ~message:"Figure without caption" ~count:cnt)
     else None
   in
   { id = "FIG-001"; run; languages = [] }
@@ -46,12 +42,8 @@ let r_fig_002 : rule =
     in
     if cnt > 0 then
       Some
-        {
-          id = "FIG-002";
-          severity = Warning;
-          message = "Figure without label";
-          count = cnt;
-        }
+        (mk_result ~id:"FIG-002" ~severity:Warning
+           ~message:"Figure without label" ~count:cnt)
     else None
   in
   { id = "FIG-002"; run; languages = [] }
@@ -84,12 +76,8 @@ let r_fig_003 : rule =
     in
     if cnt > 0 then
       Some
-        {
-          id = "FIG-003";
-          severity = Info;
-          message = "Label before caption in figure";
-          count = cnt;
-        }
+        (mk_result ~id:"FIG-003" ~severity:Info
+           ~message:"Label before caption in figure" ~count:cnt)
     else None
   in
   { id = "FIG-003"; run; languages = [] }
@@ -134,12 +122,8 @@ let r_fig_007 : rule =
     in
     if cnt > 0 then
       Some
-        {
-          id = "FIG-007";
-          severity = Info;
-          message = {|Figure lacks alt text for accessibility|};
-          count = cnt;
-        }
+        (mk_result ~id:"FIG-007" ~severity:Info
+           ~message:{|Figure lacks alt text for accessibility|} ~count:cnt)
     else None
   in
   { id = "FIG-007"; run; languages = [] }
@@ -159,12 +143,8 @@ let r_fig_009 : rule =
       envs;
     if !cnt > 0 then
       Some
-        {
-          id = "FIG-009";
-          severity = Info;
-          message = "Float position specifier ! used excessively";
-          count = !cnt;
-        }
+        (mk_result ~id:"FIG-009" ~severity:Info
+           ~message:"Float position specifier ! used excessively" ~count:!cnt)
     else None
   in
   { id = "FIG-009"; run; languages = [] }
@@ -180,12 +160,8 @@ let r_tab_001 : rule =
     in
     if cnt > 0 then
       Some
-        {
-          id = "TAB-001";
-          severity = Warning;
-          message = "Table lacks caption";
-          count = cnt;
-        }
+        (mk_result ~id:"TAB-001" ~severity:Warning
+           ~message:"Table lacks caption" ~count:cnt)
     else None
   in
   { id = "TAB-001"; run; languages = [] }
@@ -220,12 +196,8 @@ let r_tab_002 : rule =
     in
     if cnt > 0 then
       Some
-        {
-          id = "TAB-002";
-          severity = Info;
-          message = "Caption below table (journal requires above)";
-          count = cnt;
-        }
+        (mk_result ~id:"TAB-002" ~severity:Info
+           ~message:"Caption below table (journal requires above)" ~count:cnt)
     else None
   in
   { id = "TAB-002"; run; languages = [] }
@@ -286,12 +258,8 @@ let r_tab_005 : rule =
      with Not_found -> ());
     if !cnt > 0 then
       Some
-        {
-          id = "TAB-005";
-          severity = Info;
-          message = "Vertical rules present in tabular";
-          count = !cnt;
-        }
+        (mk_result ~id:"TAB-005" ~severity:Info
+           ~message:"Vertical rules present in tabular" ~count:!cnt)
     else None
   in
   { id = "TAB-005"; run; languages = [] }
@@ -309,12 +277,8 @@ let r_pkg_001 : rule =
       pkgs;
     if !cnt > 0 then
       Some
-        {
-          id = "PKG-001";
-          severity = Warning;
-          message = "Package duplicate inclusion detected";
-          count = !cnt;
-        }
+        (mk_result ~id:"PKG-001" ~severity:Warning
+           ~message:"Package duplicate inclusion detected" ~count:!cnt)
     else None
   in
   { id = "PKG-001"; run; languages = [] }
@@ -333,12 +297,8 @@ let r_pkg_002 : rule =
       pkgs;
     if !geom_pos >= 0 && !hyper_pos >= 0 && !geom_pos > !hyper_pos then
       Some
-        {
-          id = "PKG-002";
-          severity = Error;
-          message = {|geometry loaded after hyperref – must precede|};
-          count = 1;
-        }
+        (mk_result ~id:"PKG-002" ~severity:Error
+           ~message:{|geometry loaded after hyperref – must precede|} ~count:1)
     else None
   in
   { id = "PKG-002"; run; languages = [] }
@@ -361,12 +321,9 @@ let r_pkg_004 : rule =
          with Not_found -> ());
         if !cnt > 0 then
           Some
-            {
-              id = "PKG-004";
-              severity = Error;
-              message = {esc|Package loaded after \begin{document}|esc};
-              count = !cnt;
-            }
+            (mk_result ~id:"PKG-004" ~severity:Error
+               ~message:{esc|Package loaded after \begin{document}|esc}
+               ~count:!cnt)
         else None
   in
   { id = "PKG-004"; run; languages = [] }
@@ -488,12 +445,8 @@ let r_pkg_005 : rule =
      with Not_found -> ());
     if !cnt > 0 then
       Some
-        {
-          id = "PKG-005";
-          severity = Warning;
-          message = "Unknown option for geometry";
-          count = !cnt;
-        }
+        (mk_result ~id:"PKG-005" ~severity:Warning
+           ~message:"Unknown option for geometry" ~count:!cnt)
     else None
   in
   { id = "PKG-005"; run; languages = [] }
@@ -536,12 +489,8 @@ let r_cjk_004 : rule =
           || has_package s "ctex")
       then
         Some
-          {
-            id = "CJK-004";
-            severity = Warning;
-            message = "xeCJK package missing when CJK glyphs present";
-            count = 1;
-          }
+          (mk_result ~id:"CJK-004" ~severity:Warning
+             ~message:"xeCJK package missing when CJK glyphs present" ~count:1)
       else None
     else None
   in
@@ -568,12 +517,8 @@ let r_cjk_006 : rule =
       in
       if not has_ruby_pkg then
         Some
-          {
-            id = "CJK-006";
-            severity = Warning;
-            message = "Ruby annotation requires ruby package";
-            count = !cnt;
-          }
+          (mk_result ~id:"CJK-006" ~severity:Warning
+             ~message:"Ruby annotation requires ruby package" ~count:!cnt)
       else None
     else None
   in
@@ -597,12 +542,8 @@ let r_font_006 : rule =
       in
       if not found then
         Some
-          {
-            id = "FONT-006";
-            severity = Info;
-            message = {|Missing \microtypesetup{expansion=true}|};
-            count = 1;
-          }
+          (mk_result ~id:"FONT-006" ~severity:Info
+             ~message:{|Missing \microtypesetup{expansion=true}|} ~count:1)
       else None
     else None
   in
@@ -629,12 +570,9 @@ let r_font_007 : rule =
       in
       if xelatex then
         Some
-          {
-            id = "FONT-007";
-            severity = Warning;
-            message = {|Obsolete \usepackage[T1]{fontenc} under XeLaTeX|};
-            count = 1;
-          }
+          (mk_result ~id:"FONT-007" ~severity:Warning
+             ~message:{|Obsolete \usepackage[T1]{fontenc} under XeLaTeX|}
+             ~count:1)
       else None
     else None
   in
@@ -655,12 +593,8 @@ let r_font_008 : rule =
      with Not_found -> ());
     if !cnt > 1 then
       Some
-        {
-          id = "FONT-008";
-          severity = Warning;
-          message = "Multiple \\setmainfont declarations";
-          count = !cnt;
-        }
+        (mk_result ~id:"FONT-008" ~severity:Warning
+           ~message:"Multiple \\setmainfont declarations" ~count:!cnt)
     else None
   in
   { id = "FONT-008"; run; languages = [] }
@@ -689,12 +623,8 @@ let r_math_032 : rule =
      with Not_found -> ());
     if !cnt > 0 then
       Some
-        {
-          id = "MATH-032";
-          severity = Warning;
-          message = "Incorrect small matrix brackets";
-          count = !cnt;
-        }
+        (mk_result ~id:"MATH-032" ~severity:Warning
+           ~message:"Incorrect small matrix brackets" ~count:!cnt)
     else None
   in
   { id = "MATH-032"; run; languages = [] }
@@ -764,12 +694,8 @@ let r_math_054 : rule =
      with Not_found -> ());
     if !cnt > 0 then
       Some
-        {
-          id = "MATH-054";
-          severity = Warning;
-          message = {|Equation labelled 'eq:' without environment|};
-          count = !cnt;
-        }
+        (mk_result ~id:"MATH-054" ~severity:Warning
+           ~message:{|Equation labelled 'eq:' without environment|} ~count:!cnt)
     else None
   in
   { id = "MATH-054"; run; languages = [] }
@@ -792,12 +718,8 @@ let r_math_062 : rule =
       align_envs;
     if !cnt > 0 then
       Some
-        {
-          id = "MATH-062";
-          severity = Warning;
-          message = "Multiline equation lacks alignment character &";
-          count = !cnt;
-        }
+        (mk_result ~id:"MATH-062" ~severity:Warning
+           ~message:"Multiline equation lacks alignment character &" ~count:!cnt)
     else None
   in
   { id = "MATH-062"; run; languages = [] }
@@ -830,12 +752,8 @@ let r_math_063 : rule =
       eqn_envs;
     if !cnt > 0 then
       Some
-        {
-          id = "MATH-063";
-          severity = Warning;
-          message = "Equation array with > 1 alignment point";
-          count = !cnt;
-        }
+        (mk_result ~id:"MATH-063" ~severity:Warning
+           ~message:"Equation array with > 1 alignment point" ~count:!cnt)
     else None
   in
   { id = "MATH-063"; run; languages = [] }
@@ -875,12 +793,9 @@ let r_math_100 : rule =
       display_envs;
     if !cnt > 0 then
       Some
-        {
-          id = "MATH-100";
-          severity = Info;
-          message = "Punctuation after equation missing (comma/period)";
-          count = !cnt;
-        }
+        (mk_result ~id:"MATH-100" ~severity:Info
+           ~message:"Punctuation after equation missing (comma/period)"
+           ~count:!cnt)
     else None
   in
   { id = "MATH-100"; run; languages = [] }
@@ -905,12 +820,8 @@ let r_math_023 : rule =
       refs;
     if !cnt > 0 then
       Some
-        {
-          id = "MATH-023";
-          severity = Warning;
-          message = "Equation label missing although referenced";
-          count = !cnt;
-        }
+        (mk_result ~id:"MATH-023" ~severity:Warning
+           ~message:"Equation label missing although referenced" ~count:!cnt)
     else None
   in
   { id = "MATH-023"; run; languages = [] }
@@ -931,12 +842,8 @@ let r_math_024 : rule =
       labels;
     if !cnt > 0 then
       Some
-        {
-          id = "MATH-024";
-          severity = Info;
-          message = "Equation labelled but never referenced";
-          count = !cnt;
-        }
+        (mk_result ~id:"MATH-024" ~severity:Info
+           ~message:"Equation labelled but never referenced" ~count:!cnt)
     else None
   in
   { id = "MATH-024"; run; languages = [] }
@@ -967,12 +874,8 @@ let r_ref_010 : rule =
       refs;
     if !cnt > 0 then
       Some
-        {
-          id = "REF-010";
-          severity = Info;
-          message = "Figure referenced before first mention in text";
-          count = !cnt;
-        }
+        (mk_result ~id:"REF-010" ~severity:Info
+           ~message:"Figure referenced before first mention in text" ~count:!cnt)
     else None
   in
   { id = "REF-010"; run; languages = [] }
@@ -1002,12 +905,9 @@ let r_cmd_014 : rule =
          with Not_found -> ());
         if !cnt > 0 then
           Some
-            {
-              id = "CMD-014";
-              severity = Warning;
-              message = "\\AtBeginDocument placed after \\begin{document}";
-              count = !cnt;
-            }
+            (mk_result ~id:"CMD-014" ~severity:Warning
+               ~message:"\\AtBeginDocument placed after \\begin{document}"
+               ~count:!cnt)
         else None
   in
   { id = "CMD-014"; run; languages = [] }
@@ -1022,12 +922,8 @@ let r_doc_001 : rule =
       let has_maketitle = contains_substring s "\\maketitle" in
       if not has_maketitle then
         Some
-          {
-            id = "DOC-001";
-            severity = Error;
-            message = "Title missing \\maketitle";
-            count = 1;
-          }
+          (mk_result ~id:"DOC-001" ~severity:Error
+             ~message:"Title missing \\maketitle" ~count:1)
       else None
   in
   { id = "DOC-001"; run; languages = [] }
@@ -1041,12 +937,8 @@ let r_doc_002 : rule =
       let has_abstract = contains_substring s "\\begin{abstract}" in
       if not has_abstract then
         Some
-          {
-            id = "DOC-002";
-            severity = Warning;
-            message = "Abstract environment missing";
-            count = 1;
-          }
+          (mk_result ~id:"DOC-002" ~severity:Warning
+             ~message:"Abstract environment missing" ~count:1)
       else None
   in
   { id = "DOC-002"; run; languages = [] }
@@ -1060,12 +952,8 @@ let r_doc_003 : rule =
       let has_keywords = contains_substring s "\\keywords{" in
       if not has_keywords then
         Some
-          {
-            id = "DOC-003";
-            severity = Info;
-            message = "Keywords missing";
-            count = 1;
-          }
+          (mk_result ~id:"DOC-003" ~severity:Info ~message:"Keywords missing"
+             ~count:1)
       else None
   in
   { id = "DOC-003"; run; languages = [] }
@@ -1086,12 +974,8 @@ let r_tab_006 : rule =
      with Not_found -> ());
     if !cnt > 0 then
       Some
-        {
-          id = "TAB-006";
-          severity = Info;
-          message = "Consecutive \\hline duplicated";
-          count = !cnt;
-        }
+        (mk_result ~id:"TAB-006" ~severity:Info
+           ~message:"Consecutive \\hline duplicated" ~count:!cnt)
     else None
   in
   { id = "TAB-006"; run; languages = [] }
@@ -1116,12 +1000,8 @@ let r_tab_009 : rule =
     in
     if cnt > 0 then
       Some
-        {
-          id = "TAB-009";
-          severity = Warning;
-          message = "Floating table missing \\label";
-          count = cnt;
-        }
+        (mk_result ~id:"TAB-009" ~severity:Warning
+           ~message:"Floating table missing \\label" ~count:cnt)
     else None
   in
   { id = "TAB-009"; run; languages = [] }
@@ -1149,12 +1029,8 @@ let r_tab_010 : rule =
     in
     if cnt > 0 then
       Some
-        {
-          id = "TAB-010";
-          severity = Warning;
-          message = "Footnote placed inside table environment";
-          count = cnt;
-        }
+        (mk_result ~id:"TAB-010" ~severity:Warning
+           ~message:"Footnote placed inside table environment" ~count:cnt)
     else None
   in
   { id = "TAB-010"; run; languages = [] }
@@ -1182,12 +1058,9 @@ let r_tab_011 : rule =
     in
     if cnt > 0 then
       Some
-        {
-          id = "TAB-011";
-          severity = Info;
-          message = "Top/bottom \\hline instead of \\toprule/\\bottomrule";
-          count = cnt;
-        }
+        (mk_result ~id:"TAB-011" ~severity:Info
+           ~message:"Top/bottom \\hline instead of \\toprule/\\bottomrule"
+           ~count:cnt)
     else None
   in
   { id = "TAB-011"; run; languages = [] }
@@ -1208,12 +1081,9 @@ let r_tab_014 : rule =
      with Not_found -> ());
     if !cnt > 0 then
       Some
-        {
-          id = "TAB-014";
-          severity = Info;
-          message = "Empty multicolumn alignment spec {} encountered";
-          count = !cnt;
-        }
+        (mk_result ~id:"TAB-014" ~severity:Info
+           ~message:"Empty multicolumn alignment spec {} encountered"
+           ~count:!cnt)
     else None
   in
   { id = "TAB-014"; run; languages = [] }
@@ -1244,12 +1114,8 @@ let r_pkg_007 : rule =
     | Some hp, Some gp ->
         if hp < gp then
           Some
-            {
-              id = "PKG-007";
-              severity = Error;
-              message = "hyperref loaded before geometry";
-              count = 1;
-            }
+            (mk_result ~id:"PKG-007" ~severity:Error
+               ~message:"hyperref loaded before geometry" ~count:1)
         else None
     | _ -> None
   in
@@ -1280,12 +1146,8 @@ let r_pkg_009 : rule =
          with Not_found -> ());
         if !cnt > 0 then
           Some
-            {
-              id = "PKG-009";
-              severity = Info;
-              message = "TikZ libraries loaded inside document body";
-              count = !cnt;
-            }
+            (mk_result ~id:"PKG-009" ~severity:Info
+               ~message:"TikZ libraries loaded inside document body" ~count:!cnt)
         else None
   in
   { id = "PKG-009"; run; languages = [] }
@@ -1316,12 +1178,8 @@ let r_pkg_011 : rule =
     in
     if uses_booktabs_cmds && not (has_package s "booktabs") then
       Some
-        {
-          id = "PKG-011";
-          severity = Warning;
-          message = "booktabs required but not loaded for \\toprule";
-          count = 1;
-        }
+        (mk_result ~id:"PKG-011" ~severity:Warning
+           ~message:"booktabs required but not loaded for \\toprule" ~count:1)
     else None
   in
   { id = "PKG-011"; run; languages = [] }
@@ -1339,12 +1197,8 @@ let r_pkg_012 : rule =
     in
     if has_enquote && not (has_package s "csquotes") then
       Some
-        {
-          id = "PKG-012";
-          severity = Error;
-          message = "csquotes not loaded when \\enquote used";
-          count = 1;
-        }
+        (mk_result ~id:"PKG-012" ~severity:Error
+           ~message:"csquotes not loaded when \\enquote used" ~count:1)
     else None
   in
   { id = "PKG-012"; run; languages = [] }
@@ -1362,12 +1216,8 @@ let r_pkg_015 : rule =
       in
       if xeluatex then
         Some
-          {
-            id = "PKG-015";
-            severity = Warning;
-            message = "inputenc loaded under XeLaTeX/LuaLaTeX";
-            count = 1;
-          }
+          (mk_result ~id:"PKG-015" ~severity:Warning
+             ~message:"inputenc loaded under XeLaTeX/LuaLaTeX" ~count:1)
       else None
     else None
   in
@@ -1395,12 +1245,9 @@ let r_pkg_020 : rule =
       in
       if not has_lib then
         Some
-          {
-            id = "PKG-020";
-            severity = Info;
-            message = "tikz external library not loaded when externalising";
-            count = 1;
-          }
+          (mk_result ~id:"PKG-020" ~severity:Info
+             ~message:"tikz external library not loaded when externalising"
+             ~count:1)
       else None
     else None
   in
@@ -1419,12 +1266,9 @@ let r_pkg_022 : rule =
     in
     if cnt > 0 then
       Some
-        {
-          id = "PKG-022";
-          severity = Warning;
-          message = "Obsolete package (epsfig, subfigure, natbib) detected";
-          count = cnt;
-        }
+        (mk_result ~id:"PKG-022" ~severity:Warning
+           ~message:"Obsolete package (epsfig, subfigure, natbib) detected"
+           ~count:cnt)
     else None
   in
   { id = "PKG-022"; run; languages = [] }
@@ -1456,12 +1300,8 @@ let r_pkg_023 : rule =
     | Some up, Some mp ->
         if up > mp then
           Some
-            {
-              id = "PKG-023";
-              severity = Error;
-              message = {|unicode‑math must load before microtype|};
-              count = 1;
-            }
+            (mk_result ~id:"PKG-023" ~severity:Error
+               ~message:{|unicode‑math must load before microtype|} ~count:1)
         else None
     | _ -> None
   in
@@ -1488,12 +1328,8 @@ let r_lang_002 : rule =
     in
     if has_bare || has_empty then
       Some
-        {
-          id = "LANG-002";
-          severity = Warning;
-          message = "babel language option missing";
-          count = 1;
-        }
+        (mk_result ~id:"LANG-002" ~severity:Warning
+           ~message:"babel language option missing" ~count:1)
     else None
   in
   { id = "LANG-002"; run; languages = [] }
@@ -1504,12 +1340,9 @@ let r_lang_004 : rule =
   let run s =
     if has_package s "polyglossia" && has_package s "babel" then
       Some
-        {
-          id = "LANG-004";
-          severity = Error;
-          message = {|Polyglossia loaded alongside babel – mutual exclusion|};
-          count = 1;
-        }
+        (mk_result ~id:"LANG-004" ~severity:Error
+           ~message:{|Polyglossia loaded alongside babel – mutual exclusion|}
+           ~count:1)
     else None
   in
   { id = "LANG-004"; run; languages = [] }
@@ -1540,12 +1373,9 @@ let r_tikz_007 : rule =
     | Some tp, Some hp ->
         if tp > hp then
           Some
-            {
-              id = "TIKZ-007";
-              severity = Warning;
-              message = {|TikZ loaded after hyperref – reorder required|};
-              count = 1;
-            }
+            (mk_result ~id:"TIKZ-007" ~severity:Warning
+               ~message:{|TikZ loaded after hyperref – reorder required|}
+               ~count:1)
         else None
     | _ -> None
   in
@@ -1572,12 +1402,8 @@ let r_fig_010 : rule =
     in
     if cnt > 0 then
       Some
-        {
-          id = "FIG-010";
-          severity = Warning;
-          message = "Subfigure environment without \\subcaption";
-          count = cnt;
-        }
+        (mk_result ~id:"FIG-010" ~severity:Warning
+           ~message:"Subfigure environment without \\subcaption" ~count:cnt)
     else None
   in
   { id = "FIG-010"; run; languages = [] }
@@ -1598,12 +1424,8 @@ let r_fig_013 : rule =
      with Not_found -> ());
     if !cnt > 0 then
       Some
-        {
-          id = "FIG-013";
-          severity = Info;
-          message = "Graphicx option scale used instead of width";
-          count = !cnt;
-        }
+        (mk_result ~id:"FIG-013" ~severity:Info
+           ~message:"Graphicx option scale used instead of width" ~count:!cnt)
     else None
   in
   { id = "FIG-013"; run; languages = [] }
@@ -1621,12 +1443,8 @@ let r_pkg_008 : rule =
     in
     if has_xcolor_no_dvips then
       Some
-        {
-          id = "PKG-008";
-          severity = Info;
-          message = "xcolor loaded without dvipsnames option";
-          count = 1;
-        }
+        (mk_result ~id:"PKG-008" ~severity:Info
+           ~message:"xcolor loaded without dvipsnames option" ~count:1)
     else None
   in
   { id = "PKG-008"; run; languages = [] }
@@ -1644,12 +1462,8 @@ let r_pkg_010 : rule =
     in
     if has_deprecated then
       Some
-        {
-          id = "PKG-010";
-          severity = Warning;
-          message = "biblatex loaded with deprecated backend=biber";
-          count = 1;
-        }
+        (mk_result ~id:"PKG-010" ~severity:Warning
+           ~message:"biblatex loaded with deprecated backend=biber" ~count:1)
     else None
   in
   { id = "PKG-010"; run; languages = [] }
@@ -1660,12 +1474,8 @@ let r_pkg_013 : rule =
   let run s =
     if has_package s "fontspec" && not (has_package s "microtype") then
       Some
-        {
-          id = "PKG-013";
-          severity = Warning;
-          message = "microtype not loaded on XeLaTeX path";
-          count = 1;
-        }
+        (mk_result ~id:"PKG-013" ~severity:Warning
+           ~message:"microtype not loaded on XeLaTeX path" ~count:1)
     else None
   in
   { id = "PKG-013"; run; languages = [] }
@@ -1689,12 +1499,8 @@ let r_pkg_014 : rule =
        with Not_found -> ());
       if !cnt > 0 then
         Some
-          {
-            id = "PKG-014";
-            severity = Warning;
-            message = "siunitx v2 API detected (outdated)";
-            count = !cnt;
-          }
+          (mk_result ~id:"PKG-014" ~severity:Warning
+             ~message:"siunitx v2 API detected (outdated)" ~count:!cnt)
       else None
   in
   { id = "PKG-014"; run; languages = [] }
@@ -1712,12 +1518,8 @@ let r_pkg_016 : rule =
     in
     if has_pdftex_opt then
       Some
-        {
-          id = "PKG-016";
-          severity = Warning;
-          message = "graphicx option pdftex incompatible with engine";
-          count = 1;
-        }
+        (mk_result ~id:"PKG-016" ~severity:Warning
+           ~message:"graphicx option pdftex incompatible with engine" ~count:1)
     else None
   in
   { id = "PKG-016"; run; languages = [] }
@@ -1744,12 +1546,8 @@ let r_pkg_017 : rule =
       in
       if has_pdftex_marker then
         Some
-          {
-            id = "PKG-017";
-            severity = Error;
-            message = "fontspec loaded in pdfLaTeX";
-            count = 1;
-          }
+          (mk_result ~id:"PKG-017" ~severity:Error
+             ~message:"fontspec loaded in pdfLaTeX" ~count:1)
       else None
   in
   { id = "PKG-017"; run; languages = [] }
@@ -1773,12 +1571,8 @@ let r_pkg_021 : rule =
       tbl;
     if !cnt > 0 then
       Some
-        {
-          id = "PKG-021";
-          severity = Error;
-          message = "Package loaded twice with conflicting options";
-          count = !cnt;
-        }
+        (mk_result ~id:"PKG-021" ~severity:Error
+           ~message:"Package loaded twice with conflicting options" ~count:!cnt)
     else None
   in
   { id = "PKG-021"; run; languages = [] }
@@ -1808,12 +1602,9 @@ let r_pkg_024 : rule =
       (List.rev !langs);
     if !dups > 0 then
       Some
-        {
-          id = "PKG-024";
-          severity = Warning;
-          message = {|polyglossia language duplicated via \setdefaultlanguage|};
-          count = !dups;
-        }
+        (mk_result ~id:"PKG-024" ~severity:Warning
+           ~message:{|polyglossia language duplicated via \setdefaultlanguage|}
+           ~count:!dups)
     else None
   in
   { id = "PKG-024"; run; languages = [] }
@@ -1839,12 +1630,9 @@ let r_pkg_025 : rule =
     in
     if has_xeluatex && has_pdftex_enc && has_inputenc then
       Some
-        {
-          id = "PKG-025";
-          severity = Warning;
-          message = "Engine option mismatch (xelatex=true on LuaLaTeX run)";
-          count = 1;
-        }
+        (mk_result ~id:"PKG-025" ~severity:Warning
+           ~message:"Engine option mismatch (xelatex=true on LuaLaTeX run)"
+           ~count:1)
     else None
   in
   { id = "PKG-025"; run; languages = [] }
@@ -1885,12 +1673,8 @@ let r_tab_003 : rule =
     in
     if cnt > 0 then
       Some
-        {
-          id = "TAB-003";
-          severity = Info;
-          message = "Decimal column not aligned on dot";
-          count = cnt;
-        }
+        (mk_result ~id:"TAB-003" ~severity:Info
+           ~message:"Decimal column not aligned on dot" ~count:cnt)
     else None
   in
   { id = "TAB-003"; run; languages = [] }
@@ -1931,12 +1715,8 @@ let r_tab_007 : rule =
     in
     if cnt > 0 then
       Some
-        {
-          id = "TAB-007";
-          severity = Info;
-          message = {|Text in numeric column without \multicolumn|};
-          count = cnt;
-        }
+        (mk_result ~id:"TAB-007" ~severity:Info
+           ~message:{|Text in numeric column without \multicolumn|} ~count:cnt)
     else None
   in
   { id = "TAB-007"; run; languages = [] }
@@ -1957,12 +1737,8 @@ let r_tab_008 : rule =
     in
     if cnt > 0 then
       Some
-        {
-          id = "TAB-008";
-          severity = Info;
-          message = {|Table > 30 rows – suggest longtable/xtab|};
-          count = cnt;
-        }
+        (mk_result ~id:"TAB-008" ~severity:Info
+           ~message:{|Table > 30 rows – suggest longtable/xtab|} ~count:cnt)
     else None
   in
   { id = "TAB-008"; run; languages = [] }
@@ -2008,12 +1784,9 @@ let r_tab_012 : rule =
      with Not_found -> ());
     if !cnt > 0 then
       Some
-        {
-          id = "TAB-012";
-          severity = Info;
-          message = {|Numeric column not aligned using siunitx S‑column|};
-          count = !cnt;
-        }
+        (mk_result ~id:"TAB-012" ~severity:Info
+           ~message:{|Numeric column not aligned using siunitx S‑column|}
+           ~count:!cnt)
     else None
   in
   { id = "TAB-012"; run; languages = [] }
@@ -2051,12 +1824,9 @@ let r_tab_013 : rule =
     in
     if cnt > 0 then
       Some
-        {
-          id = "TAB-013";
-          severity = Info;
-          message = "Caption position for longtable must be at top per style";
-          count = cnt;
-        }
+        (mk_result ~id:"TAB-013" ~severity:Info
+           ~message:"Caption position for longtable must be at top per style"
+           ~count:cnt)
     else None
   in
   { id = "TAB-013"; run; languages = [] }
@@ -2075,12 +1845,9 @@ let r_tab_015 : rule =
     in
     if cnt > 0 then
       Some
-        {
-          id = "TAB-015";
-          severity = Warning;
-          message = {|\multirow inside tabularx column X without raggedright|};
-          count = cnt;
-        }
+        (mk_result ~id:"TAB-015" ~severity:Warning
+           ~message:{|\multirow inside tabularx column X without raggedright|}
+           ~count:cnt)
     else None
   in
   { id = "TAB-015"; run; languages = [] }
@@ -2101,12 +1868,9 @@ let r_tab_016 : rule =
      with Not_found -> ());
     if !cnt > 0 then
       Some
-        {
-          id = "TAB-016";
-          severity = Info;
-          message = "Centred 'c' column in longtable holds ragged text";
-          count = !cnt;
-        }
+        (mk_result ~id:"TAB-016" ~severity:Info
+           ~message:"Centred 'c' column in longtable holds ragged text"
+           ~count:!cnt)
     else None
   in
   { id = "TAB-016"; run; languages = [] }
@@ -2125,12 +1889,8 @@ let r_fig_012 : rule =
     in
     if cnt > 0 then
       Some
-        {
-          id = "FIG-012";
-          severity = Info;
-          message = "Figure listed in LoF but not referenced";
-          count = cnt;
-        }
+        (mk_result ~id:"FIG-012" ~severity:Info
+           ~message:"Figure listed in LoF but not referenced" ~count:cnt)
     else None
   in
   { id = "FIG-012"; run; languages = [] }
@@ -2149,12 +1909,8 @@ let r_fig_014 : rule =
     in
     if cnt > 0 then
       Some
-        {
-          id = "FIG-014";
-          severity = Info;
-          message = {|Figure caption exceeds 300 characters|};
-          count = cnt;
-        }
+        (mk_result ~id:"FIG-014" ~severity:Info
+           ~message:{|Figure caption exceeds 300 characters|} ~count:cnt)
     else None
   in
   { id = "FIG-014"; run; languages = [] }
@@ -2177,12 +1933,9 @@ let r_fig_017 : rule =
       let has_landscape = contains_substring s "landscape" in
       if not has_landscape then
         Some
-          {
-            id = "FIG-017";
-            severity = Warning;
-            message = "Sidewaysfigure used with portrait page layout";
-            count = !cnt;
-          }
+          (mk_result ~id:"FIG-017" ~severity:Warning
+             ~message:"Sidewaysfigure used with portrait page layout"
+             ~count:!cnt)
       else None
     else None
   in
@@ -2203,12 +1956,8 @@ let r_fig_019 : rule =
     in
     if cnt > 0 then
       Some
-        {
-          id = "FIG-019";
-          severity = Info;
-          message = {|Subcaption label missing (a), (b)…|};
-          count = cnt;
-        }
+        (mk_result ~id:"FIG-019" ~severity:Info
+           ~message:{|Subcaption label missing (a), (b)…|} ~count:cnt)
     else None
   in
   { id = "FIG-019"; run; languages = [] }
@@ -2242,12 +1991,9 @@ let r_fig_022 : rule =
     in
     if cnt > 0 then
       Some
-        {
-          id = "FIG-022";
-          severity = Info;
-          message = "Figure caption identical to surrounding sentence";
-          count = cnt;
-        }
+        (mk_result ~id:"FIG-022" ~severity:Info
+           ~message:"Figure caption identical to surrounding sentence"
+           ~count:cnt)
     else None
   in
   { id = "FIG-022"; run; languages = [] }
@@ -2268,12 +2014,9 @@ let r_fig_024 : rule =
      with Not_found -> ());
     if !cnt > 0 then
       Some
-        {
-          id = "FIG-024";
-          severity = Info;
-          message = {|Alt‑text exceeds 140 chars—trim for accessibility|};
-          count = !cnt;
-        }
+        (mk_result ~id:"FIG-024" ~severity:Info
+           ~message:{|Alt‑text exceeds 140 chars—trim for accessibility|}
+           ~count:!cnt)
     else None
   in
   { id = "FIG-024"; run; languages = [] }
@@ -2305,12 +2048,9 @@ let r_fig_025 : rule =
     in
     if cnt > 0 then
       Some
-        {
-          id = "FIG-025";
-          severity = Info;
-          message = {|Alt‑text identical to caption—reduce redundancy|};
-          count = cnt;
-        }
+        (mk_result ~id:"FIG-025" ~severity:Info
+           ~message:{|Alt‑text identical to caption—reduce redundancy|}
+           ~count:cnt)
     else None
   in
   { id = "FIG-025"; run; languages = [] }
@@ -2338,12 +2078,9 @@ let r_math_075 : rule =
       eq_envs;
     if !cnt > 0 then
       Some
-        {
-          id = "MATH-075";
-          severity = Warning;
-          message = {|Equation number suppressed with \nonumber but referenced|};
-          count = !cnt;
-        }
+        (mk_result ~id:"MATH-075" ~severity:Warning
+           ~message:{|Equation number suppressed with \nonumber but referenced|}
+           ~count:!cnt)
     else None
   in
   { id = "MATH-075"; run; languages = [] }
@@ -2375,12 +2112,8 @@ let r_math_080 : rule =
       envs;
     if !cnt > 0 then
       Some
-        {
-          id = "MATH-080";
-          severity = Info;
-          message = "Equation exceeds 3 alignment columns";
-          count = !cnt;
-        }
+        (mk_result ~id:"MATH-080" ~severity:Info
+           ~message:"Equation exceeds 3 alignment columns" ~count:!cnt)
     else None
   in
   { id = "MATH-080"; run; languages = [] }
@@ -2410,13 +2143,10 @@ let r_cmd_012 : rule =
         in
         if found then
           Some
-            {
-              id = "CMD-012";
-              severity = Warning;
-              message =
-                {|\renewcommand\thesection redefined after hyperref — bookmark mismatch|};
-              count = 1;
-            }
+            (mk_result ~id:"CMD-012" ~severity:Warning
+               ~message:
+                 {|\renewcommand\thesection redefined after hyperref — bookmark mismatch|}
+               ~count:1)
         else None
   in
   { id = "CMD-012"; run; languages = [] }
@@ -2442,12 +2172,8 @@ let r_doc_004 : rule =
     | Some ap, Some cp ->
         if ap < cp then
           Some
-            {
-              id = "DOC-004";
-              severity = Info;
-              message = "Acknowledgment section before conclusion";
-              count = 1;
-            }
+            (mk_result ~id:"DOC-004" ~severity:Info
+               ~message:"Acknowledgment section before conclusion" ~count:1)
         else None
     | _ -> None
   in
@@ -2484,12 +2210,9 @@ let r_l3_001 : rule =
     in
     if has_expl3 && has_2e then
       Some
-        {
-          id = "L3-001";
-          severity = Info;
-          message = {|LaTeX3 \tl_new:N in preamble mixed with 2e macros|};
-          count = 1;
-        }
+        (mk_result ~id:"L3-001" ~severity:Info
+           ~message:{|LaTeX3 \tl_new:N in preamble mixed with 2e macros|}
+           ~count:1)
     else None
   in
   { id = "L3-001"; run; languages = [] }
@@ -2514,12 +2237,9 @@ let r_l3_002 : rule =
          with Not_found -> ());
         if !cnt > 0 then
           Some
-            {
-              id = "L3-002";
-              severity = Warning;
-              message = {|Expl3 variable declared after \begin{document}|};
-              count = !cnt;
-            }
+            (mk_result ~id:"L3-002" ~severity:Warning
+               ~message:{|Expl3 variable declared after \begin{document}|}
+               ~count:!cnt)
         else None
   in
   { id = "L3-002"; run; languages = [] }
@@ -2549,12 +2269,8 @@ let r_l3_003 : rule =
     in
     if has_expl3 && has_etoolbox then
       Some
-        {
-          id = "L3-003";
-          severity = Warning;
-          message = "Expl3 and etoolbox patch macros combined";
-          count = 1;
-        }
+        (mk_result ~id:"L3-003" ~severity:Warning
+           ~message:"Expl3 and etoolbox patch macros combined" ~count:1)
     else None
   in
   { id = "L3-003"; run; languages = [] }
@@ -2574,12 +2290,8 @@ let r_l3_004 : rule =
      with Not_found -> ());
     if !cnt > 0 then
       Some
-        {
-          id = "L3-004";
-          severity = Info;
-          message = {|Undocumented \__module_internal:N used|};
-          count = !cnt;
-        }
+        (mk_result ~id:"L3-004" ~severity:Info
+           ~message:{|Undocumented \__module_internal:N used|} ~count:!cnt)
     else None
   in
   { id = "L3-004"; run; languages = [] }
@@ -2600,12 +2312,8 @@ let r_l3_005 : rule =
     let has_guard = contains_substring s "\\ExplSyntaxOn" in
     if has_expl3 && not has_guard then
       Some
-        {
-          id = "L3-005";
-          severity = Error;
-          message = {|Missing \ExplSyntaxOn guard around expl3 code|};
-          count = 1;
-        }
+        (mk_result ~id:"L3-005" ~severity:Error
+           ~message:{|Missing \ExplSyntaxOn guard around expl3 code|} ~count:1)
     else None
   in
   { id = "L3-005"; run; languages = [] }
@@ -2647,12 +2355,8 @@ let r_l3_006 : rule =
     in
     if cnt > 0 then
       Some
-        {
-          id = "L3-006";
-          severity = Warning;
-          message = "Expl3 variable clobbers package macro name";
-          count = cnt;
-        }
+        (mk_result ~id:"L3-006" ~severity:Warning
+           ~message:"Expl3 variable clobbers package macro name" ~count:cnt)
     else None
   in
   { id = "L3-006"; run; languages = [] }
@@ -2678,12 +2382,8 @@ let r_l3_007 : rule =
     in
     if has_camel && has_snake then
       Some
-        {
-          id = "L3-007";
-          severity = Info;
-          message = "Mix of camelCase and snake_case in expl3 names";
-          count = 1;
-        }
+        (mk_result ~id:"L3-007" ~severity:Info
+           ~message:"Mix of camelCase and snake_case in expl3 names" ~count:1)
     else None
   in
   { id = "L3-007"; run; languages = [] }
@@ -2706,12 +2406,8 @@ let r_l3_009 : rule =
      with Not_found -> ());
     if !cnt > 0 then
       Some
-        {
-          id = "L3-009";
-          severity = Info;
-          message = "LaTeX3 function deprecated _n: variant used";
-          count = !cnt;
-        }
+        (mk_result ~id:"L3-009" ~severity:Info
+           ~message:"LaTeX3 function deprecated _n: variant used" ~count:!cnt)
     else None
   in
   { id = "L3-009"; run; languages = [] }
@@ -2740,12 +2436,9 @@ let r_l3_011 : rule =
     in
     if has_pdftex && has_luaxe then
       Some
-        {
-          id = "L3-011";
-          severity = Warning;
-          message = "Engine‑branch uses pdfTeX primitive in Lua/XeTeX path";
-          count = 1;
-        }
+        (mk_result ~id:"L3-011" ~severity:Warning
+           ~message:"Engine‑branch uses pdfTeX primitive in Lua/XeTeX path"
+           ~count:1)
     else None
   in
   { id = "L3-011"; run; languages = [] }
@@ -2775,12 +2468,8 @@ let r_tikz_001 : rule =
      with Not_found -> ());
     if !cnt > 0 then
       Some
-        {
-          id = "TIKZ-001";
-          severity = Info;
-          message = "TikZ picture outside figure environment";
-          count = !cnt;
-        }
+        (mk_result ~id:"TIKZ-001" ~severity:Info
+           ~message:"TikZ picture outside figure environment" ~count:!cnt)
     else None
   in
   { id = "TIKZ-001"; run; languages = [] }
@@ -2809,12 +2498,8 @@ let r_tikz_003 : rule =
     in
     if cnt > 0 then
       Some
-        {
-          id = "TIKZ-003";
-          severity = Info;
-          message = "pgfplots axis labels not in math mode";
-          count = cnt;
-        }
+        (mk_result ~id:"TIKZ-003" ~severity:Info
+           ~message:"pgfplots axis labels not in math mode" ~count:cnt)
     else None
   in
   { id = "TIKZ-003"; run; languages = [] }
@@ -2834,12 +2519,8 @@ let r_tikz_004 : rule =
      with Not_found -> ());
     if !cnt > 0 then
       Some
-        {
-          id = "TIKZ-004";
-          severity = Info;
-          message = "Hard‑coded RGB values instead of xcolor names";
-          count = !cnt;
-        }
+        (mk_result ~id:"TIKZ-004" ~severity:Info
+           ~message:"Hard‑coded RGB values instead of xcolor names" ~count:!cnt)
     else None
   in
   { id = "TIKZ-004"; run; languages = [] }
@@ -2858,12 +2539,9 @@ let r_tikz_006 : rule =
     in
     if cnt > 0 then
       Some
-        {
-          id = "TIKZ-006";
-          severity = Warning;
-          message = {|Missing \caption for tikzpicture inside figure|};
-          count = cnt;
-        }
+        (mk_result ~id:"TIKZ-006" ~severity:Warning
+           ~message:{|Missing \caption for tikzpicture inside figure|}
+           ~count:cnt)
     else None
   in
   { id = "TIKZ-006"; run; languages = [] }
@@ -2890,12 +2568,8 @@ let r_tikz_009 : rule =
       let has_lib = contains_substring s "arrows.meta" in
       if not has_lib then
         Some
-          {
-            id = "TIKZ-009";
-            severity = Info;
-            message = "TikZ library arrows.meta missing for arrow tips";
-            count = 1;
-          }
+          (mk_result ~id:"TIKZ-009" ~severity:Info
+             ~message:"TikZ library arrows.meta missing for arrow tips" ~count:1)
       else None
   in
   { id = "TIKZ-009"; run; languages = [] }
@@ -2918,12 +2592,8 @@ let r_tikz_010 : rule =
      with Not_found -> ());
     if !cnt > 0 then
       Some
-        {
-          id = "TIKZ-010";
-          severity = Info;
-          message = {|Deprecated \pgfplotsset key used|};
-          count = !cnt;
-        }
+        (mk_result ~id:"TIKZ-010" ~severity:Info
+           ~message:{|Deprecated \pgfplotsset key used|} ~count:!cnt)
     else None
   in
   { id = "TIKZ-010"; run; languages = [] }
@@ -2979,13 +2649,10 @@ let r_lang_001 : rule =
           in
           if cnt > 0 then
             Some
-              {
-                id = "LANG-001";
-                severity = Info;
-                message =
-                  {|\usepackage[british]{babel} but US spelling detected|};
-                count = cnt;
-              }
+              (mk_result ~id:"LANG-001" ~severity:Info
+                 ~message:
+                   {|\usepackage[british]{babel} but US spelling detected|}
+                 ~count:cnt)
           else None
   in
   { id = "LANG-001"; run; languages = [] }
@@ -3014,12 +2681,9 @@ let r_lang_006 : rule =
         | Some ap, Some lp ->
             if ap < lp then
               Some
-                {
-                  id = "LANG-006";
-                  severity = Info;
-                  message = "Non‑English abstract before \\selectlanguage";
-                  count = 1;
-                }
+                (mk_result ~id:"LANG-006" ~severity:Info
+                   ~message:"Non‑English abstract before \\selectlanguage"
+                   ~count:1)
             else None
         | _ -> None)
   in
@@ -3060,12 +2724,9 @@ let r_lang_007 : rule =
            with Not_found -> ());
           if !cnt > 0 then
             Some
-              {
-                id = "LANG-007";
-                severity = Info;
-                message = "babel shorthand \" mis‑used instead of \\og … \\fg";
-                count = !cnt;
-              }
+              (mk_result ~id:"LANG-007" ~severity:Info
+                 ~message:"babel shorthand \" mis‑used instead of \\og … \\fg"
+                 ~count:!cnt)
           else None
   in
   { id = "LANG-007"; run; languages = [] }
@@ -3118,12 +2779,9 @@ let r_lang_013 : rule =
             match (lang_before, lang_after) with
             | Some lb, Some la when lb <> la ->
                 Some
-                  {
-                    id = "LANG-013";
-                    severity = Info;
-                    message = {|Abstract language differs from \selectlanguage|};
-                    count = 1;
-                  }
+                  (mk_result ~id:"LANG-013" ~severity:Info
+                     ~message:{|Abstract language differs from \selectlanguage|}
+                     ~count:1)
             | _ -> None))
   in
   { id = "LANG-013"; run; languages = [] }
@@ -3150,12 +2808,8 @@ let r_col_006 : rule =
       in
       if has_pdftex then
         Some
-          {
-            id = "COL-006";
-            severity = Warning;
-            message = "xcolor option dvipsnames used with pdfLaTeX";
-            count = 1;
-          }
+          (mk_result ~id:"COL-006" ~severity:Warning
+             ~message:"xcolor option dvipsnames used with pdfLaTeX" ~count:1)
       else None
   in
   { id = "COL-006"; run; languages = [] }
@@ -3183,12 +2837,8 @@ let r_l3_008 : rule =
     in
     if has_expl3 && not has_provides then
       Some
-        {
-          id = "L3-008";
-          severity = Warning;
-          message = {|Expl3 module lacks \ProvidesExplPackage|};
-          count = 1;
-        }
+        (mk_result ~id:"L3-008" ~severity:Warning
+           ~message:{|Expl3 module lacks \ProvidesExplPackage|} ~count:1)
     else None
   in
   { id = "L3-008"; run; languages = [] }
@@ -3214,12 +2864,9 @@ let r_l3_010 : rule =
     let off_count = count_matches off_re s in
     if on_count > 0 && on_count > off_count then
       Some
-        {
-          id = "L3-010";
-          severity = Info;
-          message = {|\ExplSyntaxOff missing at end of file|};
-          count = on_count - off_count;
-        }
+        (mk_result ~id:"L3-010" ~severity:Info
+           ~message:{|\ExplSyntaxOff missing at end of file|}
+           ~count:(on_count - off_count))
     else None
   in
   { id = "L3-010"; run; languages = [] }
@@ -3239,12 +2886,9 @@ let r_lay_024 : rule =
      with Not_found -> ());
     if !cnt > 0 then
       Some
-        {
-          id = "LAY-024";
-          severity = Warning;
-          message = "\\subsubsubsection depth > 3 without class support";
-          count = !cnt;
-        }
+        (mk_result ~id:"LAY-024" ~severity:Warning
+           ~message:"\\subsubsubsection depth > 3 without class support"
+           ~count:!cnt)
     else None
   in
   { id = "LAY-024"; run; languages = [] }
@@ -3274,12 +2918,8 @@ let r_meta_002 : rule =
     match has_date with
     | Some true ->
         Some
-          {
-            id = "META-002";
-            severity = Info;
-            message = {|Revision hash missing from \date field|};
-            count = 1;
-          }
+          (mk_result ~id:"META-002" ~severity:Info
+             ~message:{|Revision hash missing from \date field|} ~count:1)
     | _ -> None
   in
   { id = "META-002"; run; languages = [] }
@@ -3314,12 +2954,8 @@ let r_rtl_005 : rule =
       in
       if not has_font_spec then
         Some
-          {
-            id = "RTL-005";
-            severity = Warning;
-            message = "Polyglossia RTL font not specified";
-            count = 1;
-          }
+          (mk_result ~id:"RTL-005" ~severity:Warning
+             ~message:"Polyglossia RTL font not specified" ~count:1)
       else None
     else None
   in
@@ -3350,12 +2986,8 @@ let r_bib_002 : rule =
      with Not_found -> ());
     if !cnt > 0 then
       Some
-        {
-          id = "BIB-002";
-          severity = Info;
-          message = "DOI not normalised to https://doi.org/ form";
-          count = !cnt;
-        }
+        (mk_result ~id:"BIB-002" ~severity:Info
+           ~message:"DOI not normalised to https://doi.org/ form" ~count:!cnt)
     else None
   in
   { id = "BIB-002"; run; languages = [] }
@@ -3388,13 +3020,10 @@ let r_bib_003 : rule =
      with Not_found -> ());
     if !cnt > 0 then
       Some
-        {
-          id = "BIB-003";
-          severity = Info;
-          message =
-            "Journal title capitalisation inconsistent with @string definition";
-          count = !cnt;
-        }
+        (mk_result ~id:"BIB-003" ~severity:Info
+           ~message:
+             "Journal title capitalisation inconsistent with @string definition"
+           ~count:!cnt)
     else None
   in
   { id = "BIB-003"; run; languages = [] }
@@ -3425,12 +3054,8 @@ let r_bib_004 : rule =
       entries;
     if !cnt > 0 then
       Some
-        {
-          id = "BIB-004";
-          severity = Warning;
-          message = "Book entry lacks publisher field";
-          count = !cnt;
-        }
+        (mk_result ~id:"BIB-004" ~severity:Warning
+           ~message:"Book entry lacks publisher field" ~count:!cnt)
     else None
   in
   { id = "BIB-004"; run; languages = [] }
@@ -3454,12 +3079,8 @@ let r_bib_005 : rule =
       entries;
     if !cnt > 0 then
       Some
-        {
-          id = "BIB-005";
-          severity = Info;
-          message = "URL present without urldate";
-          count = !cnt;
-        }
+        (mk_result ~id:"BIB-005" ~severity:Info
+           ~message:"URL present without urldate" ~count:!cnt)
     else None
   in
   { id = "BIB-005"; run; languages = [] }
@@ -3500,12 +3121,9 @@ let r_bib_006 : rule =
      with Not_found -> ());
     if !cnt > 0 then
       Some
-        {
-          id = "BIB-006";
-          severity = Info;
-          message = "Author/editor names not in “von Last, First” scheme";
-          count = !cnt;
-        }
+        (mk_result ~id:"BIB-006" ~severity:Info
+           ~message:"Author/editor names not in “von Last, First” scheme"
+           ~count:!cnt)
     else None
   in
   { id = "BIB-006"; run; languages = [] }
@@ -3527,12 +3145,9 @@ let r_bib_008 : rule =
       let cnt = count_matches re s in
       if cnt > 0 then
         Some
-          {
-            id = "BIB-008";
-            severity = Info;
-            message = "Camel‑case field names detected (e.g. `Title` → `title`)";
-            count = cnt;
-          }
+          (mk_result ~id:"BIB-008" ~severity:Info
+             ~message:"Camel‑case field names detected (e.g. `Title` → `title`)"
+             ~count:cnt)
       else None
   in
   { id = "BIB-008"; run; languages = [] }
@@ -3563,12 +3178,9 @@ let r_bib_009 : rule =
       entries;
     if !cnt > 0 then
       Some
-        {
-          id = "BIB-009";
-          severity = Error;
-          message = "In‑proceedings entry missing required `booktitle` field";
-          count = !cnt;
-        }
+        (mk_result ~id:"BIB-009" ~severity:Error
+           ~message:"In‑proceedings entry missing required `booktitle` field"
+           ~count:!cnt)
     else None
   in
   { id = "BIB-009"; run; languages = [] }
@@ -3580,13 +3192,10 @@ let r_bib_010 : rule =
     let cnt = count_matches re s in
     if cnt > 0 then
       Some
-        {
-          id = "BIB-010";
-          severity = Info;
-          message =
-            "`month` field uses numeric literal instead of `#jan#` macro";
-          count = cnt;
-        }
+        (mk_result ~id:"BIB-010" ~severity:Info
+           ~message:
+             "`month` field uses numeric literal instead of `#jan#` macro"
+           ~count:cnt)
     else None
   in
   { id = "BIB-010"; run; languages = [] }
@@ -3598,12 +3207,9 @@ let r_bib_011 : rule =
     let cnt = count_matches re s in
     if cnt > 0 then
       Some
-        {
-          id = "BIB-011";
-          severity = Info;
-          message = "Legacy `note = {URL: …}` field detected; move to `url`";
-          count = cnt;
-        }
+        (mk_result ~id:"BIB-011" ~severity:Info
+           ~message:"Legacy `note = {URL: …}` field detected; move to `url`"
+           ~count:cnt)
     else None
   in
   { id = "BIB-011"; run; languages = [] }
@@ -3641,14 +3247,11 @@ let r_bib_012 : rule =
      with Not_found -> ());
     if !cnt > 0 then
       Some
-        {
-          id = "BIB-012";
-          severity = Warning;
-          message =
-            "`et al.` hard‑coded in author list instead of letting Bib(La)TeX \
-             truncate";
-          count = !cnt;
-        }
+        (mk_result ~id:"BIB-012" ~severity:Warning
+           ~message:
+             "`et al.` hard‑coded in author list instead of letting Bib(La)TeX \
+              truncate"
+           ~count:!cnt)
     else None
   in
   { id = "BIB-012"; run; languages = [] }
@@ -3678,12 +3281,9 @@ let r_bib_015 : rule =
      with Not_found -> ());
     if !cnt > 0 then
       Some
-        {
-          id = "BIB-015";
-          severity = Info;
-          message = "Trailing period in `title` or `note` field is redundant";
-          count = !cnt;
-        }
+        (mk_result ~id:"BIB-015" ~severity:Info
+           ~message:"Trailing period in `title` or `note` field is redundant"
+           ~count:!cnt)
     else None
   in
   { id = "BIB-015"; run; languages = [] }
@@ -3712,12 +3312,9 @@ let r_bib_016 : rule =
       entries;
     if !cnt > 0 then
       Some
-        {
-          id = "BIB-016";
-          severity = Info;
-          message = "Both DOI and URL present—duplicate locator information";
-          count = !cnt;
-        }
+        (mk_result ~id:"BIB-016" ~severity:Info
+           ~message:"Both DOI and URL present—duplicate locator information"
+           ~count:!cnt)
     else None
   in
   { id = "BIB-016"; run; languages = [] }
@@ -3740,12 +3337,8 @@ let r_pkg_018 : rule =
     let cnt = min cnt (c1 + max c2 0 + max c4 c3) in
     if cnt > 0 then
       Some
-        {
-          id = "PKG-018";
-          severity = Info;
-          message = "hyperref option draft left enabled";
-          count = cnt;
-        }
+        (mk_result ~id:"PKG-018" ~severity:Info
+           ~message:"hyperref option draft left enabled" ~count:cnt)
     else None
   in
   { id = "PKG-018"; run; languages = [] }
@@ -3766,12 +3359,8 @@ let r_pkg_019 : rule =
     let cnt = c1 + c2 in
     if cnt > 0 then
       Some
-        {
-          id = "PKG-019";
-          severity = Warning;
-          message = "geometry margin < 1 cm";
-          count = cnt;
-        }
+        (mk_result ~id:"PKG-019" ~severity:Warning
+           ~message:"geometry margin < 1 cm" ~count:cnt)
     else None
   in
   { id = "PKG-019"; run; languages = [] }
@@ -3808,21 +3397,13 @@ let r_font_005 : rule =
         in
         if is_lm then
           Some
-            {
-              id = "FONT-005";
-              severity = Info;
-              message = "Fontspec fallback to Latin Modern detected";
-              count = 1;
-            }
+            (mk_result ~id:"FONT-005" ~severity:Info
+               ~message:"Fontspec fallback to Latin Modern detected" ~count:1)
         else None
       else
         Some
-          {
-            id = "FONT-005";
-            severity = Info;
-            message = "Fontspec fallback to Latin Modern detected";
-            count = 1;
-          }
+          (mk_result ~id:"FONT-005" ~severity:Info
+             ~message:"Fontspec fallback to Latin Modern detected" ~count:1)
   in
   { id = "FONT-005"; run; languages = [] }
 
@@ -3852,12 +3433,8 @@ let r_lay_015 : rule =
     check re_setstretch;
     if !cnt > 0 then
       Some
-        {
-          id = "LAY-015";
-          severity = Info;
-          message = "Line spacing < 1 or > 2";
-          count = !cnt;
-        }
+        (mk_result ~id:"LAY-015" ~severity:Info
+           ~message:"Line spacing < 1 or > 2" ~count:!cnt)
     else None
   in
   { id = "LAY-015"; run; languages = [] }
@@ -3874,12 +3451,9 @@ let r_lay_020 : rule =
     let cnt = c1 + c2 in
     if cnt > 0 then
       Some
-        {
-          id = "LAY-020";
-          severity = Info;
-          message = "Float placement parameters modified (\\topnumber …)";
-          count = cnt;
-        }
+        (mk_result ~id:"LAY-020" ~severity:Info
+           ~message:"Float placement parameters modified (\\topnumber …)"
+           ~count:cnt)
     else None
   in
   { id = "LAY-020"; run; languages = [] }
@@ -3891,12 +3465,8 @@ let r_lay_022 : rule =
     let cnt = count_matches re s in
     if cnt > 0 then
       Some
-        {
-          id = "LAY-022";
-          severity = Warning;
-          message = {|Global negative \parskip detected|};
-          count = cnt;
-        }
+        (mk_result ~id:"LAY-022" ~severity:Warning
+           ~message:{|Global negative \parskip detected|} ~count:cnt)
     else None
   in
   { id = "LAY-022"; run; languages = [] }
@@ -3924,12 +3494,8 @@ let r_ref_008 : rule =
     in
     if cnt > 0 then
       Some
-        {
-          id = "REF-008";
-          severity = Warning;
-          message = "Duplicate cite key in .bib file";
-          count = cnt;
-        }
+        (mk_result ~id:"REF-008" ~severity:Warning
+           ~message:"Duplicate cite key in .bib file" ~count:cnt)
     else None
   in
   { id = "REF-008"; run; languages = [] }
@@ -3965,12 +3531,8 @@ let r_meta_001 : rule =
       if has_producer then None
       else
         Some
-          {
-            id = "META-001";
-            severity = Info;
-            message = "PDF /Producer not set to deterministic hash";
-            count = 1;
-          }
+          (mk_result ~id:"META-001" ~severity:Info
+             ~message:"PDF /Producer not set to deterministic hash" ~count:1)
   in
   { id = "META-001"; run; languages = [] }
 
@@ -4013,13 +3575,10 @@ let r_pdf_010 : rule =
      with Not_found -> ());
     if !cnt > 0 then
       Some
-        {
-          id = "PDF-010";
-          severity = Info;
-          message =
-            "Outline/bookmark text contains '_' or '#' – use \\texorpdfstring";
-          count = !cnt;
-        }
+        (mk_result ~id:"PDF-010" ~severity:Info
+           ~message:
+             "Outline/bookmark text contains '_' or '#' – use \\texorpdfstring"
+           ~count:!cnt)
     else None
   in
   { id = "PDF-010"; run; languages = [] }
@@ -4055,12 +3614,9 @@ let r_tikz_005 : rule =
       if has_ext_lib || has_ext_cmd then None
       else
         Some
-          {
-            id = "TIKZ-005";
-            severity = Info;
-            message = "TikZ externalisation not enabled for large figures";
-            count = 1;
-          }
+          (mk_result ~id:"TIKZ-005" ~severity:Info
+             ~message:"TikZ externalisation not enabled for large figures"
+             ~count:1)
   in
   { id = "TIKZ-005"; run; languages = [] }
 
@@ -4101,12 +3657,8 @@ let r_bib_001 : rule =
      with Not_found -> ());
     if !cnt > 0 then
       Some
-        {
-          id = "BIB-001";
-          severity = Warning;
-          message = "Bibliography entry missing DOI or ISBN/ISSN";
-          count = !cnt;
-        }
+        (mk_result ~id:"BIB-001" ~severity:Warning
+           ~message:"Bibliography entry missing DOI or ISBN/ISSN" ~count:!cnt)
     else None
   in
   mk_rule "BIB-001" run
@@ -4135,12 +3687,8 @@ let r_bib_007 : rule =
     let cnt = count_dups 0 sorted in
     if cnt > 0 then
       Some
-        {
-          id = "BIB-007";
-          severity = Warning;
-          message = "Duplicate DOI appears in more than one entry";
-          count = cnt;
-        }
+        (mk_result ~id:"BIB-007" ~severity:Warning
+           ~message:"Duplicate DOI appears in more than one entry" ~count:cnt)
     else None
   in
   mk_rule "BIB-007" run
@@ -4174,13 +3722,10 @@ let r_bib_013 : rule =
      with Not_found -> ());
     if !cnt > 0 then
       Some
-        {
-          id = "BIB-013";
-          severity = Info;
-          message =
-            "Title capitalisation incorrect for selected bibliography style";
-          count = !cnt;
-        }
+        (mk_result ~id:"BIB-013" ~severity:Info
+           ~message:
+             "Title capitalisation incorrect for selected bibliography style"
+           ~count:!cnt)
     else None
   in
   mk_rule "BIB-013" run
@@ -4221,12 +3766,9 @@ let r_bib_014 : rule =
     let cnt = count_dups 0 sorted in
     if cnt > 0 then
       Some
-        {
-          id = "BIB-014";
-          severity = Warning;
-          message = "Duplicate author-year key without disambiguation suffix";
-          count = cnt;
-        }
+        (mk_result ~id:"BIB-014" ~severity:Warning
+           ~message:"Duplicate author-year key without disambiguation suffix"
+           ~count:cnt)
     else None
   in
   mk_rule "BIB-014" run
@@ -4250,12 +3792,8 @@ let r_bib_017 : rule =
      with Not_found -> ());
     if !cnt > 0 then
       Some
-        {
-          id = "BIB-017";
-          severity = Info;
-          message = "Bibliography title ends with punctuation mark";
-          count = !cnt;
-        }
+        (mk_result ~id:"BIB-017" ~severity:Info
+           ~message:"Bibliography title ends with punctuation mark" ~count:!cnt)
     else None
   in
   mk_rule "BIB-017" run
@@ -4269,12 +3807,8 @@ let r_font_003 : rule =
     if not has_microtype then None
     else if contains_substring s "protrusion=false" then
       Some
-        {
-          id = "FONT-003";
-          severity = Warning;
-          message = "Microtype protrusion disabled globally";
-          count = 1;
-        }
+        (mk_result ~id:"FONT-003" ~severity:Warning
+           ~message:"Microtype protrusion disabled globally" ~count:1)
     else None
   in
   mk_rule "FONT-003" run
@@ -4297,12 +3831,9 @@ let r_font_002 : rule =
     let unique = List.sort_uniq String.compare !sizes in
     if List.length unique > 2 then
       Some
-        {
-          id = "FONT-002";
-          severity = Info;
-          message = "Mixed optical sizes in paragraph";
-          count = List.length unique;
-        }
+        (mk_result ~id:"FONT-002" ~severity:Info
+           ~message:"Mixed optical sizes in paragraph"
+           ~count:(List.length unique))
     else None
   in
   mk_rule "FONT-002" run
@@ -4331,12 +3862,8 @@ let r_rtl_001 : rule =
     done;
     if !cnt > 0 then
       Some
-        {
-          id = "RTL-001";
-          severity = Warning;
-          message = "Mixture of RTL and LTR digits within number";
-          count = !cnt;
-        }
+        (mk_result ~id:"RTL-001" ~severity:Warning
+           ~message:"Mixture of RTL and LTR digits within number" ~count:!cnt)
     else None
   in
   mk_rule "RTL-001" run
@@ -4366,12 +3893,9 @@ let r_rtl_002 : rule =
     done;
     if !cnt > 0 then
       Some
-        {
-          id = "RTL-002";
-          severity = Info;
-          message = "Missing \\textLR around Latin acronym in Arabic text";
-          count = !cnt;
-        }
+        (mk_result ~id:"RTL-002" ~severity:Info
+           ~message:"Missing \\textLR around Latin acronym in Arabic text"
+           ~count:!cnt)
     else None
   in
   mk_rule "RTL-002" run
@@ -4381,12 +3905,9 @@ let r_meta_003 : rule =
   let run s =
     if contains_substring s "\\date{\\today}" then
       Some
-        {
-          id = "META-003";
-          severity = Warning;
-          message = "Build timestamp not reproducible (\\date{\\today})";
-          count = 1;
-        }
+        (mk_result ~id:"META-003" ~severity:Warning
+           ~message:"Build timestamp not reproducible (\\date{\\today})"
+           ~count:1)
     else None
   in
   mk_rule "META-003" run
@@ -4402,12 +3923,9 @@ let r_meta_004 : rule =
       contains_substring s "\\pdfinfo" && contains_substring s "CreationDate"
     then
       Some
-        {
-          id = "META-004";
-          severity = Info;
-          message = "PDF /CreationDate not stripped — build not reproducible";
-          count = 1;
-        }
+        (mk_result ~id:"META-004" ~severity:Info
+           ~message:"PDF /CreationDate not stripped — build not reproducible"
+           ~count:1)
     else None
   in
   mk_rule "META-004" run
@@ -4420,12 +3938,9 @@ let r_doc_005 : rule =
     let has_pdfkeywords = contains_substring s "pdfkeywords" in
     if has_keywords && has_hypersetup && not has_pdfkeywords then
       Some
-        {
-          id = "DOC-005";
-          severity = Info;
-          message = "\\keywords present but absent from PDF/XMP metadata";
-          count = 1;
-        }
+        (mk_result ~id:"DOC-005" ~severity:Info
+           ~message:"\\keywords present but absent from PDF/XMP metadata"
+           ~count:1)
     else None
   in
   mk_rule "DOC-005" run
@@ -4450,12 +3965,9 @@ let r_ref_012 : rule =
      with Not_found -> ());
     if !cnt > 0 then
       Some
-        {
-          id = "REF-012";
-          severity = Info;
-          message = "Reference text 'above/below' may contradict float position";
-          count = !cnt;
-        }
+        (mk_result ~id:"REF-012" ~severity:Info
+           ~message:"Reference text 'above/below' may contradict float position"
+           ~count:!cnt)
     else None
   in
   mk_rule "REF-012" run
@@ -4476,12 +3988,9 @@ let r_font_010 : rule =
      with Not_found -> ());
     if !cnt > 0 then
       Some
-        {
-          id = "FONT-010";
-          severity = Info;
-          message = "Digits in \\textsc not converted to small-caps figures";
-          count = !cnt;
-        }
+        (mk_result ~id:"FONT-010" ~severity:Info
+           ~message:"Digits in \\textsc not converted to small-caps figures"
+           ~count:!cnt)
     else None
   in
   mk_rule "FONT-010" run
@@ -4494,12 +4003,9 @@ let r_font_013 : rule =
     let has_tabularfigs = contains_substring s "\\tabularfigures" in
     if has_tabular && has_proportional && has_tabularfigs then
       Some
-        {
-          id = "FONT-013";
-          severity = Warning;
-          message = "Mixed proportional and tabular figures in same table";
-          count = 1;
-        }
+        (mk_result ~id:"FONT-013" ~severity:Warning
+           ~message:"Mixed proportional and tabular figures in same table"
+           ~count:1)
     else None
   in
   mk_rule "FONT-013" run
@@ -4519,12 +4025,8 @@ let r_pdf_005 : rule =
       in
       if not has_pdfa then
         Some
-          {
-            id = "PDF-005";
-            severity = Warning;
-            message = "PDF/A or PDF/UA compliance flag missing";
-            count = 1;
-          }
+          (mk_result ~id:"PDF-005" ~severity:Warning
+             ~message:"PDF/A or PDF/UA compliance flag missing" ~count:1)
       else None
   in
   mk_rule "PDF-005" run
@@ -4562,12 +4064,9 @@ let r_font_009 : rule =
      with Not_found -> ());
     if !cnt > 0 then
       Some
-        {
-          id = "FONT-009";
-          severity = Warning;
-          message = "Small-caps with non-ASCII chars — fallback may be visible";
-          count = !cnt;
-        }
+        (mk_result ~id:"FONT-009" ~severity:Warning
+           ~message:"Small-caps with non-ASCII chars — fallback may be visible"
+           ~count:!cnt)
     else None
   in
   mk_rule "FONT-009" run
@@ -4582,13 +4081,10 @@ let r_font_011 : rule =
     in
     if has_microtype && has_mathfont then
       Some
-        {
-          id = "FONT-011";
-          severity = Warning;
-          message =
-            "Microtype protrusion may mismatch between text and math fonts";
-          count = 1;
-        }
+        (mk_result ~id:"FONT-011" ~severity:Warning
+           ~message:
+             "Microtype protrusion may mismatch between text and math fonts"
+           ~count:1)
     else None
   in
   mk_rule "FONT-011" run
@@ -4612,12 +4108,9 @@ let r_font_012 : rule =
      with Not_found -> ());
     if !cnt > 0 then
       Some
-        {
-          id = "FONT-012";
-          severity = Info;
-          message = "Ligature adjacent to \\texttt may cause visual clash";
-          count = !cnt;
-        }
+        (mk_result ~id:"FONT-012" ~severity:Info
+           ~message:"Ligature adjacent to \\texttt may cause visual clash"
+           ~count:!cnt)
     else None
   in
   mk_rule "FONT-012" run
@@ -4639,12 +4132,9 @@ let r_chem_010 : rule =
     in
     if cnt > 0 then
       Some
-        {
-          id = "CHEM-010";
-          severity = Info;
-          message = "Reaction scheme line exceeds page width (> 120 chars)";
-          count = cnt;
-        }
+        (mk_result ~id:"CHEM-010" ~severity:Info
+           ~message:"Reaction scheme line exceeds page width (> 120 chars)"
+           ~count:cnt)
     else None
   in
   mk_rule "CHEM-010" run
@@ -4661,12 +4151,8 @@ let r_lang_009 : rule =
     in
     if has_ragged && has_nonlatin then
       Some
-        {
-          id = "LANG-009";
-          severity = Info;
-          message = "Ragged-right text in non-Latin script";
-          count = 1;
-        }
+        (mk_result ~id:"LANG-009" ~severity:Info
+           ~message:"Ragged-right text in non-Latin script" ~count:1)
     else None
   in
   mk_rule "LANG-009" run
@@ -4689,12 +4175,8 @@ let r_lang_010 : rule =
       in
       if has_ascii_digits then
         Some
-          {
-            id = "LANG-010";
-            severity = Info;
-            message = "Arabic digits in RTL context not localised";
-            count = 1;
-          }
+          (mk_result ~id:"LANG-010" ~severity:Info
+             ~message:"Arabic digits in RTL context not localised" ~count:1)
       else None
   in
   mk_rule "LANG-010" run
@@ -4724,12 +4206,8 @@ let r_cjk_009 : rule =
     done;
     if !cnt > 0 then
       Some
-        {
-          id = "CJK-009";
-          severity = Info;
-          message = "Western inter-word space between CJK glyphs";
-          count = !cnt;
-        }
+        (mk_result ~id:"CJK-009" ~severity:Info
+           ~message:"Western inter-word space between CJK glyphs" ~count:!cnt)
     else None
   in
   mk_rule "CJK-009" run
@@ -4750,12 +4228,8 @@ let r_cjk_011 : rule =
     in
     if cnt > 0 then
       Some
-        {
-          id = "CJK-011";
-          severity = Info;
-          message = "Hiragana prolonged-sound mark at line start";
-          count = cnt;
-        }
+        (mk_result ~id:"CJK-011" ~severity:Info
+           ~message:"Hiragana prolonged-sound mark at line start" ~count:cnt)
     else None
   in
   mk_rule "CJK-011" run
@@ -4776,13 +4250,10 @@ let r_cjk_013 : rule =
     in
     if cnt > 0 then
       Some
-        {
-          id = "CJK-013";
-          severity = Info;
-          message =
-            "Prohibited break before ideographic full stop at line start";
-          count = cnt;
-        }
+        (mk_result ~id:"CJK-013" ~severity:Info
+           ~message:
+             "Prohibited break before ideographic full stop at line start"
+           ~count:cnt)
     else None
   in
   mk_rule "CJK-013" run
@@ -4797,12 +4268,9 @@ let r_lang_005 : rule =
       let v = int_of_string (Re_compat.matched_group _mr 1 s) in
       if v < 50 then
         Some
-          {
-            id = "LANG-005";
-            severity = Info;
-            message = Printf.sprintf "Hyphen-penalty too low (%d < 50)" v;
-            count = 1;
-          }
+          (mk_result ~id:"LANG-005" ~severity:Info
+             ~message:(Printf.sprintf "Hyphen-penalty too low (%d < 50)" v)
+             ~count:1)
       else None
     with Not_found | Failure _ -> None
   in
@@ -4830,14 +4298,11 @@ let r_lang_008 : rule =
     match (babel, spell) with
     | Some b, Some sp when b <> sp ->
         Some
-          {
-            id = "LANG-008";
-            severity = Info;
-            message =
-              Printf.sprintf
-                "Spell-checker dictionary '%s' differs from babel '%s'" sp b;
-            count = 1;
-          }
+          (mk_result ~id:"LANG-008" ~severity:Info
+             ~message:
+               (Printf.sprintf
+                  "Spell-checker dictionary '%s' differs from babel '%s'" sp b)
+             ~count:1)
     | _ -> None
   in
   mk_rule "LANG-008" run
@@ -4861,12 +4326,8 @@ let r_pkg_003 : rule =
       in
       if has_compat then
         Some
-          {
-            id = "PKG-003";
-            severity = Error;
-            message = "Incompatible microtype options under LuaTeX";
-            count = 1;
-          }
+          (mk_result ~id:"PKG-003" ~severity:Error
+             ~message:"Incompatible microtype options under LuaTeX" ~count:1)
       else None
     else None
   in
@@ -4879,12 +4340,8 @@ let r_pkg_006 : rule =
       contains_substring s "microtype" && contains_substring s "expansion=false"
     then
       Some
-        {
-          id = "PKG-006";
-          severity = Info;
-          message = "microtype expansion disabled";
-          count = 1;
-        }
+        (mk_result ~id:"PKG-006" ~severity:Info
+           ~message:"microtype expansion disabled" ~count:1)
     else None
   in
   mk_rule "PKG-006" run
@@ -4909,12 +4366,9 @@ let r_cjk_003 : rule =
     in
     if cnt > 0 then
       Some
-        {
-          id = "CJK-003";
-          severity = Info;
-          message = "Japanese kinsoku: forbidden break before small kana";
-          count = cnt;
-        }
+        (mk_result ~id:"CJK-003" ~severity:Info
+           ~message:"Japanese kinsoku: forbidden break before small kana"
+           ~count:cnt)
     else None
   in
   mk_rule "CJK-003" run
@@ -4929,12 +4383,8 @@ let r_cjk_005 : rule =
     in
     if has_zh_font && has_ja_font then
       Some
-        {
-          id = "CJK-005";
-          severity = Info;
-          message = "Mixed zh/ja fonts in same paragraph";
-          count = 1;
-        }
+        (mk_result ~id:"CJK-005" ~severity:Info
+           ~message:"Mixed zh/ja fonts in same paragraph" ~count:1)
     else None
   in
   mk_rule "CJK-005" run
@@ -4946,12 +4396,8 @@ let r_cjk_012 : rule =
     let has_setup = contains_substring s "\\xeCJKsetup" in
     if has_xecjk && not has_setup then
       Some
-        {
-          id = "CJK-012";
-          severity = Info;
-          message = "xeCJK spaceskip not tuned (\\xeCJKsetup)";
-          count = 1;
-        }
+        (mk_result ~id:"CJK-012" ~severity:Info
+           ~message:"xeCJK spaceskip not tuned (\\xeCJKsetup)" ~count:1)
     else None
   in
   mk_rule "CJK-012" run
@@ -4963,12 +4409,8 @@ let r_cjk_016 : rule =
     let has_ecglue = contains_substring s "CJKecglue" in
     if has_setup && not has_ecglue then
       Some
-        {
-          id = "CJK-016";
-          severity = Info;
-          message = "\\xeCJKsetup{CJKecglue} not tuned — wide gap";
-          count = 1;
-        }
+        (mk_result ~id:"CJK-016" ~severity:Info
+           ~message:"\\xeCJKsetup{CJKecglue} not tuned — wide gap" ~count:1)
     else None
   in
   mk_rule "CJK-016" run
@@ -4991,12 +4433,9 @@ let r_math_076 : rule =
     in
     if cnt > 0 then
       Some
-        {
-          id = "MATH-076";
-          severity = Info;
-          message = "Equation split across pages without \\allowbreak";
-          count = cnt;
-        }
+        (mk_result ~id:"MATH-076" ~severity:Info
+           ~message:"Equation split across pages without \\allowbreak"
+           ~count:cnt)
     else None
   in
   mk_rule "MATH-076" run
@@ -5024,13 +4463,10 @@ let r_math_103 : rule =
     in
     if cnt > 0 then
       Some
-        {
-          id = "MATH-103";
-          severity = Info;
-          message =
-            "\\left…\\right pair may shrink baseline; suggest \\mathopen";
-          count = cnt;
-        }
+        (mk_result ~id:"MATH-103" ~severity:Info
+           ~message:
+             "\\left…\\right pair may shrink baseline; suggest \\mathopen"
+           ~count:cnt)
     else None
   in
   mk_rule "MATH-103" run
@@ -5051,12 +4487,9 @@ let r_tab_004 : rule =
     in
     if cnt > 0 then
       Some
-        {
-          id = "TAB-004";
-          severity = Warning;
-          message = "Table width may exceed \\textwidth (line > 120 chars)";
-          count = cnt;
-        }
+        (mk_result ~id:"TAB-004" ~severity:Warning
+           ~message:"Table width may exceed \\textwidth (line > 120 chars)"
+           ~count:cnt)
     else None
   in
   mk_rule "TAB-004" run
@@ -5072,12 +4505,8 @@ let r_fig_008 : rule =
     let has_tikz = contains_substring s "\\begin{tikzpicture}" in
     if has_draft && has_tikz then
       Some
-        {
-          id = "FIG-008";
-          severity = Warning;
-          message = "TikZ figure compiled in draft mode";
-          count = 1;
-        }
+        (mk_result ~id:"FIG-008" ~severity:Warning
+           ~message:"TikZ figure compiled in draft mode" ~count:1)
     else None
   in
   mk_rule "FIG-008" run
@@ -5095,12 +4524,8 @@ let r_fig_011 : rule =
     in
     if has_eps && has_pdflatex then
       Some
-        {
-          id = "FIG-011";
-          severity = Warning;
-          message = "EPS graphic in pdfLaTeX run";
-          count = 1;
-        }
+        (mk_result ~id:"FIG-011" ~severity:Warning
+           ~message:"EPS graphic in pdfLaTeX run" ~count:1)
     else None
   in
   mk_rule "FIG-011" run
@@ -5133,14 +4558,11 @@ let r_lay_005 : rule =
         let lines = h /. b in
         if lines > 66.0 then
           Some
-            {
-              id = "LAY-005";
-              severity = Info;
-              message =
-                Printf.sprintf "Lines per page may exceed 66 (%.0f estimated)"
-                  lines;
-              count = 1;
-            }
+            (mk_result ~id:"LAY-005" ~severity:Info
+               ~message:
+                 (Printf.sprintf "Lines per page may exceed 66 (%.0f estimated)"
+                    lines)
+               ~count:1)
         else None
     | _ -> None
   in
@@ -5177,12 +4599,8 @@ let r_lay_013 : rule =
      with Not_found -> ());
     if !cnt > 0 then
       Some
-        {
-          id = "LAY-013";
-          severity = Info;
-          message = "Empty page without \\thispagestyle{empty}";
-          count = !cnt;
-        }
+        (mk_result ~id:"LAY-013" ~severity:Info
+           ~message:"Empty page without \\thispagestyle{empty}" ~count:!cnt)
     else None
   in
   mk_rule "LAY-013" run
@@ -5214,12 +4632,9 @@ let r_math_089 : rule =
     in
     if cnt > 0 then
       Some
-        {
-          id = "MATH-089";
-          severity = Warning;
-          message = "\\left…\\right pair may produce vertical gap > 1 ex";
-          count = cnt;
-        }
+        (mk_result ~id:"MATH-089" ~severity:Warning
+           ~message:"\\left…\\right pair may produce vertical gap > 1 ex"
+           ~count:cnt)
     else None
   in
   mk_rule "MATH-089" run
@@ -5246,12 +4661,8 @@ let r_fig_005 : rule =
      with Not_found -> ());
     if !cnt > 0 then
       Some
-        {
-          id = "FIG-005";
-          severity = Warning;
-          message = "Figure width exceeds \\linewidth";
-          count = !cnt;
-        }
+        (mk_result ~id:"FIG-005" ~severity:Warning
+           ~message:"Figure width exceeds \\linewidth" ~count:!cnt)
     else None
   in
   mk_rule "FIG-005" run
@@ -5276,12 +4687,8 @@ let r_fig_015 : rule =
     match (fig_pos, ref_pos) with
     | Some fp, Some rp when fp < rp ->
         Some
-          {
-            id = "FIG-015";
-            severity = Info;
-            message = "Figure placed before first reference in text";
-            count = 1;
-          }
+          (mk_result ~id:"FIG-015" ~severity:Info
+             ~message:"Figure placed before first reference in text" ~count:1)
     | _ -> None
   in
   mk_rule "FIG-015" run
@@ -5305,12 +4712,9 @@ let r_fig_018 : rule =
     in
     if cnt > 0 then
       Some
-        {
-          id = "FIG-018";
-          severity = Info;
-          message = "Float distance from reference may exceed 3 pages";
-          count = cnt;
-        }
+        (mk_result ~id:"FIG-018" ~severity:Info
+           ~message:"Float distance from reference may exceed 3 pages"
+           ~count:cnt)
     else None
   in
   mk_rule "FIG-018" run
@@ -5323,12 +4727,9 @@ let r_fig_020 : rule =
     | Some ctx ->
         if ctx.max_overfull_pt > 0.0 then
           Some
-            {
-              id = "FIG-020";
-              severity = Warning;
-              message = "Overfull \\hbox detected (may be in caption)";
-              count = List.length ctx.overfull_lines;
-            }
+            (mk_result ~id:"FIG-020" ~severity:Warning
+               ~message:"Overfull \\hbox detected (may be in caption)"
+               ~count:(List.length ctx.overfull_lines))
         else None
   in
   mk_rule "FIG-020" run
@@ -5345,12 +4746,9 @@ let r_lay_008 : rule =
     in
     if has_centered_class && has_raggedright then
       Some
-        {
-          id = "LAY-008";
-          severity = Info;
-          message = "Heading left-aligned but style may require centred";
-          count = 1;
-        }
+        (mk_result ~id:"LAY-008" ~severity:Info
+           ~message:"Heading left-aligned but style may require centred"
+           ~count:1)
     else None
   in
   mk_rule "LAY-008" run
@@ -5363,12 +4761,8 @@ let r_lay_010 : rule =
       && contains_substring s "\\chapter"
     then
       Some
-        {
-          id = "LAY-010";
-          severity = Info;
-          message = "Page number suppressed on chapter opener";
-          count = 1;
-        }
+        (mk_result ~id:"LAY-010" ~severity:Info
+           ~message:"Page number suppressed on chapter opener" ~count:1)
     else None
   in
   mk_rule "LAY-010" run
@@ -5384,12 +4778,9 @@ let r_lay_012 : rule =
     let has_cleardouble = contains_substring s "\\cleardoublepage" in
     if has_openright && has_chapter && not has_cleardouble then
       Some
-        {
-          id = "LAY-012";
-          severity = Info;
-          message = "Chapter may start on even page (missing \\cleardoublepage)";
-          count = 1;
-        }
+        (mk_result ~id:"LAY-012" ~severity:Info
+           ~message:"Chapter may start on even page (missing \\cleardoublepage)"
+           ~count:1)
     else None
   in
   mk_rule "LAY-012" run
@@ -5411,12 +4802,8 @@ let r_lay_019 : rule =
      with Not_found -> ());
     if !cnt > 0 then
       Some
-        {
-          id = "LAY-019";
-          severity = Info;
-          message = "Margin note may be wider than marginpar width";
-          count = !cnt;
-        }
+        (mk_result ~id:"LAY-019" ~severity:Info
+           ~message:"Margin note may be wider than marginpar width" ~count:!cnt)
     else None
   in
   mk_rule "LAY-019" run
@@ -5439,12 +4826,8 @@ let r_lay_023 : rule =
     in
     if cnt > 3 then
       Some
-        {
-          id = "LAY-023";
-          severity = Info;
-          message = "Multiple single-sentence paragraphs detected";
-          count = cnt;
-        }
+        (mk_result ~id:"LAY-023" ~severity:Info
+           ~message:"Multiple single-sentence paragraphs detected" ~count:cnt)
     else None
   in
   mk_rule "LAY-023" run
@@ -5465,15 +4848,12 @@ let r_lay_001 : rule =
         in
         if cnt > 0 && ctx.max_overfull_pt > 2.0 then
           Some
-            {
-              id = "LAY-001";
-              severity = Warning;
-              message =
-                Printf.sprintf
-                  "Overfull \\hbox > 2pt (%d occurrences, max %.1fpt)" cnt
-                  ctx.max_overfull_pt;
-              count = cnt;
-            }
+            (mk_result ~id:"LAY-001" ~severity:Warning
+               ~message:
+                 (Printf.sprintf
+                    "Overfull \\hbox > 2pt (%d occurrences, max %.1fpt)" cnt
+                    ctx.max_overfull_pt)
+               ~count:cnt)
         else None
   in
   mk_rule "LAY-001" run
@@ -5489,12 +4869,8 @@ let r_lay_002 : rule =
         in
         if cnt > 0 then
           Some
-            {
-              id = "LAY-002";
-              severity = Info;
-              message = "Widow or orphan line detected";
-              count = cnt;
-            }
+            (mk_result ~id:"LAY-002" ~severity:Info
+               ~message:"Widow or orphan line detected" ~count:cnt)
         else None
   in
   mk_rule "LAY-002" run
@@ -5535,13 +4911,10 @@ let r_lay_003 : rule =
         in
         if cnt > 0 then
           Some
-            {
-              id = "LAY-003";
-              severity = Info;
-              message =
-                "Section heading near page break (possible bottom-of-page)";
-              count = cnt;
-            }
+            (mk_result ~id:"LAY-003" ~severity:Info
+               ~message:
+                 "Section heading near page break (possible bottom-of-page)"
+               ~count:cnt)
         else None
   in
   mk_rule "LAY-003" run
@@ -5554,15 +4927,12 @@ let r_lay_004 : rule =
     | Some ctx ->
         if ctx.max_overfull_pt > 10.0 then
           Some
-            {
-              id = "LAY-004";
-              severity = Warning;
-              message =
-                Printf.sprintf
-                  "Content extends beyond margins (max overflow %.1fpt)"
-                  ctx.max_overfull_pt;
-              count = 1;
-            }
+            (mk_result ~id:"LAY-004" ~severity:Warning
+               ~message:
+                 (Printf.sprintf
+                    "Content extends beyond margins (max overflow %.1fpt)"
+                    ctx.max_overfull_pt)
+               ~count:1)
         else None
   in
   mk_rule "LAY-004" run
@@ -5581,12 +4951,8 @@ let r_lay_006 : rule =
         in
         if cnt > 0 then
           Some
-            {
-              id = "LAY-006";
-              severity = Info;
-              message = "Float placement warning in compile log";
-              count = cnt;
-            }
+            (mk_result ~id:"LAY-006" ~severity:Info
+               ~message:"Float placement warning in compile log" ~count:cnt)
         else None
   in
   mk_rule "LAY-006" run
@@ -5621,12 +4987,9 @@ let r_lay_007 : rule =
      with Not_found -> ());
     if !cnt > 0 then
       Some
-        {
-          id = "LAY-007";
-          severity = Info;
-          message = "Paragraph indent inconsistent after display math";
-          count = !cnt;
-        }
+        (mk_result ~id:"LAY-007" ~severity:Info
+           ~message:"Paragraph indent inconsistent after display math"
+           ~count:!cnt)
     else None
   in
   mk_rule "LAY-007" run
@@ -5648,12 +5011,9 @@ let r_lay_009 : rule =
         in
         if cnt > 0 then
           Some
-            {
-              id = "LAY-009";
-              severity = Warning;
-              message = "Underfull \\vbox detected — possible footnote overflow";
-              count = cnt;
-            }
+            (mk_result ~id:"LAY-009" ~severity:Warning
+               ~message:"Underfull \\vbox detected — possible footnote overflow"
+               ~count:cnt)
         else None
   in
   mk_rule "LAY-009" run
@@ -5675,12 +5035,8 @@ let r_lay_011 : rule =
         in
         if cnt > 0 then
           Some
-            {
-              id = "LAY-011";
-              severity = Warning;
-              message = "Figure overlaps footer (compile warning)";
-              count = cnt;
-            }
+            (mk_result ~id:"LAY-011" ~severity:Warning
+               ~message:"Figure overlaps footer (compile warning)" ~count:cnt)
         else None
   in
   mk_rule "LAY-011" run
@@ -5701,12 +5057,8 @@ let r_lay_014 : rule =
      with Not_found -> ());
     if !cnt > 0 then
       Some
-        {
-          id = "LAY-014";
-          severity = Info;
-          message = "Page break before subsection discouraged";
-          count = !cnt;
-        }
+        (mk_result ~id:"LAY-014" ~severity:Info
+           ~message:"Page break before subsection discouraged" ~count:!cnt)
     else None
   in
   mk_rule "LAY-014" run
@@ -5723,12 +5075,9 @@ let r_lay_016 : rule =
     in
     if cnt > 0 then
       Some
-        {
-          id = "LAY-016";
-          severity = Info;
-          message = "Table split across page without \\allowbreak hints";
-          count = cnt;
-        }
+        (mk_result ~id:"LAY-016" ~severity:Info
+           ~message:"Table split across page without \\allowbreak hints"
+           ~count:cnt)
     else None
   in
   mk_rule "LAY-016" run
@@ -5741,12 +5090,8 @@ let r_lay_017 : rule =
     | Some ctx ->
         if ctx.has_widows then
           Some
-            {
-              id = "LAY-017";
-              severity = Info;
-              message = "Section heading may be orphaned at page top";
-              count = 1;
-            }
+            (mk_result ~id:"LAY-017" ~severity:Info
+               ~message:"Section heading may be orphaned at page top" ~count:1)
         else None
   in
   mk_rule "LAY-017" run
@@ -5767,12 +5112,8 @@ let r_lay_018 : rule =
         in
         if cnt > 0 then
           Some
-            {
-              id = "LAY-018";
-              severity = Info;
-              message = "Underfull \\vbox warning in log";
-              count = cnt;
-            }
+            (mk_result ~id:"LAY-018" ~severity:Info
+               ~message:"Underfull \\vbox warning in log" ~count:cnt)
         else None
   in
   mk_rule "LAY-018" run
@@ -5793,12 +5134,8 @@ let r_lay_021 : rule =
         in
         if cnt > 0 then
           Some
-            {
-              id = "LAY-021";
-              severity = Warning;
-              message = "Overfull \\vbox inside bibliography section";
-              count = cnt;
-            }
+            (mk_result ~id:"LAY-021" ~severity:Warning
+               ~message:"Overfull \\vbox inside bibliography section" ~count:cnt)
         else None
   in
   mk_rule "LAY-021" run
@@ -5811,14 +5148,11 @@ let r_math_026 : rule =
     | Some ctx ->
         if ctx.max_overfull_pt > 0.0 then
           Some
-            {
-              id = "MATH-026";
-              severity = Warning;
-              message =
-                Printf.sprintf "Overfull \\hbox in equation (%.1fpt)"
-                  ctx.max_overfull_pt;
-              count = List.length ctx.overfull_lines;
-            }
+            (mk_result ~id:"MATH-026" ~severity:Warning
+               ~message:
+                 (Printf.sprintf "Overfull \\hbox in equation (%.1fpt)"
+                    ctx.max_overfull_pt)
+               ~count:(List.length ctx.overfull_lines))
         else None
   in
   mk_rule "MATH-026" run
@@ -5831,15 +5165,12 @@ let r_math_027 : rule =
     | Some ctx ->
         if ctx.max_overfull_pt > 5.0 then
           Some
-            {
-              id = "MATH-027";
-              severity = Warning;
-              message =
-                Printf.sprintf
-                  "Displayed equation exceeds page margins (%.1fpt overflow)"
-                  ctx.max_overfull_pt;
-              count = 1;
-            }
+            (mk_result ~id:"MATH-027" ~severity:Warning
+               ~message:
+                 (Printf.sprintf
+                    "Displayed equation exceeds page margins (%.1fpt overflow)"
+                    ctx.max_overfull_pt)
+               ~count:1)
         else None
   in
   mk_rule "MATH-027" run
@@ -6040,12 +5371,9 @@ let r_lay_025 : rule =
     | Some ctx ->
         if ctx.has_rerun_warnings then
           Some
-            {
-              id = "LAY-025";
-              severity = Warning;
-              message = "LaTeX rerun required -- cross-references may be wrong";
-              count = 1;
-            }
+            (mk_result ~id:"LAY-025" ~severity:Warning
+               ~message:"LaTeX rerun required -- cross-references may be wrong"
+               ~count:1)
         else None
   in
   mk_rule "LAY-025" run
@@ -6059,13 +5387,10 @@ let r_lay_026 : rule =
         let cnt = List.length ctx.undefined_citations in
         if cnt > 0 then
           Some
-            {
-              id = "LAY-026";
-              severity = Warning;
-              message =
-                Printf.sprintf "Undefined citation(s) in compile log (%d)" cnt;
-              count = cnt;
-            }
+            (mk_result ~id:"LAY-026" ~severity:Warning
+               ~message:
+                 (Printf.sprintf "Undefined citation(s) in compile log (%d)" cnt)
+               ~count:cnt)
         else None
   in
   mk_rule "LAY-026" run
@@ -6079,12 +5404,9 @@ let r_lay_027 : rule =
         let cnt = List.length ctx.font_substitutions in
         if cnt > 0 then
           Some
-            {
-              id = "LAY-027";
-              severity = Info;
-              message = Printf.sprintf "Font substitution warning (%d)" cnt;
-              count = cnt;
-            }
+            (mk_result ~id:"LAY-027" ~severity:Info
+               ~message:(Printf.sprintf "Font substitution warning (%d)" cnt)
+               ~count:cnt)
         else None
   in
   mk_rule "LAY-027" run
@@ -6129,12 +5451,9 @@ let r_cmd_002 : rule =
      with Not_found -> ());
     if !cnt > 0 then
       Some
-        {
-          id = "CMD-002";
-          severity = Warning;
-          message = "Command redefined with \\def instead of \\renewcommand";
-          count = !cnt;
-        }
+        (mk_result ~id:"CMD-002" ~severity:Warning
+           ~message:"Command redefined with \\def instead of \\renewcommand"
+           ~count:!cnt)
     else None
   in
   { id = "CMD-002"; run; languages = [] }
@@ -6164,12 +5483,8 @@ let r_cmd_004 : rule =
      with Not_found -> ());
     if !cnt > 0 then
       Some
-        {
-          id = "CMD-004";
-          severity = Info;
-          message = "CamelCase command names discouraged";
-          count = !cnt;
-        }
+        (mk_result ~id:"CMD-004" ~severity:Info
+           ~message:"CamelCase command names discouraged" ~count:!cnt)
     else None
   in
   { id = "CMD-004"; run; languages = [] }
@@ -6199,12 +5514,8 @@ let r_cmd_005 : rule =
     let cnt = count_matches re_cmd s + count_matches re_def s in
     if cnt > 0 then
       Some
-        {
-          id = "CMD-005";
-          severity = Warning;
-          message = {|Single‑letter macro created (\x)|};
-          count = cnt;
-        }
+        (mk_result ~id:"CMD-005" ~severity:Warning
+           ~message:{|Single‑letter macro created (\x)|} ~count:cnt)
     else None
   in
   { id = "CMD-005"; run; languages = [] }
@@ -6229,12 +5540,8 @@ let r_cmd_006 : rule =
          with Not_found -> ());
         if !cnt > 0 then
           Some
-            {
-              id = "CMD-006";
-              severity = Info;
-              message = "Macro defined inside document body";
-              count = !cnt;
-            }
+            (mk_result ~id:"CMD-006" ~severity:Info
+               ~message:"Macro defined inside document body" ~count:!cnt)
         else None
   in
   { id = "CMD-006"; run; languages = [] }
@@ -6267,12 +5574,9 @@ let r_cmd_008 : rule =
        with Not_found -> ());
       if !cnt > 0 then
         Some
-          {
-            id = "CMD-008";
-            severity = Warning;
-            message = "Macro uses \\@ in name outside maketitle context";
-            count = !cnt;
-          }
+          (mk_result ~id:"CMD-008" ~severity:Warning
+             ~message:"Macro uses \\@ in name outside maketitle context"
+             ~count:!cnt)
       else None
   in
   { id = "CMD-008"; run; languages = [] }
@@ -6296,12 +5600,8 @@ let r_cmd_009 : rule =
      with Not_found -> ());
     if !cnt > 0 then
       Some
-        {
-          id = "CMD-009";
-          severity = Info;
-          message = "Macro name contains digits";
-          count = !cnt;
-        }
+        (mk_result ~id:"CMD-009" ~severity:Info
+           ~message:"Macro name contains digits" ~count:!cnt)
     else None
   in
   { id = "CMD-009"; run; languages = [] }
@@ -6339,13 +5639,10 @@ let r_cmd_011 : rule =
        with Not_found -> ());
       if !cnt > 0 then
         Some
-          {
-            id = "CMD-011";
-            severity = Warning;
-            message =
-              {|Macro defined with \def/\edef in preamble without \makeatletter guard|};
-            count = !cnt;
-          }
+          (mk_result ~id:"CMD-011" ~severity:Warning
+             ~message:
+               {|Macro defined with \def/\edef in preamble without \makeatletter guard|}
+             ~count:!cnt)
       else None
   in
   { id = "CMD-011"; run; languages = [] }
@@ -6368,12 +5665,9 @@ let r_cmd_013 : rule =
          with Not_found -> ());
         if !cnt > 0 then
           Some
-            {
-              id = "CMD-013";
-              severity = Info;
-              message = "\\def\\arraystretch declared inside document body";
-              count = !cnt;
-            }
+            (mk_result ~id:"CMD-013" ~severity:Info
+               ~message:"\\def\\arraystretch declared inside document body"
+               ~count:!cnt)
         else None
   in
   { id = "CMD-013"; run; languages = [] }
@@ -6406,14 +5700,11 @@ let r_cmd_015 : rule =
               unsupported
           in
           Some
-            {
-              id = "CMD-015";
-              severity = Warning;
-              message =
-                Printf.sprintf "Unsupported user macro construct(s): %s"
-                  (String.concat "; " reasons);
-              count = cnt;
-            }
+            (mk_result ~id:"CMD-015" ~severity:Warning
+               ~message:
+                 (Printf.sprintf "Unsupported user macro construct(s): %s"
+                    (String.concat "; " reasons))
+               ~count:cnt)
         else None
   in
   mk_rule "CMD-015" run
@@ -6430,13 +5721,10 @@ let r_cmd_016 : rule =
               (List.map (fun n -> "\\" ^ n) reg.User_macro_registry.cycle_path)
           in
           Some
-            {
-              id = "CMD-016";
-              severity = Error;
-              message =
-                Printf.sprintf "Cycle in user macro definitions: %s" path;
-              count = 1;
-            }
+            (mk_result ~id:"CMD-016" ~severity:Error
+               ~message:
+                 (Printf.sprintf "Cycle in user macro definitions: %s" path)
+               ~count:1)
         else None
   in
   mk_rule "CMD-016" run
@@ -6497,15 +5785,13 @@ let r_cmd_017 : rule =
         let cnt = List.length shadows in
         if cnt > 0 then
           Some
-            {
-              id = "CMD-017";
-              severity = Warning;
-              message =
-                Printf.sprintf
-                  "User \\newcommand shadows built-in: %s (use \\renewcommand)"
-                  (String.concat ", " (List.map (fun n -> "\\" ^ n) shadows));
-              count = cnt;
-            }
+            (mk_result ~id:"CMD-017" ~severity:Warning
+               ~message:
+                 (Printf.sprintf
+                    "User \\newcommand shadows built-in: %s (use \
+                     \\renewcommand)"
+                    (String.concat ", " (List.map (fun n -> "\\" ^ n) shadows)))
+               ~count:cnt)
         else None
   in
   mk_rule "CMD-017" run
@@ -6547,12 +5833,8 @@ let r_typo_062 : rule =
     done;
     if !cnt > 0 then
       Some
-        {
-          id = "TYPO-062";
-          severity = Warning;
-          message = "Literal backslash in text; use \\textbackslash";
-          count = !cnt;
-        }
+        (mk_result ~id:"TYPO-062" ~severity:Warning
+           ~message:"Literal backslash in text; use \\textbackslash" ~count:!cnt)
     else None
   in
   { id = "TYPO-062"; run; languages = [] }
@@ -6569,12 +5851,8 @@ let r_math_083 : rule =
     let cnt = count_substring s_text "\xe2\x88\x92" in
     if cnt > 0 then
       Some
-        {
-          id = "MATH-083";
-          severity = Warning;
-          message = "Unicode minus inside text mode";
-          count = cnt;
-        }
+        (mk_result ~id:"MATH-083" ~severity:Warning
+           ~message:"Unicode minus inside text mode" ~count:cnt)
     else None
   in
   { id = "MATH-083"; run; languages = [] }
@@ -6602,17 +5880,14 @@ let r_doc_structure : rule =
       doc.Parser_l2.refs;
     if !issues > 0 then
       Some
-        {
-          id = "STRUCT-005";
-          severity = Info;
-          message =
-            Printf.sprintf
-              "Document structure: %d parse errors, %d labels, %d refs"
-              (List.length doc.Parser_l2.errors)
-              (List.length doc.Parser_l2.labels)
-              (List.length doc.Parser_l2.refs);
-          count = !issues;
-        }
+        (mk_result ~id:"STRUCT-005" ~severity:Info
+           ~message:
+             (Printf.sprintf
+                "Document structure: %d parse errors, %d labels, %d refs"
+                (List.length doc.Parser_l2.errors)
+                (List.length doc.Parser_l2.labels)
+                (List.length doc.Parser_l2.refs))
+           ~count:!issues)
     else None
   in
   mk_rule "STRUCT-005" run

--- a/latex-parse/src/validators_l3_file.ml
+++ b/latex-parse/src/validators_l3_file.ml
@@ -29,12 +29,8 @@ let r_fig_004 : rule =
         in
         if cnt > 0 then
           Some
-            {
-              id = "FIG-004";
-              severity = Info;
-              message = "Raster image exceeds 300 dpi";
-              count = cnt;
-            }
+            (mk_result ~id:"FIG-004" ~severity:Info
+               ~message:"Raster image exceeds 300 dpi" ~count:cnt)
         else None
   in
   mk_rule "FIG-004" run
@@ -53,12 +49,8 @@ let r_fig_006 : rule =
         in
         if cnt > 0 then
           Some
-            {
-              id = "FIG-006";
-              severity = Info;
-              message = "Bitmap image with transparency channel";
-              count = cnt;
-            }
+            (mk_result ~id:"FIG-006" ~severity:Info
+               ~message:"Bitmap image with transparency channel" ~count:cnt)
         else None
   in
   mk_rule "FIG-006" run
@@ -78,12 +70,8 @@ let r_fig_016 : rule =
         in
         if cnt > 0 then
           Some
-            {
-              id = "FIG-016";
-              severity = Info;
-              message = "Raster image colour profile not sRGB";
-              count = cnt;
-            }
+            (mk_result ~id:"FIG-016" ~severity:Info
+               ~message:"Raster image colour profile not sRGB" ~count:cnt)
         else None
   in
   mk_rule "FIG-016" run
@@ -103,12 +91,8 @@ let r_fig_021 : rule =
         in
         if cnt > 0 then
           Some
-            {
-              id = "FIG-021";
-              severity = Warning;
-              message = "Embedded bitmap > 20 MiB — PDF bloat risk";
-              count = cnt;
-            }
+            (mk_result ~id:"FIG-021" ~severity:Warning
+               ~message:"Embedded bitmap > 20 MiB — PDF bloat risk" ~count:cnt)
         else None
   in
   mk_rule "FIG-021" run
@@ -127,12 +111,8 @@ let r_col_001 : rule =
         in
         if cnt > 0 then
           Some
-            {
-              id = "COL-001";
-              severity = Info;
-              message = "CMYK image in RGB workflow";
-              count = cnt;
-            }
+            (mk_result ~id:"COL-001" ~severity:Info
+               ~message:"CMYK image in RGB workflow" ~count:cnt)
         else None
   in
   mk_rule "COL-001" run
@@ -151,12 +131,8 @@ let r_col_002 : rule =
         in
         if cnt > 0 then
           Some
-            {
-              id = "COL-002";
-              severity = Info;
-              message = "ICC profile missing in embedded image";
-              count = cnt;
-            }
+            (mk_result ~id:"COL-002" ~severity:Info
+               ~message:"ICC profile missing in embedded image" ~count:cnt)
         else None
   in
   mk_rule "COL-002" run
@@ -179,12 +155,9 @@ let r_col_003 : rule =
           in
           if cnt > 0 then
             Some
-              {
-                id = "COL-003";
-                severity = Warning;
-                message = "Transparent PNG in print-optimised document class";
-                count = cnt;
-              }
+              (mk_result ~id:"COL-003" ~severity:Warning
+                 ~message:"Transparent PNG in print-optimised document class"
+                 ~count:cnt)
           else None
   in
   mk_rule "COL-003" run
@@ -203,12 +176,9 @@ let r_col_005 : rule =
         in
         if cnt > 0 then
           Some
-            {
-              id = "COL-005";
-              severity = Info;
-              message = "Excess distinct colours (> 256) in indexed image";
-              count = cnt;
-            }
+            (mk_result ~id:"COL-005" ~severity:Info
+               ~message:"Excess distinct colours (> 256) in indexed image"
+               ~count:cnt)
         else None
   in
   mk_rule "COL-005" run
@@ -232,12 +202,8 @@ let r_pdf_006 : rule =
         in
         if cnt > 0 then
           Some
-            {
-              id = "PDF-006";
-              severity = Warning;
-              message = "Tagged PDF lacks /StructTreeRoot";
-              count = cnt;
-            }
+            (mk_result ~id:"PDF-006" ~severity:Warning
+               ~message:"Tagged PDF lacks /StructTreeRoot" ~count:cnt)
         else None
   in
   mk_rule "PDF-006" run
@@ -256,12 +222,9 @@ let r_pdf_007 : rule =
         in
         if cnt > 0 then
           Some
-            {
-              id = "PDF-007";
-              severity = Warning;
-              message = "Figure objects without /Alt text in tagged PDF";
-              count = cnt;
-            }
+            (mk_result ~id:"PDF-007" ~severity:Warning
+               ~message:"Figure objects without /Alt text in tagged PDF"
+               ~count:cnt)
         else None
   in
   mk_rule "PDF-007" run
@@ -280,13 +243,10 @@ let r_pdf_008 : rule =
         in
         if cnt > 0 then
           Some
-            {
-              id = "PDF-008";
-              severity = Warning;
-              message =
-                "Link annotations missing /Contents — screen-reader issue";
-              count = cnt;
-            }
+            (mk_result ~id:"PDF-008" ~severity:Warning
+               ~message:
+                 "Link annotations missing /Contents — screen-reader issue"
+               ~count:cnt)
         else None
   in
   mk_rule "PDF-008" run
@@ -305,12 +265,8 @@ let r_pdf_009 : rule =
         in
         if cnt > 0 then
           Some
-            {
-              id = "PDF-009";
-              severity = Warning;
-              message = "/Lang entry missing in PDF catalog";
-              count = cnt;
-            }
+            (mk_result ~id:"PDF-009" ~severity:Warning
+               ~message:"/Lang entry missing in PDF catalog" ~count:cnt)
         else None
   in
   mk_rule "PDF-009" run
@@ -332,12 +288,9 @@ let r_pdf_011 : rule =
         in
         if cnt > 0 then
           Some
-            {
-              id = "PDF-011";
-              severity = Error;
-              message = "Fonts in PDF not fully embedded or subsetted";
-              count = cnt;
-            }
+            (mk_result ~id:"PDF-011" ~severity:Error
+               ~message:"Fonts in PDF not fully embedded or subsetted"
+               ~count:cnt)
         else None
   in
   mk_rule "PDF-011" run
@@ -363,12 +316,9 @@ let r_pdf_012 : rule =
         in
         if cnt > 0 then
           Some
-            {
-              id = "PDF-012";
-              severity = Info;
-              message = "Logical page labels inconsistent with numbering";
-              count = cnt;
-            }
+            (mk_result ~id:"PDF-012" ~severity:Info
+               ~message:"Logical page labels inconsistent with numbering"
+               ~count:cnt)
         else None
   in
   mk_rule "PDF-012" run
@@ -387,12 +337,8 @@ let r_col_004 : rule =
         in
         if cnt > 0 then
           Some
-            {
-              id = "COL-004";
-              severity = Info;
-              message = "PDF contains spot-colour separation";
-              count = cnt;
-            }
+            (mk_result ~id:"COL-004" ~severity:Info
+               ~message:"PDF contains spot-colour separation" ~count:cnt)
         else None
   in
   mk_rule "COL-004" run
@@ -411,12 +357,8 @@ let r_col_007 : rule =
         in
         if cnt > 0 then
           Some
-            {
-              id = "COL-007";
-              severity = Info;
-              message = "Spot colour detected in vector element";
-              count = cnt;
-            }
+            (mk_result ~id:"COL-007" ~severity:Info
+               ~message:"Spot colour detected in vector element" ~count:cnt)
         else None
   in
   mk_rule "COL-007" run
@@ -438,12 +380,8 @@ let r_tikz_002 : rule =
         in
         if cnt > 0 then
           Some
-            {
-              id = "TIKZ-002";
-              severity = Warning;
-              message = "TikZ compile time exceeds 5 seconds";
-              count = cnt;
-            }
+            (mk_result ~id:"TIKZ-002" ~severity:Warning
+               ~message:"TikZ compile time exceeds 5 seconds" ~count:cnt)
         else None
   in
   mk_rule "TIKZ-002" run
@@ -462,12 +400,9 @@ let r_tikz_008 : rule =
         in
         if cnt > 0 then
           Some
-            {
-              id = "TIKZ-008";
-              severity = Info;
-              message = "Uncompressed streams in PDF (possible TikZ output)";
-              count = cnt;
-            }
+            (mk_result ~id:"TIKZ-008" ~severity:Info
+               ~message:"Uncompressed streams in PDF (possible TikZ output)"
+               ~count:cnt)
         else None
   in
   mk_rule "TIKZ-008" run
@@ -490,12 +425,8 @@ let r_cjk_007 : rule =
         in
         if cnt > 0 then
           Some
-            {
-              id = "CJK-007";
-              severity = Warning;
-              message = "Kanji glyph missing in selected CJK font";
-              count = cnt;
-            }
+            (mk_result ~id:"CJK-007" ~severity:Warning
+               ~message:"Kanji glyph missing in selected CJK font" ~count:cnt)
         else None
   in
   mk_rule "CJK-007" run

--- a/latex-parse/src/validators_l4_style.ml
+++ b/latex-parse/src/validators_l4_style.ml
@@ -127,12 +127,8 @@ let r_style_004 : rule =
     in
     if cnt > 0 then
       Some
-        {
-          id = "STYLE-004";
-          severity = Info;
-          message = "Paragraph exceeds 300 words";
-          count = cnt;
-        }
+        (mk_result ~id:"STYLE-004" ~severity:Info
+           ~message:"Paragraph exceeds 300 words" ~count:cnt)
     else None
   in
   mk_rule "STYLE-004" run
@@ -153,12 +149,8 @@ let r_style_006 : rule =
     let cnt = check 0 sents in
     if cnt > 0 then
       Some
-        {
-          id = "STYLE-006";
-          severity = Info;
-          message = "Consecutive sentences start with same word";
-          count = cnt;
-        }
+        (mk_result ~id:"STYLE-006" ~severity:Info
+           ~message:"Consecutive sentences start with same word" ~count:cnt)
     else None
   in
   mk_rule "STYLE-006" run
@@ -181,12 +173,8 @@ let r_style_008 : rule =
      with Not_found -> ());
     if !cnt > 0 then
       Some
-        {
-          id = "STYLE-008";
-          severity = Info;
-          message = "Sentence starts with mathematical symbol";
-          count = !cnt;
-        }
+        (mk_result ~id:"STYLE-008" ~severity:Info
+           ~message:"Sentence starts with mathematical symbol" ~count:!cnt)
     else None
   in
   mk_rule "STYLE-008" run
@@ -208,12 +196,8 @@ let r_style_013 : rule =
      with Not_found -> ());
     if !cnt > 0 then
       Some
-        {
-          id = "STYLE-013";
-          severity = Info;
-          message = "Sentence starts with numeric figure";
-          count = !cnt;
-        }
+        (mk_result ~id:"STYLE-013" ~severity:Info
+           ~message:"Sentence starts with numeric figure" ~count:!cnt)
     else None
   in
   mk_rule "STYLE-013" run
@@ -261,12 +245,8 @@ let r_style_014 : rule =
     in
     if cnt > 0 then
       Some
-        {
-          id = "STYLE-014";
-          severity = Info;
-          message = "Contraction in formal text";
-          count = cnt;
-        }
+        (mk_result ~id:"STYLE-014" ~severity:Info
+           ~message:"Contraction in formal text" ~count:cnt)
     else None
   in
   mk_rule "STYLE-014" run
@@ -278,12 +258,8 @@ let r_style_015 : rule =
     let cnt = count_substring text ".  " in
     if cnt > 0 then
       Some
-        {
-          id = "STYLE-015";
-          severity = Info;
-          message = "Double space after period";
-          count = cnt;
-        }
+        (mk_result ~id:"STYLE-015" ~severity:Info
+           ~message:"Double space after period" ~count:cnt)
     else None
   in
   mk_rule "STYLE-015" run
@@ -305,13 +281,10 @@ let r_style_016 : rule =
      with Not_found -> ());
     if !cnt > 0 then
       Some
-        {
-          id = "STYLE-016";
-          severity = Info;
-          message =
-            "Latin abbreviation (e.g., i.e.) missing comma after abbreviation";
-          count = !cnt;
-        }
+        (mk_result ~id:"STYLE-016" ~severity:Info
+           ~message:
+             "Latin abbreviation (e.g., i.e.) missing comma after abbreviation"
+           ~count:!cnt)
     else None
   in
   mk_rule "STYLE-016" run
@@ -328,12 +301,8 @@ let r_style_017 : rule =
     in
     if cnt > 0 then
       Some
-        {
-          id = "STYLE-017";
-          severity = Info;
-          message = "Sentence exceeds 40 words";
-          count = cnt;
-        }
+        (mk_result ~id:"STYLE-017" ~severity:Info
+           ~message:"Sentence exceeds 40 words" ~count:cnt)
     else None
   in
   mk_rule "STYLE-017" run
@@ -371,12 +340,9 @@ let r_style_019 : rule =
     let cnt = check 0 positions in
     if cnt > 0 then
       Some
-        {
-          id = "STYLE-019";
-          severity = Info;
-          message = "Multiple consecutive headings without intervening text";
-          count = cnt;
-        }
+        (mk_result ~id:"STYLE-019" ~severity:Info
+           ~message:"Multiple consecutive headings without intervening text"
+           ~count:cnt)
     else None
   in
   mk_rule "STYLE-019" run
@@ -392,12 +358,8 @@ let r_style_023 : rule =
     done;
     if !cnt > 0 then
       Some
-        {
-          id = "STYLE-023";
-          severity = Warning;
-          message = "Percent sign in text not escaped";
-          count = !cnt;
-        }
+        (mk_result ~id:"STYLE-023" ~severity:Warning
+           ~message:"Percent sign in text not escaped" ~count:!cnt)
     else None
   in
   mk_rule "STYLE-023" run
@@ -418,12 +380,8 @@ let r_style_024 : rule =
       done;
       if !cnt > 0 then
         Some
-          {
-            id = "STYLE-024";
-            severity = Warning;
-            message = "Ampersand in text not escaped";
-            count = !cnt;
-          }
+          (mk_result ~id:"STYLE-024" ~severity:Warning
+             ~message:"Ampersand in text not escaped" ~count:!cnt)
       else None
   in
   mk_rule "STYLE-024" run
@@ -445,12 +403,8 @@ let r_style_026 : rule =
     let cnt = check 0 words in
     if cnt > 0 then
       Some
-        {
-          id = "STYLE-026";
-          severity = Info;
-          message = "Repeated word detected";
-          count = cnt;
-        }
+        (mk_result ~id:"STYLE-026" ~severity:Info
+           ~message:"Repeated word detected" ~count:cnt)
     else None
   in
   mk_rule "STYLE-026" run
@@ -491,12 +445,9 @@ let r_style_030 : rule =
       in
       if tc_count > 0 && sc_count > 0 then
         Some
-          {
-            id = "STYLE-030";
-            severity = Info;
-            message = "Sub-heading capitalisation inconsistent";
-            count = min tc_count sc_count;
-          }
+          (mk_result ~id:"STYLE-030" ~severity:Info
+             ~message:"Sub-heading capitalisation inconsistent"
+             ~count:(min tc_count sc_count))
       else None
   in
   mk_rule "STYLE-030" run
@@ -517,12 +468,9 @@ let r_style_031 : rule =
      with Not_found -> ());
     if !cnt > 0 then
       Some
-        {
-          id = "STYLE-031";
-          severity = Warning;
-          message = "Heading contains only numbers without title text";
-          count = !cnt;
-        }
+        (mk_result ~id:"STYLE-031" ~severity:Warning
+           ~message:"Heading contains only numbers without title text"
+           ~count:!cnt)
     else None
   in
   mk_rule "STYLE-031" run
@@ -546,12 +494,9 @@ let r_style_033 : rule =
      with Not_found -> ());
     if !cnt > 0 then
       Some
-        {
-          id = "STYLE-033";
-          severity = Info;
-          message = "Space before \\cite — use ~ (non-breaking space)";
-          count = !cnt;
-        }
+        (mk_result ~id:"STYLE-033" ~severity:Info
+           ~message:"Space before \\cite — use ~ (non-breaking space)"
+           ~count:!cnt)
     else None
   in
   mk_rule "STYLE-033" run
@@ -575,12 +520,8 @@ let r_style_034 : rule =
     in
     if cnt > 0 then
       Some
-        {
-          id = "STYLE-034";
-          severity = Info;
-          message = "Orphan word (1-2 letters) at paragraph end";
-          count = cnt;
-        }
+        (mk_result ~id:"STYLE-034" ~severity:Info
+           ~message:"Orphan word (1-2 letters) at paragraph end" ~count:cnt)
     else None
   in
   mk_rule "STYLE-034" run
@@ -592,12 +533,8 @@ let r_style_035 : rule =
     let cnt = count_substring text "and/or" in
     if cnt > 0 then
       Some
-        {
-          id = "STYLE-035";
-          severity = Info;
-          message = "Slash used for 'and/or'";
-          count = cnt;
-        }
+        (mk_result ~id:"STYLE-035" ~severity:Info
+           ~message:"Slash used for 'and/or'" ~count:cnt)
     else None
   in
   mk_rule "STYLE-035" run
@@ -621,12 +558,8 @@ let r_style_036 : rule =
     in
     if cnt > 0 then
       Some
-        {
-          id = "STYLE-036";
-          severity = Info;
-          message = "Latin phrase not italicised";
-          count = cnt;
-        }
+        (mk_result ~id:"STYLE-036" ~severity:Info
+           ~message:"Latin phrase not italicised" ~count:cnt)
     else None
   in
   mk_rule "STYLE-036" run
@@ -648,12 +581,9 @@ let r_style_037 : rule =
      with Not_found -> ());
     if !cnt > 0 then
       Some
-        {
-          id = "STYLE-037";
-          severity = Info;
-          message = "Sentence starts with conjunction 'And' or 'But'";
-          count = !cnt;
-        }
+        (mk_result ~id:"STYLE-037" ~severity:Info
+           ~message:"Sentence starts with conjunction 'And' or 'But'"
+           ~count:!cnt)
     else None
   in
   mk_rule "STYLE-037" run
@@ -665,12 +595,8 @@ let r_style_040 : rule =
     let cnt = count_char text '!' in
     if cnt > 0 then
       Some
-        {
-          id = "STYLE-040";
-          severity = Info;
-          message = "Exclamation mark in academic prose";
-          count = cnt;
-        }
+        (mk_result ~id:"STYLE-040" ~severity:Info
+           ~message:"Exclamation mark in academic prose" ~count:cnt)
     else None
   in
   mk_rule "STYLE-040" run
@@ -691,12 +617,8 @@ let r_style_042 : rule =
     let cnt = check 0 paras in
     if cnt > 0 then
       Some
-        {
-          id = "STYLE-042";
-          severity = Info;
-          message = "Consecutive short paragraphs (< 15 words each)";
-          count = cnt;
-        }
+        (mk_result ~id:"STYLE-042" ~severity:Info
+           ~message:"Consecutive short paragraphs (< 15 words each)" ~count:cnt)
     else None
   in
   mk_rule "STYLE-042" run
@@ -715,12 +637,8 @@ let r_style_045 : rule =
     in
     if cnt > 0 then
       Some
-        {
-          id = "STYLE-045";
-          severity = Info;
-          message = "Excess parentheses in single sentence (> 3)";
-          count = cnt;
-        }
+        (mk_result ~id:"STYLE-045" ~severity:Info
+           ~message:"Excess parentheses in single sentence (> 3)" ~count:cnt)
     else None
   in
   mk_rule "STYLE-045" run
@@ -744,12 +662,8 @@ let r_style_046 : rule =
     in
     if cnt > 0 then
       Some
-        {
-          id = "STYLE-046";
-          severity = Info;
-          message = "Mixed en-dash and em-dash in same sentence";
-          count = cnt;
-        }
+        (mk_result ~id:"STYLE-046" ~severity:Info
+           ~message:"Mixed en-dash and em-dash in same sentence" ~count:cnt)
     else None
   in
   mk_rule "STYLE-046" run
@@ -770,12 +684,8 @@ let r_style_048 : rule =
     in
     if cnt > 0 then
       Some
-        {
-          id = "STYLE-048";
-          severity = Info;
-          message = "Word-pair variant mixed (e.g. among/amongst)";
-          count = cnt;
-        }
+        (mk_result ~id:"STYLE-048" ~severity:Info
+           ~message:"Word-pair variant mixed (e.g. among/amongst)" ~count:cnt)
     else None
   in
   mk_rule "STYLE-048" run
@@ -794,12 +704,8 @@ let r_style_049 : rule =
     in
     if cnt > 0 then
       Some
-        {
-          id = "STYLE-049";
-          severity = Info;
-          message = "Section heading ends with colon";
-          count = cnt;
-        }
+        (mk_result ~id:"STYLE-049" ~severity:Info
+           ~message:"Section heading ends with colon" ~count:cnt)
     else None
   in
   mk_rule "STYLE-049" run
@@ -830,12 +736,8 @@ let r_style_001 : rule =
     in
     if has_oxford && has_no_oxford then
       Some
-        {
-          id = "STYLE-001";
-          severity = Info;
-          message = "Inconsistent Oxford-comma usage";
-          count = 1;
-        }
+        (mk_result ~id:"STYLE-001" ~severity:Info
+           ~message:"Inconsistent Oxford-comma usage" ~count:1)
     else None
   in
   mk_rule "STYLE-001" run
@@ -872,12 +774,8 @@ let r_style_002 : rule =
     in
     if cnt > 0 then
       Some
-        {
-          id = "STYLE-002";
-          severity = Info;
-          message = "Mixed UK and US spelling detected";
-          count = cnt;
-        }
+        (mk_result ~id:"STYLE-002" ~severity:Info
+           ~message:"Mixed UK and US spelling detected" ~count:cnt)
     else None
   in
   mk_rule "STYLE-002" run
@@ -904,12 +802,9 @@ let r_style_005 : rule =
     in
     if has_we && has_i then
       Some
-        {
-          id = "STYLE-005";
-          severity = Info;
-          message = "First-person pronoun inconsistent (mixed 'we' and 'I')";
-          count = 1;
-        }
+        (mk_result ~id:"STYLE-005" ~severity:Info
+           ~message:"First-person pronoun inconsistent (mixed 'we' and 'I')"
+           ~count:1)
     else None
   in
   mk_rule "STYLE-005" run
@@ -945,12 +840,9 @@ let r_style_007 : rule =
       let without_p = List.length items - with_p in
       if with_p > 0 && without_p > 0 then
         Some
-          {
-            id = "STYLE-007";
-            severity = Info;
-            message = "Bullet-list items have inconsistent punctuation";
-            count = min with_p without_p;
-          }
+          (mk_result ~id:"STYLE-007" ~severity:Info
+             ~message:"Bullet-list items have inconsistent punctuation"
+             ~count:(min with_p without_p))
       else None
   in
   mk_rule "STYLE-007" run
@@ -970,12 +862,9 @@ let r_style_009 : rule =
     in
     if has_cite && (has_citep || has_citet) then
       Some
-        {
-          id = "STYLE-009";
-          severity = Info;
-          message = "Mixed citation styles (\\cite with \\citep/\\citet)";
-          count = 1;
-        }
+        (mk_result ~id:"STYLE-009" ~severity:Info
+           ~message:"Mixed citation styles (\\cite with \\citep/\\citet)"
+           ~count:1)
     else None
   in
   mk_rule "STYLE-009" run
@@ -1002,12 +891,8 @@ let r_style_010 : rule =
     in
     if multi && has_i then
       Some
-        {
-          id = "STYLE-010";
-          severity = Info;
-          message = "First-person 'I' in multi-author paper";
-          count = 1;
-        }
+        (mk_result ~id:"STYLE-010" ~severity:Info
+           ~message:"First-person 'I' in multi-author paper" ~count:1)
     else None
   in
   mk_rule "STYLE-010" run
@@ -1034,12 +919,8 @@ let r_style_011 : rule =
     in
     if has_hyphen && has_endash then
       Some
-        {
-          id = "STYLE-011";
-          severity = Info;
-          message = "Hyphen vs en-dash inconsistency in number ranges";
-          count = 1;
-        }
+        (mk_result ~id:"STYLE-011" ~severity:Info
+           ~message:"Hyphen vs en-dash inconsistency in number ranges" ~count:1)
     else None
   in
   mk_rule "STYLE-011" run
@@ -1064,12 +945,8 @@ let r_style_018 : rule =
      with Not_found -> ());
     if !cnt > 0 then
       Some
-        {
-          id = "STYLE-018";
-          severity = Info;
-          message = "Dangling 'this' without noun";
-          count = !cnt;
-        }
+        (mk_result ~id:"STYLE-018" ~severity:Info
+           ~message:"Dangling 'this' without noun" ~count:!cnt)
     else None
   in
   mk_rule "STYLE-018" run
@@ -1101,12 +978,8 @@ let r_style_020 : rule =
     in
     if cnt > 0 then
       Some
-        {
-          id = "STYLE-020";
-          severity = Info;
-          message = "Acronym defined but never used";
-          count = cnt;
-        }
+        (mk_result ~id:"STYLE-020" ~severity:Info
+           ~message:"Acronym defined but never used" ~count:cnt)
     else None
   in
   mk_rule "STYLE-020" run
@@ -1138,12 +1011,8 @@ let r_style_021 : rule =
       in
       if used_before then
         Some
-          {
-            id = "STYLE-021";
-            severity = Warning;
-            message = "Acronym used before definition";
-            count = 1;
-          }
+          (mk_result ~id:"STYLE-021" ~severity:Warning
+             ~message:"Acronym used before definition" ~count:1)
       else None
   in
   mk_rule "STYLE-021" run
@@ -1165,12 +1034,8 @@ let r_style_022 : rule =
      with Not_found -> ());
     if !cnt > 0 then
       Some
-        {
-          id = "STYLE-022";
-          severity = Info;
-          message = "Serial comma missing in three-item list";
-          count = !cnt;
-        }
+        (mk_result ~id:"STYLE-022" ~severity:Info
+           ~message:"Serial comma missing in three-item list" ~count:!cnt)
     else None
   in
   mk_rule "STYLE-022" run
@@ -1187,12 +1052,8 @@ let r_style_025 : rule =
     in
     if cnt > 0 then
       Some
-        {
-          id = "STYLE-025";
-          severity = Info;
-          message = "Run-on sentence detected (> 60 words)";
-          count = cnt;
-        }
+        (mk_result ~id:"STYLE-025" ~severity:Info
+           ~message:"Run-on sentence detected (> 60 words)" ~count:cnt)
     else None
   in
   mk_rule "STYLE-025" run
@@ -1218,14 +1079,11 @@ let r_style_027 : rule =
       let ratio = float_of_int !cnt /. float_of_int total in
       if ratio > 0.05 then
         Some
-          {
-            id = "STYLE-027";
-            severity = Info;
-            message =
-              Printf.sprintf "Overuse of adverbs (%.1f%% -ly words)"
-                (ratio *. 100.0);
-            count = !cnt;
-          }
+          (mk_result ~id:"STYLE-027" ~severity:Info
+             ~message:
+               (Printf.sprintf "Overuse of adverbs (%.1f%% -ly words)"
+                  (ratio *. 100.0))
+             ~count:!cnt)
       else None
   in
   mk_rule "STYLE-027" run
@@ -1247,12 +1105,9 @@ let r_style_028 : rule =
      with Not_found -> ());
     if !cnt > 0 then
       Some
-        {
-          id = "STYLE-028";
-          severity = Info;
-          message = "Equation reference without adjoining punctuation";
-          count = !cnt;
-        }
+        (mk_result ~id:"STYLE-028" ~severity:Info
+           ~message:"Equation reference without adjoining punctuation"
+           ~count:!cnt)
     else None
   in
   mk_rule "STYLE-028" run
@@ -1278,12 +1133,8 @@ let r_ce_001 : rule =
     in
     if cnt > 0 then
       Some
-        {
-          id = "CE-001";
-          severity = Info;
-          message = "Canadian EN: mixes BrE and AmE spelling";
-          count = cnt;
-        }
+        (mk_result ~id:"CE-001" ~severity:Info
+           ~message:"Canadian EN: mixes BrE and AmE spelling" ~count:cnt)
     else None
   in
   mk_lang_rule "CE-001" run [ "en" ]
@@ -1305,12 +1156,8 @@ let r_ce_002 : rule =
      with Not_found -> ());
     if !cnt > 0 then
       Some
-        {
-          id = "CE-002";
-          severity = Info;
-          message = "Canadian EN: Oxford comma must always be used";
-          count = !cnt;
-        }
+        (mk_result ~id:"CE-002" ~severity:Info
+           ~message:"Canadian EN: Oxford comma must always be used" ~count:!cnt)
     else None
   in
   mk_lang_rule "CE-002" run [ "en" ]
@@ -1335,12 +1182,9 @@ let r_th_001 : rule =
     in
     if cnt > 0 then
       Some
-        {
-          id = "TH-001";
-          severity = Info;
-          message = "Thai leading vowel at line start needs \\nobreakspace";
-          count = cnt;
-        }
+        (mk_result ~id:"TH-001" ~severity:Info
+           ~message:"Thai leading vowel at line start needs \\nobreakspace"
+           ~count:cnt)
     else None
   in
   mk_lang_rule "TH-001" run [ "th" ]
@@ -1357,12 +1201,8 @@ let r_ib_001 : rule =
     in
     if has_voce && has_tu then
       Some
-        {
-          id = "IB-001";
-          severity = Info;
-          message = {|Brochure mixes pt-BR 'você' with es-ES 'tú'|};
-          count = 1;
-        }
+        (mk_result ~id:"IB-001" ~severity:Info
+           ~message:{|Brochure mixes pt-BR 'você' with es-ES 'tú'|} ~count:1)
     else None
   in
   mk_lang_rule "IB-001" run [ "pt"; "es" ]
@@ -1382,12 +1222,8 @@ let r_lang_003 : rule =
     let has_both = fr_style && en_style in
     if has_both then
       Some
-        {
-          id = "LANG-003";
-          severity = Info;
-          message = "Mixed French/English punctuation spacing";
-          count = 1;
-        }
+        (mk_result ~id:"LANG-003" ~severity:Info
+           ~message:"Mixed French/English punctuation spacing" ~count:1)
     else None
   in
   mk_lang_rule "LANG-003" run [ "fr" ]
@@ -1408,12 +1244,9 @@ let r_lang_011 : rule =
       in
       if has_ascii_quotes then
         Some
-          {
-            id = "LANG-011";
-            severity = Info;
-            message = "French document uses ASCII quotes — use \\og ... \\fg{}";
-            count = 1;
-          }
+          (mk_result ~id:"LANG-011" ~severity:Info
+             ~message:"French document uses ASCII quotes — use \\og ... \\fg{}"
+             ~count:1)
       else None
   in
   mk_lang_rule "LANG-011" run [ "fr" ]
@@ -1440,14 +1273,11 @@ let r_lang_012 : rule =
     match (babel_lang, select_lang) with
     | Some b, Some sl when b <> sl ->
         Some
-          {
-            id = "LANG-012";
-            severity = Info;
-            message =
-              Printf.sprintf
-                "babel language '%s' mismatches \\selectlanguage{'%s'}" b sl;
-            count = 1;
-          }
+          (mk_result ~id:"LANG-012" ~severity:Info
+             ~message:
+               (Printf.sprintf
+                  "babel language '%s' mismatches \\selectlanguage{'%s'}" b sl)
+             ~count:1)
     | _ -> None
   in
   mk_rule "LANG-012" run
@@ -1476,12 +1306,8 @@ let r_lang_014 : rule =
     in
     if has_ize && has_ise then
       Some
-        {
-          id = "LANG-014";
-          severity = Info;
-          message = "BrE -ize/-ise ending inconsistency";
-          count = 1;
-        }
+        (mk_result ~id:"LANG-014" ~severity:Info
+           ~message:"BrE -ize/-ise ending inconsistency" ~count:1)
     else None
   in
   mk_lang_rule "LANG-014" run [ "en" ]
@@ -1504,12 +1330,8 @@ let r_lang_015 : rule =
      with Not_found -> ());
     if !cnt > 0 then
       Some
-        {
-          id = "LANG-015";
-          severity = Info;
-          message = "Serial-comma rule violated (per style)";
-          count = !cnt;
-        }
+        (mk_result ~id:"LANG-015" ~severity:Info
+           ~message:"Serial-comma rule violated (per style)" ~count:!cnt)
     else None
   in
   mk_lang_rule "LANG-015" run [ "en" ]
@@ -1528,12 +1350,8 @@ let r_lang_016 : rule =
     in
     if has_programme && has_program then
       Some
-        {
-          id = "LANG-016";
-          severity = Info;
-          message = "'programme'/'program' inconsistency in text";
-          count = 1;
-        }
+        (mk_result ~id:"LANG-016" ~severity:Info
+           ~message:"'programme'/'program' inconsistency in text" ~count:1)
     else None
   in
   mk_lang_rule "LANG-016" run [ "en" ]
@@ -1569,14 +1387,11 @@ let r_style_003 : rule =
       let ratio = float_of_int passive_cnt /. float_of_int total in
       if ratio > 0.20 then
         Some
-          {
-            id = "STYLE-003";
-            severity = Info;
-            message =
-              Printf.sprintf "Passive voice in %.0f%% of sentences"
-                (ratio *. 100.0);
-            count = passive_cnt;
-          }
+          (mk_result ~id:"STYLE-003" ~severity:Info
+             ~message:
+               (Printf.sprintf "Passive voice in %.0f%% of sentences"
+                  (ratio *. 100.0))
+             ~count:passive_cnt)
       else None
   in
   mk_rule "STYLE-003" run
@@ -1604,12 +1419,9 @@ let r_style_012 : rule =
     (* Only fire if both patterns present — indicates potential misuse *)
     if has_which && has_that then
       Some
-        {
-          id = "STYLE-012";
-          severity = Info;
-          message = "That/which relative-clause usage may be inconsistent";
-          count = 1;
-        }
+        (mk_result ~id:"STYLE-012" ~severity:Info
+           ~message:"That/which relative-clause usage may be inconsistent"
+           ~count:1)
     else None
   in
   mk_rule "STYLE-012" run
@@ -1634,12 +1446,8 @@ let r_style_029 : rule =
     in
     if has_author_we && has_generic_we then
       Some
-        {
-          id = "STYLE-029";
-          severity = Info;
-          message = "Undefined 'we' — mixes author-we and generic-we";
-          count = 1;
-        }
+        (mk_result ~id:"STYLE-029" ~severity:Info
+           ~message:"Undefined 'we' — mixes author-we and generic-we" ~count:1)
     else None
   in
   mk_rule "STYLE-029" run
@@ -1663,12 +1471,9 @@ let r_style_032 : rule =
      with Not_found -> ());
     if !uppers > 0 && !lowers > 0 then
       Some
-        {
-          id = "STYLE-032";
-          severity = Info;
-          message = "Bullet list mixes sentence-case and title-case";
-          count = min !uppers !lowers;
-        }
+        (mk_result ~id:"STYLE-032" ~severity:Info
+           ~message:"Bullet list mixes sentence-case and title-case"
+           ~count:(min !uppers !lowers))
     else None
   in
   mk_rule "STYLE-032" run
@@ -1703,12 +1508,8 @@ let r_style_038 : rule =
      with Not_found -> ());
     if !cnt > 0 then
       Some
-        {
-          id = "STYLE-038";
-          severity = Info;
-          message = "Footnote paragraph exceeds 80 words";
-          count = !cnt;
-        }
+        (mk_result ~id:"STYLE-038" ~severity:Info
+           ~message:"Footnote paragraph exceeds 80 words" ~count:!cnt)
     else None
   in
   mk_rule "STYLE-038" run
@@ -1751,12 +1552,9 @@ let r_style_039 : rule =
       let without_period = List.filter (fun c -> c <> '.') endings in
       if List.length with_period > 0 && List.length without_period > 0 then
         Some
-          {
-            id = "STYLE-039";
-            severity = Info;
-            message = "Figure-caption ending punctuation inconsistent";
-            count = min (List.length with_period) (List.length without_period);
-          }
+          (mk_result ~id:"STYLE-039" ~severity:Info
+             ~message:"Figure-caption ending punctuation inconsistent"
+             ~count:(min (List.length with_period) (List.length without_period)))
       else None
   in
   mk_rule "STYLE-039" run
@@ -1794,12 +1592,8 @@ let r_style_041 : rule =
      with Not_found -> ());
     if !cnt > 0 then
       Some
-        {
-          id = "STYLE-041";
-          severity = Info;
-          message = "Footnote lacks terminal period";
-          count = !cnt;
-        }
+        (mk_result ~id:"STYLE-041" ~severity:Info
+           ~message:"Footnote lacks terminal period" ~count:!cnt)
     else None
   in
   mk_rule "STYLE-041" run
@@ -1823,12 +1617,9 @@ let r_style_043 : rule =
       let without_punct = List.length titles - with_punct in
       if with_punct > 0 && without_punct > 0 then
         Some
-          {
-            id = "STYLE-043";
-            severity = Info;
-            message = "Section-heading punctuation inconsistent";
-            count = min with_punct without_punct;
-          }
+          (mk_result ~id:"STYLE-043" ~severity:Info
+             ~message:"Section-heading punctuation inconsistent"
+             ~count:(min with_punct without_punct))
       else None
   in
   mk_rule "STYLE-043" run
@@ -1854,12 +1645,8 @@ let r_style_044 : rule =
      with Not_found -> ());
     if !cnt > 0 then
       Some
-        {
-          id = "STYLE-044";
-          severity = Info;
-          message = "Ambiguous demonstrative 'this' without noun";
-          count = !cnt;
-        }
+        (mk_result ~id:"STYLE-044" ~severity:Info
+           ~message:"Ambiguous demonstrative 'this' without noun" ~count:!cnt)
     else None
   in
   mk_rule "STYLE-044" run
@@ -1877,12 +1664,9 @@ let r_style_047 : rule =
     in
     if ame && bre then
       Some
-        {
-          id = "STYLE-047";
-          severity = Info;
-          message = "Quote-punctuation placement AmE vs BrE inconsistent";
-          count = 1;
-        }
+        (mk_result ~id:"STYLE-047" ~severity:Info
+           ~message:"Quote-punctuation placement AmE vs BrE inconsistent"
+           ~count:1)
     else None
   in
   mk_rule "STYLE-047" run

--- a/latex-parse/src/validators_partial.ml
+++ b/latex-parse/src/validators_partial.ml
@@ -17,28 +17,22 @@ let r_prt_001 : rule =
         | Partial_cst.Complete -> None
         | Partial_cst.Partial ->
             Some
-              {
-                id = "PRT-001";
-                severity = Warning;
-                message =
-                  Printf.sprintf
-                    "Document has parse errors in %d region(s); some results \
-                     may be incomplete"
-                    (List.length pd.error_regions);
-                count = List.length pd.error_regions;
-              }
+              (mk_result ~id:"PRT-001" ~severity:Warning
+                 ~message:
+                   (Printf.sprintf
+                      "Document has parse errors in %d region(s); some results \
+                       may be incomplete"
+                      (List.length pd.error_regions))
+                 ~count:(List.length pd.error_regions))
         | Partial_cst.Broken ->
             Some
-              {
-                id = "PRT-001";
-                severity = Error;
-                message =
-                  Printf.sprintf
-                    "Document has %d parse error(s); results in affected \
-                     regions are unreliable"
-                    (List.length pd.error_regions);
-                count = List.length pd.error_regions;
-              })
+              (mk_result ~id:"PRT-001" ~severity:Error
+                 ~message:
+                   (Printf.sprintf
+                      "Document has %d parse error(s); results in affected \
+                       regions are unreliable"
+                      (List.length pd.error_regions))
+                 ~count:(List.length pd.error_regions)))
   in
   mk_rule "PRT-001" run
 
@@ -65,17 +59,14 @@ let r_prt_002 : rule =
         in
         if cross_boundary then
           Some
-            {
-              id = "PRT-002";
-              severity = Info;
-              message =
-                Printf.sprintf
-                  "Parse errors affect %d zone(s) with %d adjacent partial \
-                   zone(s)"
-                  (List.length broken_zones)
-                  (List.length partial_zones);
-              count = List.length broken_zones + List.length partial_zones;
-            }
+            (mk_result ~id:"PRT-002" ~severity:Info
+               ~message:
+                 (Printf.sprintf
+                    "Parse errors affect %d zone(s) with %d adjacent partial \
+                     zone(s)"
+                    (List.length broken_zones)
+                    (List.length partial_zones))
+               ~count:(List.length broken_zones + List.length partial_zones))
         else None
   in
   mk_rule "PRT-002" run

--- a/latex-parse/src/validators_project.ml
+++ b/latex-parse/src/validators_project.ml
@@ -19,14 +19,11 @@ let r_prj_001 : rule =
             List.map (fun cycle -> String.concat " -> " cycle) cycles
           in
           Some
-            {
-              id = "PRJ-001";
-              severity = Error;
-              message =
-                Printf.sprintf "Cycle in include graph: %s"
-                  (String.concat "; " paths);
-              count = List.length cycles;
-            }
+            (mk_result ~id:"PRJ-001" ~severity:Error
+               ~message:
+                 (Printf.sprintf "Cycle in include graph: %s"
+                    (String.concat "; " paths))
+               ~count:(List.length cycles))
         else None
   in
   mk_rule "PRJ-001" run
@@ -46,14 +43,11 @@ let r_prj_002 : rule =
               unresolved
           in
           Some
-            {
-              id = "PRJ-002";
-              severity = Warning;
-              message =
-                Printf.sprintf "Unresolved include path(s): %s"
-                  (String.concat "; " paths);
-              count = List.length unresolved;
-            }
+            (mk_result ~id:"PRJ-002" ~severity:Warning
+               ~message:
+                 (Printf.sprintf "Unresolved include path(s): %s"
+                    (String.concat "; " paths))
+               ~count:(List.length unresolved))
         else None
   in
   mk_rule "PRJ-002" run
@@ -73,14 +67,11 @@ let r_prj_003 : rule =
               undef
           in
           Some
-            {
-              id = "PRJ-003";
-              severity = Warning;
-              message =
-                Printf.sprintf "Cross-file undefined reference(s): %s"
-                  (String.concat "; " keys);
-              count = List.length undef;
-            }
+            (mk_result ~id:"PRJ-003" ~severity:Warning
+               ~message:
+                 (Printf.sprintf "Cross-file undefined reference(s): %s"
+                    (String.concat "; " keys))
+               ~count:(List.length undef))
         else None
   in
   mk_rule "PRJ-003" run
@@ -101,14 +92,11 @@ let r_prj_004 : rule =
               dups
           in
           Some
-            {
-              id = "PRJ-004";
-              severity = Warning;
-              message =
-                Printf.sprintf "Cross-file duplicate label(s): %s"
-                  (String.concat "; " descs);
-              count = List.length dups;
-            }
+            (mk_result ~id:"PRJ-004" ~severity:Warning
+               ~message:
+                 (Printf.sprintf "Cross-file duplicate label(s): %s"
+                    (String.concat "; " descs))
+               ~count:(List.length dups))
         else None
   in
   mk_rule "PRJ-004" run

--- a/proofs/ADMISSIBILITY_MAP.md
+++ b/proofs/ADMISSIBILITY_MAP.md
@@ -142,10 +142,18 @@ its premise.
 
 ### CST round-trip — byte-lossless (`CSTRoundTrip.v`)
 
-**Section variables** (`Section Structure_lossless`):
+**Section variables** (`Section Structure_lossless`, lines 126–168):
 - `ast : Type`, `parse : bytes -> ast`, `in_subset : bytes -> Prop`,
   `builder : bytes -> list cst_abs` — opaque carriers + the abstract
   builder; v26.3 instantiates.
+
+> **Discharge unit note.** This Section has **two** hypotheses
+> (`builder_partitions` + `parse_serialize_is_id_on_subset`). In Coq you
+> cannot partially close a Section — to produce useful instantiated
+> theorems for v26.3+, BOTH hypotheses must be discharged together
+> against the same concrete carriers. Discharging only one yields a
+> strictly weaker "parametric in the other" theorem and doesn't unblock
+> runtime claims. Sized accordingly: this is a single discharge unit.
 
 **Hypotheses:**
 1. `builder_partitions` — every source has a byte-lossless
@@ -173,7 +181,14 @@ its premise.
 
 ### Rewrite engine — byte preservation (`RewritePreservesCST.v`)
 
-**Section variable:** `apply_edits : bytes -> list edit -> bytes`.
+**Section variable** (`Section Rewrite_preserves`, lines 54–86):
+`apply_edits : bytes -> list edit -> bytes`.
+
+> **Discharge unit note.** Only **one** hypothesis in this Section —
+> this is the **smallest v26.3 Coq discharge unit** and is the
+> recommended starting point for anyone picking up v26.3 Coq work. The
+> OCaml reference implementation (`Cst_edit.apply_all`) already exists
+> and is total on non-overlapping edit lists.
 
 **Hypothesis:**
 1. `apply_total` — `apply_edits` is total on its input:
@@ -191,7 +206,20 @@ its premise.
 
 ### Rewrite engine — semantic preservation (`RewritePreservesSemantics.v`)
 
-**Section variables:** `token : Type`, `tokens : bytes -> list token`.
+**Section variables** (`Section Semantic_preservation`, lines 32–86):
+`token : Type`, `tokens : bytes -> list token`.
+
+> **Discharge unit note.** This Section has **two** hypotheses
+> (`tokens_ws_empty` + `tokens_concat`) used together by every in-section
+> theorem (`ws_replacement_preserves_tokens` /
+> `ws_deletion_preserves_tokens` / `ws_insertion_preserves_tokens`).
+> Discharging only `tokens_ws_empty` does not close the Section.
+> `tokens_ws_empty` is mechanical in isolation BUT `tokens_concat` is
+> not — real `Parser_l2` has local lookahead (e.g. `\[`), so concat-
+> compositionality only holds when restricted to non-command whitespace
+> chunks. The discharge unit is: a minimal Coq tokenizer model on
+> trivia-only chunks satisfying both hypotheses, instantiated against
+> a reduced `in_subset` predicate.
 
 **Hypotheses:**
 1. `tokens_ws_empty` — whitespace-only input tokenises to the empty

--- a/scripts/tools/check_doc_refs.py
+++ b/scripts/tools/check_doc_refs.py
@@ -64,6 +64,10 @@ REF_ALLOWLIST = {
     "stable_spans.ml",
     # v27 WS8 forward reference — discharge target for T6/T7 hypotheses.
     "proofs/PdflatexModel.v",
+    # V26.2.1 planned files referenced in specs/v26/V26_2_1_PLAN.md
+    "scripts/tools/migrate_result_literals.py",  # one-shot migration, PR #1
+    "scripts/tools/check_result_helpers.py",  # new gate, PR #1
+    "docs/MIGRATION_v26.2_to_v26.2.1.md",  # consumer migration doc, PR #5
 }
 
 LINK_PATTERN = re.compile(r"\[([^\]]*)\]\(([^)]+)\)")

--- a/scripts/tools/check_result_helpers.py
+++ b/scripts/tools/check_result_helpers.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Gate (v26.2.1 PR #1): reject raw [Validators_common.result] record
+literals in [latex-parse/src/validators_*.ml] and test files.
+
+Rationale
+---------
+v26.2.1 introduced [Validators_common.mk_result] and
+[mk_result_with_fix] helpers so that the new [fix : Cst_edit.t list
+option] field is only produced in one place. New rules that construct
+[result] values directly as record literals bypass the helper and will
+fail to compile when future fields are added. This gate makes the
+invariant machine-checked.
+
+The gate scans every validator source and test file, detects any
+4-field [{ id = ...; severity = ...; message = ...; count = ... }]
+record literal (OCaml-aware on strings, char literals, quoted strings
+and comments), and fails if one is found.
+
+Escape hatch: none. If a helper is insufficient (e.g. because a new
+field needs a non-[None] default), extend the helper signature instead
+of bypassing it.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# Reuse the OCaml-aware parser from the migration script.
+sys.path.insert(0, str(REPO_ROOT / "scripts" / "tools"))
+from migrate_result_literals import (  # noqa: E402
+    try_parse_result_literal,
+    skip_string,
+    skip_comment,
+    try_skip_quoted_string,
+    try_skip_char_literal,
+)
+
+
+def count_raw_literals(path: Path) -> list[tuple[int, str]]:
+    """Return a list of (line_number, first_field_excerpt) for each raw
+    result record literal found in [path]."""
+    text = path.read_text()
+    n = len(text)
+    hits: list[tuple[int, str]] = []
+    i = 0
+    while i < n:
+        c = text[i]
+        if c == '"':
+            i = skip_string(text, i)
+        elif c == "'":
+            ch = try_skip_char_literal(text, i)
+            if ch is not None:
+                i = ch
+            else:
+                i += 1
+        elif text[i : i + 2] == "(*":
+            i = skip_comment(text, i)
+        elif c == "{":
+            qs = try_skip_quoted_string(text, i)
+            if qs is not None:
+                i = qs
+                continue
+            parsed = try_parse_result_literal(text, i)
+            if parsed is not None:
+                end, _prefix, vals = parsed
+                line = text.count("\n", 0, i) + 1
+                hits.append((line, vals[0][:40]))
+                i = end
+            else:
+                i += 1
+        else:
+            i += 1
+    return hits
+
+
+def main() -> int:
+    src = REPO_ROOT / "latex-parse" / "src"
+    targets = sorted(
+        set(src.glob("validators*.ml"))
+        | set(src.glob("test_validators*.ml"))
+        | set(src.glob("test_chunk_store.ml"))
+        | set(src.glob("test_edf_scheduler.ml"))
+        | set(src.glob("test_evidence_scoring.ml"))
+    )
+    total_hits = 0
+    for f in targets:
+        hits = count_raw_literals(f)
+        for line, excerpt in hits:
+            rel = f.relative_to(REPO_ROOT).as_posix()
+            print(
+                f"[result-helpers] FAIL: {rel}:{line}: raw result "
+                f"record literal (id={excerpt}); use "
+                f"Validators_common.mk_result / mk_result_with_fix."
+            )
+            total_hits += 1
+    if total_hits > 0:
+        print(
+            f"[result-helpers] FAIL: {total_hits} raw literal(s) remain. "
+            f"Introduced in v26.2.1 PR #1; see "
+            f"specs/v26/V26_2_1_PLAN.md §3 PR #1."
+        )
+        return 1
+    print("[result-helpers] PASS: no raw result record literals.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tools/migrate_result_literals.py
+++ b/scripts/tools/migrate_result_literals.py
@@ -1,0 +1,292 @@
+#!/usr/bin/env python3
+"""One-shot migration (v26.2.1 PR #1): rewrite every
+[Validators_common.result] record literal to use the
+[mk_result]/[mk_result_with_fix] helpers so the new [fix] field is
+introduced without touching every callsite manually.
+
+Pattern matched (whitespace/comments tolerated everywhere):
+
+    { id = <expr>; severity = <expr>; message = <expr>; count = <expr>; }
+
+Rewritten to:
+
+    (mk_result ~id:(<expr>) ~severity:(<expr>) ~message:(<expr>) ~count:(<expr>))
+
+After a full repo sweep, run `dune fmt --auto-promote` to normalise
+formatting. The script itself is intentionally minimal and is DELETED
+when PR #1 lands (see specs/v26/V26_2_1_PLAN.md §3 PR #1).
+
+The parser is OCaml-aware on strings and nested comments — it does NOT
+trip on semicolons inside quoted messages or `(* comments *)`.
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def skip_string(text: str, i: int) -> int:
+    """[text[i]] must be '"'. Return index just past the closing unescaped
+    quote (or end-of-text if unterminated)."""
+    assert text[i] == '"'
+    n = len(text)
+    i += 1
+    while i < n:
+        c = text[i]
+        if c == "\\" and i + 1 < n:
+            i += 2
+        elif c == '"':
+            return i + 1
+        else:
+            i += 1
+    return i
+
+
+_QSTR_OPEN = re.compile(r"\{([a-z_]*)\|")
+
+# OCaml character literal: 'c', '\n', '\xFF', '\065', etc.
+# NOT a type variable ('a, 'foo).
+_CHAR_LITERAL = re.compile(
+    r"'(?:\\x[0-9a-fA-F]{1,2}|\\[0-9]{1,3}|\\.|[^'\\])'"
+)
+
+
+def try_skip_char_literal(text: str, i: int) -> int | None:
+    """If [text[i:]] starts an OCaml character literal, return the index
+    just past its closing quote. Otherwise None. Distinguishes from
+    type variables (['a, 'foo])."""
+    m = _CHAR_LITERAL.match(text, i)
+    if not m:
+        return None
+    return m.end()
+
+
+def try_skip_quoted_string(text: str, i: int) -> int | None:
+    """If [text[i:]] starts an OCaml quoted-string literal
+    [{delim|...|delim}], return the index just past it. Otherwise None.
+    Quoted strings are opened with '{<delim>|' where <delim> is a
+    (possibly empty) lowercase-id, and closed with '|<delim>}'."""
+    m = _QSTR_OPEN.match(text, i)
+    if not m:
+        return None
+    delim = m.group(1)
+    close = "|" + delim + "}"
+    end = text.find(close, m.end())
+    if end < 0:
+        return None
+    return end + len(close)
+
+
+def skip_comment(text: str, i: int) -> int:
+    """[text[i:i+2]] must be '(*'. Return index just past the matching
+    '*)'. Handles nested comments. Does NOT parse strings inside
+    comments (OCaml comments are allowed to contain anything as long as
+    nested comments + string-like constructs balance — we just track
+    comment depth)."""
+    assert text[i : i + 2] == "(*"
+    n = len(text)
+    i += 2
+    depth = 1
+    while i + 1 < n:
+        if text[i : i + 2] == "(*":
+            depth += 1
+            i += 2
+        elif text[i : i + 2] == "*)":
+            depth -= 1
+            i += 2
+            if depth == 0:
+                return i
+        else:
+            i += 1
+    return n
+
+
+def skip_ws_and_comments(text: str, i: int) -> int:
+    n = len(text)
+    while i < n:
+        if text[i].isspace():
+            i += 1
+        elif text[i : i + 2] == "(*":
+            i = skip_comment(text, i)
+        else:
+            break
+    return i
+
+
+def extract_value(text: str, i: int) -> tuple[int, str]:
+    """Extract an OCaml expression starting at [text[i]] until the next
+    ';' or '}' at nesting depth 0. Respects string literals (both
+    ["..."] and [{delim|...|delim}]), comments, and
+    bracket/paren/brace nesting. Returns (end_index, value_string)
+    where [text[end_index]] is the terminator."""
+    n = len(text)
+    depth = 0
+    start = i
+    while i < n:
+        c = text[i]
+        if c == '"':
+            i = skip_string(text, i)
+        elif c == "'":
+            ch = try_skip_char_literal(text, i)
+            if ch is not None:
+                i = ch
+            else:
+                i += 1
+        elif text[i : i + 2] == "(*":
+            i = skip_comment(text, i)
+        elif c == "{":
+            qs = try_skip_quoted_string(text, i)
+            if qs is not None:
+                i = qs
+            else:
+                depth += 1
+                i += 1
+        elif c in "([":
+            depth += 1
+            i += 1
+        elif c in "})]":
+            if depth == 0:
+                return (i, text[start:i].strip())
+            depth -= 1
+            i += 1
+        elif c == ";" and depth == 0:
+            return (i, text[start:i].strip())
+        else:
+            i += 1
+    return (i, text[start:i].strip())
+
+
+FIELD_ORDER = ("id", "severity", "message", "count")
+
+
+def try_parse_result_literal(
+    text: str, start: int
+) -> tuple[int, str, list[str]] | None:
+    """[text[start]] must be '{'. Try to parse a four-field result
+    literal in the required order id/severity/message/count. Returns
+    (end_index_after_}, module_prefix, [id_val, sev_val, msg_val, cnt_val])
+    or None if the record doesn't match the expected shape.
+    [module_prefix] is e.g. "Validators_common." if the first field was
+    qualified, or "" otherwise — callers use it to qualify the helper
+    name in the replacement."""
+    assert text[start] == "{"
+    n = len(text)
+    i = start + 1
+    i = skip_ws_and_comments(text, i)
+    values: list[str] = []
+    prefix = ""
+    for idx, expected in enumerate(FIELD_ORDER):
+        # First field may be qualified: `Validators_common.id = ...` or
+        # `Latex_parse_lib.Validators_common.id = ...`. Subsequent
+        # fields are always bare (OCaml infers record type from first).
+        if idx == 0:
+            pattern = r"((?:[A-Z][a-zA-Z0-9_]*\.)*)" + re.escape(expected) + r"\s*="
+            m = re.match(pattern, text[i:])
+            if not m:
+                return None
+            prefix = m.group(1)
+        else:
+            pattern = re.escape(expected) + r"\s*="
+            m = re.match(pattern, text[i:])
+            if not m:
+                return None
+        i += m.end()
+        i = skip_ws_and_comments(text, i)
+        end, value = extract_value(text, i)
+        values.append(value)
+        i = end
+        if idx < len(FIELD_ORDER) - 1:
+            # Require ';' between fields
+            if i >= n or text[i] != ";":
+                return None
+            i += 1
+            i = skip_ws_and_comments(text, i)
+    # Optional trailing ';' after count
+    if i < n and text[i] == ";":
+        i += 1
+    i = skip_ws_and_comments(text, i)
+    if i >= n or text[i] != "}":
+        return None
+    return (i + 1, prefix, values)
+
+
+def migrate_file(path: Path, *, dry_run: bool = False) -> int:
+    text = path.read_text()
+    n = len(text)
+    out: list[str] = []
+    i = 0
+    replacements = 0
+    while i < n:
+        c = text[i]
+        if c == '"':
+            end = skip_string(text, i)
+            out.append(text[i:end])
+            i = end
+        elif c == "'":
+            ch = try_skip_char_literal(text, i)
+            if ch is not None:
+                out.append(text[i:ch])
+                i = ch
+            else:
+                out.append(c)
+                i += 1
+        elif text[i : i + 2] == "(*":
+            end = skip_comment(text, i)
+            out.append(text[i:end])
+            i = end
+        elif c == "{":
+            qs = try_skip_quoted_string(text, i)
+            if qs is not None:
+                out.append(text[i:qs])
+                i = qs
+                continue
+            parsed = try_parse_result_literal(text, i)
+            if parsed is not None:
+                end, prefix, vals = parsed
+                id_v, sev_v, msg_v, cnt_v = vals
+                replacement = (
+                    f"({prefix}mk_result ~id:({id_v}) ~severity:({sev_v}) "
+                    f"~message:({msg_v}) ~count:({cnt_v}))"
+                )
+                out.append(replacement)
+                i = end
+                replacements += 1
+            else:
+                out.append(c)
+                i += 1
+        else:
+            out.append(c)
+            i += 1
+    new_text = "".join(out)
+    if replacements > 0 and not dry_run:
+        path.write_text(new_text)
+    return replacements
+
+
+def main() -> int:
+    src = REPO_ROOT / "latex-parse" / "src"
+    # All validator files + tests that build result literals.
+    # Intentionally broad — the parser only rewrites actual 4-field
+    # result records; other `{...}` blocks are left untouched.
+    targets = sorted(
+        set(src.glob("validators*.ml"))
+        | set(src.glob("test_validators*.ml"))
+        | set(src.glob("test_chunk_store.ml"))
+        | set(src.glob("test_edf_scheduler.ml"))
+    )
+    dry = "--dry" in sys.argv
+    total = 0
+    for f in targets:
+        n = migrate_file(f, dry_run=dry)
+        if n > 0:
+            print(f"{f.relative_to(REPO_ROOT)}: {n} literals")
+            total += n
+    print(f"Total: {total} literals across {sum(1 for f in targets if f.exists())} files scanned")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tools/pre_release_check.py
+++ b/scripts/tools/pre_release_check.py
@@ -40,6 +40,7 @@ GATES = [
     ("python3", "scripts/tools/check_release_integrity.py", "--repo", "."),
     ("python3", "scripts/tools/check_gates_meta.py", "--repo", "."),
     ("python3", "scripts/tools/check_perf_ratchet.py", "--repo", "."),
+    ("python3", "scripts/tools/check_result_helpers.py"),
 ]
 
 BUILD_CHECKS = [

--- a/specs/v26/V26_2_1_PLAN.md
+++ b/specs/v26/V26_2_1_PLAN.md
@@ -1,0 +1,352 @@
+# V26.2.1 — Fix producer track
+
+**Status:** draft, 2026-04-24. Successor to `V26_2_PLAN.md`.
+**Scope:** the five fix-producer items CHANGELOG deferred from v26.2.0.
+**Cadence:** five PRs, one-per-item, merged sequentially. Target tag: 2026-05-08
+(two-week cycle — smaller than v26.1 / v26.2 per `V26_2_PLAN.md` §13).
+
+## 0. Pre-conditions (verified 2026-04-24 on HEAD `830c58b`)
+
+- `dune build` green, `dune runtest latex-parse/src` green.
+- `python3 scripts/tools/pre_release_check.py --allow-dirty --skip-build`
+  → 14/14 gates PASS (`check_repo_facts`, `check_rule_contracts`,
+  `check_regression_gates`, `check_memo_files`, `check_proof_substance`,
+  `validate_catalogue`, `check_severity_drift`, `check_mli_doc_coverage`,
+  `check_code_quality`, `check_unused_hypotheses`, `check_doc_refs`,
+  `check_release_integrity`, `check_gates_meta`, `check_perf_ratchet`).
+- `check_memo_files.py` → 115/115 paths resolve.
+- No open PRs against main. Four open GitHub issues are historical
+  `proof-regression` labels from PR #206/#245 era (April 10–21); not
+  v26.2.1 blockers.
+- No prior v26.2.1 planning artifacts (no branches, no plan file, no
+  issues).
+
+## 1. Verified scope numbers (grep audit)
+
+Prior memory/CHANGELOG claims were stale; re-verified counts used below.
+
+### 1.1 `result` record literal refactor
+
+`grep -c "severity = \(Error\|Warning\|Info\)" latex-parse/src/*.ml`
+yields **681 literals across 18 files**. Per-file top (ordered):
+
+| File | Literals |
+|---|---|
+| `validators_l2.ml` | 204 |
+| `validators_l0.ml` | 134 |
+| `validators_l1.ml` | 90 |
+| `validators_l1_math.ml` | 82 |
+| `validators_l0_typo.ml` | 61 |
+| `validators_l4_style.ml` | 59 |
+| `validators_l3_file.ml` | 19 |
+| `validators_l1_expl3.ml` | 12 |
+| remainder (10 files) | ≤4 each |
+
+The prior memory claim of "~40" was a 17× under-count. Implication: the
+record-literal migration is **not** a manual PR-sized edit; it ships
+via a helper-constructor rewrite (§3.1 PR #1 design).
+
+### 1.2 Rule-fix producer scope (target rules verified to exist)
+
+- `STRUCT-001` at `validators_l0.ml:25` (`require_documentclass`),
+  gated by `L0_VALIDATORS` pilot mode. Returns `count = 1` on miss.
+- `TYPO-002` at `validators_l0_typo.ml:19` (double-hyphen →
+  en-dash), dual-mode: token-aware (`L0_TOKEN_AWARE=1`) or
+  substring. Returns aggregate `count`, no offsets.
+- `TYPO-003` at `validators_l0_typo.ml:62` (triple-hyphen →
+  em-dash), same structure as TYPO-002.
+
+**Key finding:** TYPO-002/003 aggregate matches into one `result` with
+`count = N`. A fix for N matches needs N edits. Therefore
+`result.fix` must be `Cst_edit.t list option`, not `Cst_edit.t option`
+as CHANGELOG and memory implied. This plan adopts the `list option`
+type; §4 §CHANGELOG deviation notes this.
+
+### 1.3 Rewrite-engine hooks (verified present)
+
+- `Cst_edit.t` private record at `cst_edit.mli:16`.
+- `Cst_edit.make / insert / delete / replace` constructors
+  (`cst_edit.mli:23-35`).
+- `Cst_edit.apply_all : string -> t list -> (string, [\`Overlap of t*t]) result`
+  at `cst_edit.mli:61`.
+- `Rewrite_engine.apply` + `apply_and_reparse` in `rewrite_engine.mli`.
+- `--apply-fixes` / `L0_APPLY_FIXES` NOT present anywhere in
+  `latex-parse/src/` or `scripts/` (verified by negative grep).
+
+### 1.4 Section structure of v26.3 Coq targets (out of v26.2.1 scope)
+
+For completeness; these land in v26.3 per `ADMISSIBILITY_MAP.md`:
+
+- `CSTRoundTrip.v` Section `Structure_lossless` (lines 126–168) — 2
+  hypotheses, must discharge together.
+- `RewritePreservesCST.v` Section `Rewrite_preserves` (lines 54–86) —
+  1 hypothesis (`apply_total`); smallest v26.3 unit.
+- `RewritePreservesSemantics.v` Section `Semantic_preservation`
+  (lines 32–86) — 2 hypotheses, must discharge together.
+
+## 2. Non-goals
+
+- No Coq-level hypothesis discharge. The v26.3 sections above stay
+  hypothesis-parametric in v26.2.1.
+- No `edf_scheduler.ml` per-class rewrite; v26.1 priority offsets
+  remain.
+- No xelatex/lualatex `.aux` parser extensions.
+- No migration of TYPO-002/003 to one-result-per-match. Aggregate
+  `count` stays; the fix producer walks source independently to emit
+  per-match edits.
+- No rolling fix producers for rules beyond STRUCT-001 / TYPO-002 /
+  TYPO-003. The three "exemplars" model the pattern; rest ship in
+  v26.3+ per plan §10.
+
+## 3. PR slate
+
+### PR #1 — `result.fix` field via `mk_result` helper
+
+**Branch:** `v26.2.1/a1-result-fix-field`
+**Size:** 681-site mechanical rewrite + helper module. Single-review PR.
+**Reviewer requirement:** 1 (mechanical), but author cannot self-merge
+(standard).
+
+**Changes:**
+
+1. `latex-parse/src/validators_common.ml(i)`:
+   - Add `fix : Cst_edit.t list option` field to `type result`.
+   - Add helpers:
+     ```ocaml
+     val mk_result :
+       id:string -> severity:severity -> message:string ->
+       count:int -> result
+     val mk_result_with_fix :
+       id:string -> severity:severity -> message:string ->
+       count:int -> fix:Cst_edit.t list -> result
+     ```
+   - `mk_result` sets `fix = None`; `mk_result_with_fix` sets
+     `fix = Some <list>`.
+2. Mechanical migration of all 681 record literals:
+   ```
+   Some { id = "X"; severity = S; message = M; count = C }
+   → Some (mk_result ~id:"X" ~severity:S ~message:M ~count:C)
+   ```
+   Script: `scripts/tools/migrate_result_literals.py` (new, one-shot,
+   deleted after PR #1 lands). Must be idempotent and refuse to touch
+   a file that doesn't parse identically post-rewrite
+   (round-trip gate).
+3. `latex-parse/src/dune` — no change; `validators_common` already
+   depends on `cst_edit` via the rewrite engine wrapped lib.
+
+**Gates added/modified:**
+
+- New gate: `scripts/tools/check_result_helpers.py` — rejects new
+  `{ id = ...; severity = ...; message = ...; count = ... }` record
+  literals in `validators_*.ml`. Forces future rules to use the
+  helper. Wired into `pre_release_check.py` as gate #15.
+- `run_differential_test.py` baseline reset to `v26.2.0`; fix-present
+  diffs use `--expected-diff-keys fix` (per CHANGELOG line 70).
+
+**Semver:** additive — new field defaults to `None` through the
+helpers; no behavior change on consumers. Patch bump (`26.2.0 →
+26.2.1`).
+
+**Acceptance:**
+
+- `dune build && dune runtest` green.
+- 14+1 gates pass (new `check_result_helpers`).
+- `run_differential_test.py --baseline-ref v26.2.0 --current-ref HEAD
+  --expected-diff-keys ""` → zero diffs (no fix producers yet).
+
+### PR #2 — STRUCT-001 fix producer
+
+**Branch:** `v26.2.1/a2-struct-001-fix`
+**Size:** ~20 lines. Single commit.
+
+**Changes:**
+
+1. `validators_l0.ml::require_documentclass` — when firing, emit:
+   ```ocaml
+   let fix = [Cst_edit.insert ~at:0 "\\documentclass{article}\n"] in
+   mk_result_with_fix ~id:"STRUCT-001" ~severity:Warning
+     ~message:"Missing \\documentclass" ~count:1 ~fix
+   ```
+2. Test: `test_validators_struct.ml` asserts
+   `r.fix = Some [edit]` with `edit.start_offset = 0 && edit.end_offset = 0
+   && edit.replacement = "\\documentclass{article}\n"`.
+3. Doc: extend `docs/v26_2/FIX_STYLE_GUIDE.md` with the STRUCT-001
+   example.
+
+**Gates:** differential-test expected-diff-keys includes `fix` for
+STRUCT-001-firing corpus files from here on.
+
+### PR #3 — TYPO-002 + TYPO-003 fix producers
+
+**Branch:** `v26.2.1/a3-typo-dashes-fix`
+**Size:** ~80 lines (two rules + position scan).
+
+**Design note:** the current rules aggregate `count` without tracking
+offsets. The fix producer does a separate second pass over the source
+to collect offsets and build N edits. Does NOT change the existing
+count logic.
+
+**Changes:**
+
+1. New helper in `validators_l0_typo.ml`:
+   ```ocaml
+   let find_all_substrings s sub =
+     (* returns sorted list of byte offsets where sub occurs in s *)
+   ```
+2. TYPO-002 fix: for each offset `o` where `--` appears, emit
+   `Cst_edit.replace ~start_offset:o ~end_offset:(o+2) "–"`.
+3. TYPO-003 fix: same but for `---` → `—`, offsets +3.
+4. **Conflict note:** TYPO-002 and TYPO-003 conflict on `---`
+   (TYPO-003 matches, TYPO-002's second+third char also match). The
+   existing `conflicts_with` edge (PR #241 p1.3: TYPO-003 suppresses
+   TYPO-002 on `---`) means only TYPO-003 fires in that case, so the
+   fix set is non-overlapping by construction.
+5. Tests in `test_typo_fix.ml` (new): firing + fix-content assertions
+   on curated fixtures.
+6. Doc: FIX_STYLE_GUIDE.md — add the two-pass "scan for offsets"
+   pattern.
+
+### PR #4 — `--apply-fixes` CLI + `L0_APPLY_FIXES` env gate
+
+**Branch:** `v26.2.1/a4-apply-fixes-cli`
+**Size:** ~100 lines in `validators_cli.ml` + wiring.
+
+**Changes:**
+
+1. `validators_cli.ml`:
+   - Add `--apply-fixes` boolean flag (default false). Alternative gate:
+     env var `L0_APPLY_FIXES=1|true|on`.
+   - When gated on: after `Validators.run_all`, collect every
+     `r.fix = Some edits` into a single list, call
+     `Rewrite_engine.apply` via `Cst_edit.apply_all`. On overlap:
+     emit `E.apply-fixes.overlap` error to stderr, exit non-zero,
+     DO NOT modify output.
+   - Output: modified source to stdout (existing non-fix mode writes
+     per-rule reports to stdout; `--apply-fixes` replaces that output
+     unambiguously — semantically distinct mode, no confusion).
+2. Decision (pre-filled, override if needed): all-or-nothing
+   application only. `--apply-fixes-for RULE-ID` stays deferred to
+   v26.3 per `V26_2_PLAN.md` §3.2 B3.
+3. Wire into `latex-parse/src/dune` (no change expected — CLI is
+   already in the main target).
+4. Tests in `test_apply_fixes_cli.ml`:
+   - STRUCT-001 apply inserts `\documentclass` at top.
+   - TYPO-002 apply converts `a -- b` to `a – b`.
+   - Overlapping fixes from contrived corpus → exit code 2, stderr
+     `E.apply-fixes.overlap`.
+
+### PR #5 — E2E fix integration test + runtime gate
+
+**Branch:** `v26.2.1/a5-fix-integration-e2e`
+**Size:** ~150 lines.
+
+**Changes:**
+
+1. `test_rule_fix_integration.ml` (new):
+   - Full pipeline per test: raw source → `Validators.run_all` →
+     collect fixes → `Rewrite_engine.apply_and_reparse` → assert no
+     firing of the same rule on the output.
+   - Cases: STRUCT-001, TYPO-002, TYPO-003, combinations.
+2. CI gate: `pre_release_check.py` adds `test_rule_fix_integration`
+   to the required-tests list (gate #16).
+3. `corpora/fixtures/v26_2_1/` (new): curated inputs for the E2E
+   tests. 5 files, small.
+4. Documentation:
+   - CHANGELOG `[v26.2.1]` entry with the five PRs listed.
+   - `docs/MIGRATION_v26.2_to_v26.2.1.md` (new, small): the helper
+     constructor is the only consumer-visible change, but third-party
+     code constructing `result` literals directly must migrate.
+   - Update `docs/v26_2/FIX_STYLE_GUIDE.md` with the three exemplars.
+
+## 4. CHANGELOG deviation from v26.2.0 deferred-list
+
+The v26.2.0 CHANGELOG line described the deferred field as
+`result.fix : Cst_edit.t option`. During verification we determined
+the correct type is `Cst_edit.t list option` (see §1.2). The v26.2.1
+CHANGELOG entry documents the deviation:
+
+> Type deviation from v26.2.0 plan: `result.fix` is
+> `Cst_edit.t list option`, not `Cst_edit.t option`. Single-edit was
+> incorrect — TYPO-002/003 rules aggregate `count` per document and
+> produce one edit per match, requiring a list. The v26.2.0 `option`
+> claim was an authoring error; no third-party code depended on it
+> (the field didn't exist in v26.2.0).
+
+## 5. Gates and ratchets
+
+**No ratchet bumps expected.** New tests are structural, not
+`expect true`. MLI doc coverage: `validators_common.mli` gains two
+helpers with docstrings, so coverage goes up, not down. Perf budget:
+no hot-path change.
+
+**New gates added across the cycle:**
+- PR #1: `check_result_helpers.py` (forbids raw `result` record
+  literals in `validators_*.ml`).
+- PR #5: `test_rule_fix_integration` in required-tests list.
+
+Final pre-release check count: **14 → 16 gates** by tag.
+
+## 6. Risks + mitigations
+
+| ID | Risk | Likelihood | Impact | Mitigation | Backout |
+|---|---|---|---|---|---|
+| R1 | Migration script (PR #1) misses a literal | Med | High | Check `check_result_helpers.py` + full `dune runtest` before merge; staged rollout file-by-file | Revert PR, single commit |
+| R2 | TYPO-002 and TYPO-003 fix sets overlap in corner cases | Low | Med | Existing `conflicts_with` edge suppresses TYPO-002 when TYPO-003 fires; test on `a---b---c` corpus explicitly | `--apply-fixes` emits overlap error + non-zero exit |
+| R3 | STRUCT-001 fix inserts at wrong offset when BOM present | Low | Low | Fix-producer respects byte-0 semantics; test includes UTF-8 BOM fixture | Rule keeps working without fix; fix is optional |
+| R4 | `--apply-fixes` output mode confuses existing stdout consumers | Med | Low | Mode is gated on explicit flag/env; existing stdout format preserved in non-fix mode | Ship with `FIX_STYLE_GUIDE.md` warning |
+| R5 | v26.2.0 downstream consumers construct `result` records directly | Low | Med | Migration doc + deprecation note on `result` type literal usage | Helper is additive; raw literals still compile (gate is lint-only) |
+| R6 | 681-site refactor introduces syntax error in one file | Med | High | Per-file round-trip gate in migration script + per-file `dune build` check | Revert file |
+
+## 7. Release flow
+
+Per `V26_2_PLAN.md` §12 template:
+
+```bash
+# After PR #5 merges and the CHANGELOG entry is complete:
+git checkout main && git pull
+git checkout -b v26.2.1/release-bump
+python3 scripts/release.sh 26.2.1  # runs 16 gates + bumps facts
+git push -u origin v26.2.1/release-bump
+gh pr create --title "chore: bump version to 26.2.1" \
+  --body "See CHANGELOG §v26.2.1"
+# On merge, tag:
+git checkout main && git pull
+git tag -a v26.2.1 -m "v26.2.1 fix-producer track"
+git push origin v26.2.1
+```
+
+## 8. Out-of-v26.2.1 (confirmed)
+
+These stay in v26.3 per §10 of V26_2_PLAN and §1.4 above:
+
+- Three Section-level Coq discharges (`CSTRoundTrip.Structure_lossless`,
+  `RewritePreservesCST.Rewrite_preserves`,
+  `RewritePreservesSemantics.Semantic_preservation`).
+- Rolling fix producers for the remaining ~657 rules.
+- `--apply-fixes-for RULE-ID` granularity flag.
+- `edf_scheduler.ml` per-class rewrite.
+- CST structure-lossless runtime gate.
+- xelatex / lualatex `.aux` parser variants.
+- L3 AST migration (docs/L3_ROADMAP.md).
+
+## 9. First concrete action
+
+Open **PR #1 (result.fix field + mk_result helpers)**:
+
+```bash
+git checkout main && git pull
+git checkout -b v26.2.1/a1-result-fix-field
+# 1. Edit validators_common.ml(i) with field + helpers
+# 2. Write scripts/tools/migrate_result_literals.py
+# 3. Run it — verify `dune build` after every file
+# 4. Write scripts/tools/check_result_helpers.py
+# 5. Wire new gate into pre_release_check.py
+python3 scripts/tools/pre_release_check.py --allow-dirty --skip-build
+git commit -m "feat(v26.2.1): PR #1 — result.fix field + mk_result helper"
+git push -u origin v26.2.1/a1-result-fix-field
+gh pr create --title "feat(v26.2.1): PR #1 — result.fix field via mk_result helper" \
+  --body "See specs/v26/V26_2_1_PLAN.md §3 PR #1"
+```
+
+Estimated time: 1–2 days for PR #1, 1 day each for PRs #2–#4, 2 days
+for PR #5. Total: ~8 days of work over a 2-week calendar cycle.


### PR DESCRIPTION
## Summary

Opens the v26.2.1 fix-producer cycle (see `specs/v26/V26_2_1_PLAN.md`).

- Adds `fix : Cst_edit.t list option` to `Validators_common.result`.
- Introduces `mk_result` / `mk_result_with_fix` constructors.
- Migrates all 673 existing record literals across 15 validator / test files via a one-shot OCaml-aware script (`scripts/tools/migrate_result_literals.py`, deleted in follow-up once this lands).
- Lands the v26.2.1 plan + supporting ADMISSIBILITY_MAP / doc-refs / memory updates.

## Type deviation from v26.2.0 CHANGELOG

`fix` is `Cst_edit.t list option`, **not** `Cst_edit.t option`. TYPO-002/003 aggregate `count` per document and need one edit per match → list is required. Empty `Some` is rejected by the helper.

## Migration

Mechanical. The parser is OCaml-aware on strings, quoted strings (`{|...|}`), character literals (`'"'`), comments, and qualified field names (`Validators_common.id =`). Ran in four passes; each resolved one parser-coverage edge case, all documented inline.

## Gates

- New gate: `scripts/tools/check_result_helpers.py` forbids raw 4-field `{ id; severity; message; count }` record literals. Wired into `pre_release_check.py` as gate #15.
- Updated: `scripts/tools/check_doc_refs.py` REF_ALLOWLIST gains 3 forward references to PR-#2..#5 files.
- **15/15 pre-release gates pass.**
- `dune runtest latex-parse/src` green (no test changes).

## Semver

Additive. `fix` defaults to `None`; no rule emits fixes yet (arrives in PR #2/#3). This is a v26.2.1 patch bump.

## Test plan
- [x] `dune build` green
- [x] `dune runtest latex-parse/src` green (all test files PASS)
- [x] `python3 scripts/tools/pre_release_check.py --allow-dirty --skip-build` → 15/15 PASS
- [x] `check_result_helpers` gate rejects raw literals (verified via unit test: script removed all 673)
- [x] `check_doc_refs` gate happy with the V26_2_1_PLAN file

Refs: `specs/v26/V26_2_1_PLAN.md` §3 PR #1