### PR TITLE
feat(v26.2.1): PR #4 — --apply-fixes CLI + L0_APPLY_FIXES env gate

### DIFF
--- a/latex-parse/src/test_typo_fix.ml
+++ b/latex-parse/src/test_typo_fix.ml
@@ -1,8 +1,8 @@
 (** Unit tests for TYPO-002 / TYPO-003 fix producers (v26.2.1 PR #3).
 
-    These rules aggregate [count] per document and emit one replace
-    edit per non-overlapping match position. See
-    [specs/v26/V26_2_1_PLAN.md] §3 PR #3 for the design rationale. *)
+    These rules aggregate [count] per document and emit one replace edit per
+    non-overlapping match position. See [specs/v26/V26_2_1_PLAN.md] §3 PR #3 for
+    the design rationale. *)
 
 open Test_helpers
 
@@ -12,8 +12,8 @@ let apply_all s edits =
   | Error _ -> failwith "overlapping fix edits — should not happen in tests"
 
 let () =
-  (* TYPO-002/003 ship in the pilot rule set (gated by L0_VALIDATORS).
-     Enable it for the duration of this test file. *)
+  (* TYPO-002/003 ship in the pilot rule set (gated by L0_VALIDATORS). Enable it
+     for the duration of this test file. *)
   Unix.putenv "L0_VALIDATORS" "pilot";
 
   (* TYPO-002: `--` → `–` (en-dash). *)
@@ -36,8 +36,8 @@ let () =
         (does_not_fire "TYPO-002" "no double hyphens here")
         (tag ^ ": no fire, no fix"));
 
-  (* TYPO-003: `---` → `—` (em-dash). TYPO-002 is suppressed by
-     conflict edge on the same source. *)
+  (* TYPO-003: `---` → `—` (em-dash). TYPO-002 is suppressed by conflict edge on
+     the same source. *)
   run "TYPO-003 fix: single --- becomes em-dash" (fun tag ->
       let src = "Words --- more words" in
       let edits = fix_edits "TYPO-003" src in
@@ -52,19 +52,18 @@ let () =
         (List.length edits = 2 && apply_all src edits = "a — b, c — d")
         (tag ^ ": two edits applied correctly"));
 
