### PR TITLE
feat(v26.2.1): PR #2 — STRUCT-001 fix producer

### DIFF
--- a/docs/v26_2/FIX_STYLE_GUIDE.md
+++ b/docs/v26_2/FIX_STYLE_GUIDE.md
@@ -1,8 +1,16 @@
-# Fix-suggestion style guide (v26.2)
+# Fix-suggestion style guide (v26.2 / v26.2.1)
 
-As rule authors add `fix : Cst_edit.edit option` suggestions, consistency
-matters: users see these in validator output and potentially `--apply-fixes`
-their source. Inconsistent style erodes trust.
+As rule authors add `fix : Cst_edit.t list option` suggestions,
+consistency matters: users see these in validator output and
+potentially `--apply-fixes` their source. Inconsistent style erodes
+trust.
+
+**v26.2.1 update:** the field is a **list** of edits per result
+(`Cst_edit.t list option`), not a single edit, because many rules
+aggregate matches per document (see TYPO-002/003 below). The list
+must be non-empty when `Some`; use `None` for "no fix available".
+Construct via `Validators_common.mk_result_with_fix ~fix` — never
+populate the record literal directly (gate: `check_result_helpers`).
 
 ## Canonical patterns
 
@@ -22,31 +30,31 @@ their source. Inconsistent style erodes trust.
 - Delete minimal span. If the problem is `  ,` (space before comma),
   delete the space, not the comma.
 
-## Examples (exemplar rules that ship in v26.2 B3)
+## Examples (exemplar rules — v26.2.1 PRs #2, #3)
 
-**STRUCT-001: Missing \documentclass**
+**STRUCT-001: Missing `\documentclass`** (single insertion at top)
 ```ocaml
-fix = Some (Cst_edit.Insert {
-  at = top_of_source;
-  text = "\\documentclass{article}\n";
-})
+let fix = [ Cst_edit.insert ~at:0 "\\documentclass{article}\n" ] in
+mk_result_with_fix ~id:"STRUCT-001" ~severity:Warning
+  ~message:"Missing \\documentclass" ~count:1 ~fix
 ```
 
-**TYPO-002: `--` should be `–` (en dash)**
+**TYPO-002: `--` should be `–` (en dash)** (N replacements, one per
+match — requires a second scan pass to collect offsets because the
+rule aggregates `count`)
 ```ocaml
-fix = Some (Cst_edit.Replace {
-  span = span_of_match;    (* the `--` itself *)
-  text = "–";
-})
+let edits =
+  List.map
+    (fun off -> Cst_edit.replace ~start_offset:off ~end_offset:(off + 2) "–")
+    offsets
+in
+mk_result_with_fix ~id:"TYPO-002" ~severity:Warning
+  ~message:"Double hyphen -- should be en-dash –" ~count:(List.length edits)
+  ~fix:edits
 ```
 
-**TYPO-003: `---` should be `—` (em dash)**
-```ocaml
-fix = Some (Cst_edit.Replace {
-  span = span_of_match;
-  text = "—";
-})
-```
+**TYPO-003: `---` should be `—` (em dash)** — same shape as TYPO-002
+with `end_offset:(off + 3)` and replacement `"—"`.
 
 ## Anti-patterns (reject in review)
 

--- a/latex-parse/src/test_helpers.ml
+++ b/latex-parse/src/test_helpers.ml
@@ -59,6 +59,20 @@ let fires_advisory_with_count id src expected_count =
 
 let fires_with_count_advisory = fires_advisory_with_count
 
+(** [fires_with_fix id src] is [true] when rule [id] fires on [src] and emits a
+    non-empty fix edit list (v26.2.1 PR #2/#3). *)
+let fires_with_fix id src =
+  match find_result id src with
+  | Some { fix = Some (_ :: _); _ } -> true
+  | _ -> false
+
+(** [fix_edits id src] returns the fix edit list for rule [id] on [src], or [[]]
+    if the rule didn't fire or produced no fix. *)
+let fix_edits id src =
+  match find_result id src with
+  | Some { fix = Some edits; _ } -> edits
+  | _ -> []
+
 (** [with_pilot_env f] sets [L0_VALIDATORS=pilot], runs [f ()], then returns. *)
 let with_pilot_env f =
   Unix.putenv "L0_VALIDATORS" "pilot";

--- a/latex-parse/src/test_validators_struct.ml
+++ b/latex-parse/src/test_validators_struct.ml
@@ -18,6 +18,20 @@ let () =
         (does_not_fire "STRUCT-001"
            "\\documentclass{article}\n\\begin{document}\n\\end{document}")
         (tag ^ ": docclass present"));
+  run "STRUCT-001 emits a single insert-at-0 fix edit" (fun tag ->
+      let src = "Hello world\nNo documentclass here." in
+      let edits = fix_edits "STRUCT-001" src in
+      let applied =
+        match edits with
+        | [ edit ] -> Latex_parse_lib.Cst_edit.apply_single src edit
+        | _ -> ""
+      in
+      expect
+        (List.length edits = 1
+        && String.length applied - String.length src
+           = String.length "\\documentclass{article}\n"
+        && String.sub applied 0 14 = "\\documentclass")
+        (tag ^ ": inserts \\documentclass at top"));
 
   (* STRUCT-002: Empty section title *)
   run "STRUCT-002 fires on empty section title" (fun tag ->

--- a/latex-parse/src/validators_l0.ml
+++ b/latex-parse/src/validators_l0.ml
@@ -28,9 +28,10 @@ let require_documentclass : rule =
     if pilot_mode then None
     else if contains_substring s "\\documentclass" then None
     else
+      let fix = [ Cst_edit.insert ~at:0 "\\documentclass{article}\n" ] in
       Some
-        (mk_result ~id:"STRUCT-001" ~severity:Warning
-           ~message:"Missing \\documentclass" ~count:1)
+        (mk_result_with_fix ~id:"STRUCT-001" ~severity:Warning
+           ~message:"Missing \\documentclass" ~count:1 ~fix)
   in
   { id = "STRUCT-001"; run; languages = [] }
 


### PR DESCRIPTION
## Summary

Second PR in the v26.2.1 fix-producer cycle. Stacks on top of PR #265 (PR #1).

- STRUCT-001 now emits `[Cst_edit.insert ~at:0 "\documentclass{article}\n"]` when firing.
- Uses `Validators_common.mk_result_with_fix`.
- Adds `fires_with_fix` / `fix_edits` helpers to `test_helpers.ml`.
- Refreshes `docs/v26_2/FIX_STYLE_GUIDE.md` to the v26.2.1 API (list + helper).

## Test plan
- [x] `dune build` green
- [x] `dune runtest latex-parse/src` — `[validators-struct] PASS 11 cases` (was 10)
- [x] New assertion: single edit, applied source begins with `\documentclass`
- [x] 15/15 pre-release gates pass

Depends on: #265
Refs: `specs/v26/V26_2_1_PLAN.md` §3 PR #2