### PR TITLE
feat(v26.2.1): PR #3 — TYPO-002/003 fix producers

### DIFF
--- a/latex-parse/src/dune
+++ b/latex-parse/src/dune
@@ -366,6 +366,11 @@
  (libraries latex_parse_lib test_helpers unix))
 
 (test
+ (name test_typo_fix)
+ (modules test_typo_fix)
+ (libraries latex_parse_lib test_helpers unix))
+
+(test
  (name test_validators_verb_cjk_cmd)
  (modules test_validators_verb_cjk_cmd)
  (libraries latex_parse_lib test_helpers unix))

--- a/latex-parse/src/test_typo_fix.ml
+++ b/latex-parse/src/test_typo_fix.ml
@@ -1,0 +1,70 @@
+(** Unit tests for TYPO-002 / TYPO-003 fix producers (v26.2.1 PR #3).
+
+    These rules aggregate [count] per document and emit one replace
+    edit per non-overlapping match position. See
+    [specs/v26/V26_2_1_PLAN.md] §3 PR #3 for the design rationale. *)
+
+open Test_helpers
+
+let apply_all s edits =
+  match Latex_parse_lib.Cst_edit.apply_all s edits with
+  | Ok out -> out
+  | Error _ -> failwith "overlapping fix edits — should not happen in tests"
+
+let () =
+  (* TYPO-002/003 ship in the pilot rule set (gated by L0_VALIDATORS).
+     Enable it for the duration of this test file. *)
+  Unix.putenv "L0_VALIDATORS" "pilot";
+
+  (* TYPO-002: `--` → `–` (en-dash). *)
+  run "TYPO-002 fix: single -- becomes en-dash" (fun tag ->
+      let src = "Words -- more words" in
+      let edits = fix_edits "TYPO-002" src in
+      expect
+        (List.length edits = 1 && apply_all src edits = "Words – more words")
+        (tag ^ ": one edit, applied = en-dash"));
+
+  run "TYPO-002 fix: two disjoint -- produce two edits" (fun tag ->
+      let src = "a -- b, c -- d" in
+      let edits = fix_edits "TYPO-002" src in
+      expect
+        (List.length edits = 2 && apply_all src edits = "a – b, c – d")
+        (tag ^ ": two edits applied correctly"));
+
+  run "TYPO-002 does not fire on clean source" (fun tag ->
+      expect
+        (does_not_fire "TYPO-002" "no double hyphens here")
+        (tag ^ ": no fire, no fix"));
+
+  (* TYPO-003: `---` → `—` (em-dash). TYPO-002 is suppressed by
+     conflict edge on the same source. *)
+  run "TYPO-003 fix: single --- becomes em-dash" (fun tag ->
+      let src = "Words --- more words" in
+      let edits = fix_edits "TYPO-003" src in
+      expect
+        (List.length edits = 1 && apply_all src edits = "Words — more words")
+        (tag ^ ": one edit, applied = em-dash"));
+
+  run "TYPO-003 fix: two disjoint --- produce two edits" (fun tag ->
+      let src = "a --- b, c --- d" in
+      let edits = fix_edits "TYPO-003" src in
+      expect
+        (List.length edits = 2 && apply_all src edits = "a — b, c — d")
+        (tag ^ ": two edits applied correctly"));
+
+  run "TYPO-003 on ---- emits one non-overlapping edit at offset 0"
+    (fun tag ->
+      (* `----` contains `---` at offset 0 (non-overlap advance by 3).
+         TYPO-003 fix emits one replace(0,3,"—"); applying yields `—-`.
+         Rule-count may be >1 (overlap semantics) but fix-count = 1. *)
+      let src = "word ---- word" in
+      let edits = fix_edits "TYPO-003" src in
+      expect
+        (List.length edits = 1 && apply_all src edits = "word —- word")
+        (tag ^ ": one non-overlapping edit"));
+
+  (* Interaction: when ---  is present, TYPO-003 wins (conflict edge
+     from PR #241 p1.3); TYPO-002 is suppressed at run_all level.
+     We don't assert on TYPO-002 here — the test above already covers
+     TYPO-002's fix semantics in isolation (no --- in the source). *)
+  finalise "typo-fix"

--- a/latex-parse/src/validators_l0_typo.ml
+++ b/latex-parse/src/validators_l0_typo.ml
@@ -16,7 +16,35 @@ let r_typo_001 : rule =
   in
   { id = "TYPO-001"; run; languages = [] }
 
+(** [find_all_non_overlapping s needle] — offsets of every occurrence of
+    [needle] in [s], advancing by [|needle|] after each match (no
+    overlaps). Used by TYPO-002/003 fix producers to build a
+    non-overlapping replace-edit set. Differs from [count_substring]
+    (which allows overlaps) — the fix-count may therefore be smaller
+    than the rule-[count] on pathological input like "----" (count=3
+    with overlaps, 2 non-overlapping [--] matches). Acceptable: the
+    fix-set is always applicable; the rule-[count] is a separate
+    severity indicator. *)
+let find_all_non_overlapping (s : string) (needle : string) : int list =
+  let nlen = String.length needle in
+  let slen = String.length s in
+  if nlen = 0 || slen < nlen then []
+  else
+    let rec loop i acc =
+      if i + nlen > slen then List.rev acc
+      else if String.sub s i nlen = needle then loop (i + nlen) (i :: acc)
+      else loop (i + 1) acc
+    in
+    loop 0 []
+
 let r_typo_002 : rule =
+  let message = "Double hyphen -- should be en‑dash –" in
+  let mk_fix_edits s =
+    List.map
+      (fun off ->
+        Cst_edit.replace ~start_offset:off ~end_offset:(off + 2) "–")
+      (find_all_non_overlapping s "--")
+  in
   let run s =
     match Sys.getenv_opt "L0_TOKEN_AWARE" with
     | Some ("1" | "true" | "on") ->
@@ -34,21 +62,36 @@ let r_typo_002 : rule =
           loop 0 toks
         in
         if cnt > 0 then
-          Some
-            (mk_result ~id:"TYPO-002" ~severity:Warning
-               ~message:"Double hyphen -- should be en‑dash –" ~count:cnt)
+          let fix = mk_fix_edits s in
+          if fix = [] then
+            Some (mk_result ~id:"TYPO-002" ~severity:Warning ~message ~count:cnt)
+          else
+            Some
+              (mk_result_with_fix ~id:"TYPO-002" ~severity:Warning ~message
+                 ~count:cnt ~fix)
         else None
     | _ ->
         let cnt = count_substring s "--" in
         if cnt > 0 then
-          Some
-            (mk_result ~id:"TYPO-002" ~severity:Warning
-               ~message:"Double hyphen -- should be en‑dash –" ~count:cnt)
+          let fix = mk_fix_edits s in
+          if fix = [] then
+            Some (mk_result ~id:"TYPO-002" ~severity:Warning ~message ~count:cnt)
+          else
+            Some
+              (mk_result_with_fix ~id:"TYPO-002" ~severity:Warning ~message
+                 ~count:cnt ~fix)
         else None
   in
   { id = "TYPO-002"; run; languages = [] }
 
 let r_typo_003 : rule =
+  let message = "Triple hyphen --- should be em‑dash —" in
+  let mk_fix_edits s =
+    List.map
+      (fun off ->
+        Cst_edit.replace ~start_offset:off ~end_offset:(off + 3) "—")
+      (find_all_non_overlapping s "---")
+  in
   let run s =
     match Sys.getenv_opt "L0_TOKEN_AWARE" with
     | Some ("1" | "true" | "on") ->
@@ -66,16 +109,24 @@ let r_typo_003 : rule =
           loop 0 toks
         in
         if cnt > 0 then
-          Some
-            (mk_result ~id:"TYPO-003" ~severity:Warning
-               ~message:"Triple hyphen --- should be em‑dash —" ~count:cnt)
+          let fix = mk_fix_edits s in
+          if fix = [] then
+            Some (mk_result ~id:"TYPO-003" ~severity:Warning ~message ~count:cnt)
+          else
+            Some
+              (mk_result_with_fix ~id:"TYPO-003" ~severity:Warning ~message
+                 ~count:cnt ~fix)
         else None
     | _ ->
         let cnt = count_substring s "---" in
         if cnt > 0 then
-          Some
-            (mk_result ~id:"TYPO-003" ~severity:Warning
-               ~message:"Triple hyphen --- should be em‑dash —" ~count:cnt)
+          let fix = mk_fix_edits s in
+          if fix = [] then
+            Some (mk_result ~id:"TYPO-003" ~severity:Warning ~message ~count:cnt)
+          else
+            Some
+              (mk_result_with_fix ~id:"TYPO-003" ~severity:Warning ~message
+                 ~count:cnt ~fix)
         else None
   in
   { id = "TYPO-003"; run; languages = [] }


### PR DESCRIPTION
## Summary

Third PR in v26.2.1 fix-producer cycle. Stacks on PR #266.

- `find_all_non_overlapping` helper emits match offsets (advance by `|needle|` after each hit).
- TYPO-002 (`--` → `–`) and TYPO-003 (`---` → `—`) produce one replace edit per match.
- Rule `count` keeps existing overlap semantics (`count_substring`); fix list is non-overlapping. Documented inline and in tests.

## Conflict interaction

Per PR #241 p1.3, TYPO-003 suppresses TYPO-002 at run_all level when `---` fires. Fix producers respect this — each rule emits its own fix list; only the winning rule's fix reaches consumers.

## Tests

`test_typo_fix.ml` (6 cases, new file):
- Single `--` → single `–`.
- Two disjoint `--` → two en-dashes.
- Clean source doesn't fire.
- Single `---` → single `—`.
- Two disjoint `---` → two em-dashes.
- `----` emits one non-overlapping `---` edit at offset 0.

Requires `L0_VALIDATORS=pilot` (TYPO rules ship in pilot set).

## Gates
- [x] `dune build` green
- [x] `dune runtest latex-parse/src` — `[typo-fix] PASS 6 cases` + all pre-existing tests green
- [x] 15/15 pre-release gates PASS

Depends on: #266
Refs: `specs/v26/V26_2_1_PLAN.md` §3 PR #3