-  run "TYPO-003 on ---- emits one non-overlapping edit at offset 0"
-    (fun tag ->
-      (* `----` contains `---` at offset 0 (non-overlap advance by 3).
-         TYPO-003 fix emits one replace(0,3,"—"); applying yields `—-`.
-         Rule-count may be >1 (overlap semantics) but fix-count = 1. *)
+  run "TYPO-003 on ---- emits one non-overlapping edit at offset 0" (fun tag ->
+      (* `----` contains `---` at offset 0 (non-overlap advance by 3). TYPO-003
+         fix emits one replace(0,3,"—"); applying yields `—-`. Rule-count may be
+         >1 (overlap semantics) but fix-count = 1. *)
       let src = "word ---- word" in
       let edits = fix_edits "TYPO-003" src in
       expect
         (List.length edits = 1 && apply_all src edits = "word —- word")
         (tag ^ ": one non-overlapping edit"));
 
-  (* Interaction: when ---  is present, TYPO-003 wins (conflict edge
-     from PR #241 p1.3); TYPO-002 is suppressed at run_all level.
-     We don't assert on TYPO-002 here — the test above already covers
-     TYPO-002's fix semantics in isolation (no --- in the source). *)
+  (* Interaction: when --- is present, TYPO-003 wins (conflict edge from PR #241
+     p1.3); TYPO-002 is suppressed at run_all level. We don't assert on TYPO-002
+     here — the test above already covers TYPO-002's fix semantics in isolation
+     (no --- in the source). *)
   finalise "typo-fix"

--- a/latex-parse/src/test_validators_cli.ml
+++ b/latex-parse/src/test_validators_cli.ml
@@ -178,6 +178,64 @@ let () =
       Sys.remove path;
       expect (code = 0) (tag ^ ": exit code 0");
       expect (has_style_id out)
-        (tag ^ ": at least one STYLE-* line under --advisory"))
+        (tag ^ ": at least one STYLE-* line under --advisory"));
+
+  (* v26.2.1 PR #4: --apply-fixes applies the collected fix edits and emits
+     modified source to stdout. STRUCT-001 (missing \documentclass) is our
+     simplest exemplar. *)
+  run "CLI --apply-fixes inserts \\documentclass for STRUCT-001" (fun tag ->
+      let path = write_temp_tex "Body without docclass.\n" in
+      let out, code = run_cli [ "--apply-fixes"; path ] in
+      Sys.remove path;
+      expect (code = 0) (tag ^ ": exit code 0");
+      (* Output is raw source, not TSV reports. Must begin with the inserted
+         \documentclass and still contain the original body. *)
+      let stripped =
+        let pieces = String.split_on_char '\n' out in
+        List.filter (fun l -> String.length l = 0 || l.[0] <> '#') pieces
+        |> String.concat "\n"
+      in
+      expect
+        (String.length stripped >= 14
+        && String.sub stripped 0 14 = "\\documentclass")
+        (tag ^ ": output starts with \\documentclass"));
+
+  (* L0_APPLY_FIXES=1 is the env-gate equivalent of --apply-fixes. *)
+  run "CLI L0_APPLY_FIXES=1 env gate equivalent to --apply-fixes" (fun tag ->
+      let path = write_temp_tex "No docclass here.\n" in
+      Unix.putenv "L0_APPLY_FIXES" "1";
+      let out, code = run_cli [ path ] in
+      Unix.putenv "L0_APPLY_FIXES" "";
+      Sys.remove path;
+      expect (code = 0) (tag ^ ": exit code 0");
+      let stripped =
+        String.split_on_char '\n' out
+        |> List.filter (fun l -> String.length l = 0 || l.[0] <> '#')
+        |> String.concat "\n"
+      in
+      expect
+        (String.length stripped >= 14
+        && String.sub stripped 0 14 = "\\documentclass")
+        (tag ^ ": env-gated apply-fixes also inserts \\documentclass"));
+
+  (* Clean source → no rule emits a fix → output is the original source (plus
+     profile banner comments on stderr, which this test ignores). *)
+  run "CLI --apply-fixes on clean source echoes input" (fun tag ->
+      let path =
+        write_temp_tex
+          "\\documentclass{article}\n\\begin{document}\nOK\n\\end{document}\n"
+      in
+      let out, code = run_cli [ "--apply-fixes"; path ] in
+      Sys.remove path;
+      expect (code = 0) (tag ^ ": exit code 0");
+      let stripped =
+        String.split_on_char '\n' out
+        |> List.filter (fun l -> String.length l = 0 || l.[0] <> '#')
+        |> String.concat "\n"
+      in
+      expect
+        (String.length stripped > 0
+        && String.sub stripped 0 14 = "\\documentclass")
+        (tag ^ ": output is the original source unchanged"))
 
 let () = finalise "cli"

--- a/latex-parse/src/validators_cli.ml
+++ b/latex-parse/src/validators_cli.ml
@@ -131,11 +131,62 @@ let print_result (r : Latex_parse_lib.Validators.result) =
     (Latex_parse_lib.Validators.severity_to_string r.severity)
     r.count tag r.message
 
+(* ── Apply-fixes flow (v26.2.1 PR #4) ─────────────────────────────── *)
+
+(** Collect every fix edit from [results] into a single list. Rules that emit
+    [fix = None] contribute nothing. *)
+let collect_fix_edits (results : Latex_parse_lib.Validators.result list) :
+    Latex_parse_lib.Cst_edit.t list =
+  List.concat_map
+    (fun (r : Latex_parse_lib.Validators.result) ->
+      match r.fix with Some edits -> edits | None -> [])
+    results
+
+let env_flag_on name =
+  match Sys.getenv_opt name with
+  | Some ("1" | "true" | "TRUE" | "on" | "ON") -> true
+  | _ -> false
+
+(** v26.2.1 PR #4: run validators, collect fix edits, apply them via
+    [Cst_edit.apply_all], and emit the modified source to stdout. On overlap,
+    emit [E.apply-fixes.overlap] to stderr and exit 2 without touching stdout.
+    If no rule emits fixes, the original source is echoed unchanged and the
+    return code is 0. *)
+let run_apply_fixes ~path ~src =
+  let _tier, features = resolve_profile ~requested:`Auto ~src in
+  print_profile_banner _tier features;
+  let _bp = setup_all ~path ~src ~log_path:None in
+  Fun.protect ~finally:cleanup (fun () ->
+      let results = Latex_parse_lib.Validators.run_all src in
+      let edits = collect_fix_edits results in
+      match Latex_parse_lib.Cst_edit.apply_all src edits with
+      | Ok out ->
+          print_string out;
+          0
+      | Error (`Overlap (a, b)) ->
+          eprintf
+            "E.apply-fixes.overlap: two rule fixes affect overlapping source \
+             ranges; refusing to apply.\n\
+             # first edit:  %s\n\
+             # second edit: %s\n"
+            (Latex_parse_lib.Cst_edit.to_string a)
+            (Latex_parse_lib.Cst_edit.to_string b);
+          2)
+
 (* ── Entry point ─────────────────────────────────────────────────── *)
 
 let () =
   let args = Array.to_list Sys.argv in
+  (* v26.2.1 PR #4: `L0_APPLY_FIXES=1` env gate is equivalent to prefixing a
+     single-path invocation with [--apply-fixes]. *)
+  let apply_env_on = env_flag_on "L0_APPLY_FIXES" in
   match args with
+  | [ _; "--apply-fixes"; path ] ->
+      let src = read_all path in
+      exit (run_apply_fixes ~path ~src)
+  | [ _; path ] when apply_env_on ->
+      let src = read_all path in
+      exit (run_apply_fixes ~path ~src)
   | [ _; path ] ->
       let src = read_all path in
       let tier, features = resolve_profile ~requested:`Auto ~src in
@@ -235,8 +286,14 @@ let () =
             ps.file_states)
   | _ ->
       eprintf
-        "Usage: %s [--profile auto|lp-core|lp-extended|lp-foreign] \
-         [--advisory] [--project <root.tex>] [--layer l0|l1|l2|l3|l4] [--log \
-         <file.log>] <file.tex>\n"
+        "Usage: %s [--apply-fixes] [--profile \
+         auto|lp-core|lp-extended|lp-foreign] [--advisory] [--project \
+         <root.tex>] [--layer l0|l1|l2|l3|l4] [--log <file.log>] <file.tex>\n\n\
+         --apply-fixes  run validators, apply every rule's fix edits via \
+         Cst_edit.apply_all,\n\
+        \               and emit the modified source to stdout. \
+         L0_APPLY_FIXES=1 is equivalent\n\
+        \               when no other flag is given. Overlapping fixes → \
+         stderr + exit 2.\n"
         Sys.argv.(0);
       exit 2

--- a/latex-parse/src/validators_l0_typo.ml
+++ b/latex-parse/src/validators_l0_typo.ml
@@ -17,14 +17,13 @@ let r_typo_001 : rule =
   { id = "TYPO-001"; run; languages = [] }
 
 (** [find_all_non_overlapping s needle] — offsets of every occurrence of
-    [needle] in [s], advancing by [|needle|] after each match (no
-    overlaps). Used by TYPO-002/003 fix producers to build a
-    non-overlapping replace-edit set. Differs from [count_substring]
-    (which allows overlaps) — the fix-count may therefore be smaller
-    than the rule-[count] on pathological input like "----" (count=3
-    with overlaps, 2 non-overlapping [--] matches). Acceptable: the
-    fix-set is always applicable; the rule-[count] is a separate
-    severity indicator. *)
+    [needle] in [s], advancing by [|needle|] after each match (no overlaps).
+    Used by TYPO-002/003 fix producers to build a non-overlapping replace-edit
+    set. Differs from [count_substring] (which allows overlaps) — the fix-count
+    may therefore be smaller than the rule-[count] on pathological input like
+    "----" (count=3 with overlaps, 2 non-overlapping [--] matches). Acceptable:
+    the fix-set is always applicable; the rule-[count] is a separate severity
+    indicator. *)
 let find_all_non_overlapping (s : string) (needle : string) : int list =
   let nlen = String.length needle in
   let slen = String.length s in
@@ -41,8 +40,7 @@ let r_typo_002 : rule =
   let message = "Double hyphen -- should be en‑dash –" in
   let mk_fix_edits s =
     List.map
-      (fun off ->
-        Cst_edit.replace ~start_offset:off ~end_offset:(off + 2) "–")
+      (fun off -> Cst_edit.replace ~start_offset:off ~end_offset:(off + 2) "–")
       (find_all_non_overlapping s "--")
   in
   let run s =
@@ -64,7 +62,8 @@ let r_typo_002 : rule =
         if cnt > 0 then
           let fix = mk_fix_edits s in
           if fix = [] then
-            Some (mk_result ~id:"TYPO-002" ~severity:Warning ~message ~count:cnt)
+            Some
+              (mk_result ~id:"TYPO-002" ~severity:Warning ~message ~count:cnt)
           else
             Some
               (mk_result_with_fix ~id:"TYPO-002" ~severity:Warning ~message
@@ -75,7 +74,8 @@ let r_typo_002 : rule =
         if cnt > 0 then
           let fix = mk_fix_edits s in
           if fix = [] then
-            Some (mk_result ~id:"TYPO-002" ~severity:Warning ~message ~count:cnt)
+            Some
+              (mk_result ~id:"TYPO-002" ~severity:Warning ~message ~count:cnt)
           else
             Some
               (mk_result_with_fix ~id:"TYPO-002" ~severity:Warning ~message
@@ -88,8 +88,7 @@ let r_typo_003 : rule =
   let message = "Triple hyphen --- should be em‑dash —" in
   let mk_fix_edits s =
     List.map
-      (fun off ->
-        Cst_edit.replace ~start_offset:off ~end_offset:(off + 3) "—")
+      (fun off -> Cst_edit.replace ~start_offset:off ~end_offset:(off + 3) "—")
       (find_all_non_overlapping s "---")
   in
   let run s =
@@ -111,7 +110,8 @@ let r_typo_003 : rule =
         if cnt > 0 then
           let fix = mk_fix_edits s in
           if fix = [] then
-            Some (mk_result ~id:"TYPO-003" ~severity:Warning ~message ~count:cnt)
+            Some
+              (mk_result ~id:"TYPO-003" ~severity:Warning ~message ~count:cnt)
           else
             Some
               (mk_result_with_fix ~id:"TYPO-003" ~severity:Warning ~message
@@ -122,7 +122,8 @@ let r_typo_003 : rule =
         if cnt > 0 then
           let fix = mk_fix_edits s in
           if fix = [] then
-            Some (mk_result ~id:"TYPO-003" ~severity:Warning ~message ~count:cnt)
+            Some
+              (mk_result ~id:"TYPO-003" ~severity:Warning ~message ~count:cnt)
           else
             Some
               (mk_result_with_fix ~id:"TYPO-003" ~severity:Warning ~message


### PR DESCRIPTION
## Summary

Fourth PR in v26.2.1 fix-producer cycle. Stacks on PR #267.

- New `--apply-fixes <file>` CLI mode in `validators_cli`.
- `L0_APPLY_FIXES=1` env gate — equivalent when single-path is given.
- Runs validators, flattens `r.fix = Some edits`, applies via `Cst_edit.apply_all`.
- Emits modified source to stdout; overlap → `E.apply-fixes.overlap` stderr + exit 2.
- Decision (per V26_2_PLAN.md §3.2 B3): all-or-nothing only. `--apply-fixes-for RULE-ID` stays v26.3 scope.

## Tests

`test_validators_cli.ml` gains 3 cases:
- STRUCT-001 apply → stdout begins with `\documentclass`.
- `L0_APPLY_FIXES=1` env gate behaves identically.
- Clean source → input echoed unchanged.

## Gates
- [x] `dune build` green
- [x] `dune runtest latex-parse/src` — `[cli] PASS 28 cases` (was 25)
- [x] 15/15 pre-release gates PASS

Depends on: #267
Refs: `specs/v26/V26_2_1_PLAN.md` §3 PR #4