### PR TITLE
feat(v26.2.1): PR #5 — E2E test + CHANGELOG + migration doc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,82 @@
 
 All notable changes to LaTeX Perfectionist are documented here.
 
+## [v26.2.1] — 2026-04-24
+
+v26.2.1 closes the fix-producer track deferred from v26.2.0. Every
+item in the v26.2.0 `Deferred to v26.2.1 / v26.3` fix-producer
+sub-list has shipped; the remaining deferrals are now exclusively
+v26.3 scope (see `specs/v26/V26_2_1_PLAN.md` §8).
+
+### Shipped (v26.2.1 plan)
+
+- **`Validators_common.result.fix : Cst_edit.t list option`** — new
+  field + `mk_result` / `mk_result_with_fix` constructors. Every of
+  the 673 existing record literals across 15 validator / test files
+  was migrated through the helpers via a one-shot OCaml-aware script
+  (`scripts/tools/migrate_result_literals.py`). New gate
+  `scripts/tools/check_result_helpers.py` (pre-release #15) forbids
+  raw 4-field `{ id; severity; message; count }` literals in
+  validator sources.
+- **Type deviation from v26.2.0 CHANGELOG:** the field is
+  `Cst_edit.t list option`, **not** `Cst_edit.t option`. TYPO-002/003
+  aggregate `count` per document and need one edit per match; a list
+  is required. Empty `Some` rejected by the helper.
+- **STRUCT-001 fix producer** — emits a single
+  `Cst_edit.insert ~at:0 "\documentclass{article}\n"` on missing
+  `\documentclass`.
+- **TYPO-002 / TYPO-003 fix producers** — one
+  `Cst_edit.replace (off..off+2) "–"` (resp. `…+3 "—"`) per
+  non-overlapping match offset found by the new
+  `find_all_non_overlapping` helper. Rule `count` retains its
+  overlap-count semantics via `count_substring` for back-compat; fix
+  list is strictly non-overlapping. On pathological input like
+  `----`, fix-count may be smaller than rule-count (documented).
+- **`--apply-fixes` CLI flag + `L0_APPLY_FIXES` env gate** — runs
+  validators, flattens `r.fix`, applies via `Cst_edit.apply_all`,
+  emits modified source to stdout. Overlapping fixes → stderr
+  `E.apply-fixes.overlap` + exit 2. Decision (per
+  `V26_2_PLAN.md` §3.2 B3): all-or-nothing only;
+  `--apply-fixes-for RULE-ID` stays v26.3 scope.
+- **`test_rule_fix_integration.ml`** (new) — E2E pipeline test for
+  STRUCT-001 / TYPO-002 / TYPO-003: fire → collect fixes → apply →
+  assert rule no longer fires. 4 cases.
+- **`docs/v26_2/FIX_STYLE_GUIDE.md`** refreshed to the v26.2.1 API
+  (list + helper exemplars).
+- **`docs/MIGRATION_v26.2_to_v26.2.1.md`** (new) — consumer-side
+  migration notes: helper usage, the deviation from the CHANGELOG
+  type, and the new `--apply-fixes` CLI mode.
+
+### Gate count
+
+- **16 pre-release gates** (was 14 at v26.2.0, +1 for PR #1's
+  `check_result_helpers`, +1 for the required
+  `test_rule_fix_integration` test wiring).
+- Test suites: `[typo-fix] PASS 6`, `[fix-integration] PASS 4`,
+  `[validators-struct] PASS 11`, `[cli] PASS 28`. All pre-existing
+  test files continue green.
+
+### Deferred to v26.3 (explicit)
+
+- Rolling fix producers for the remaining ~657 rules.
+- `--apply-fixes-for RULE-ID` granularity flag.
+- CST structure-lossless runtime gate (corpus-scoped).
+- `edf_scheduler.ml` per-class scheduling full rewrite.
+- Three Section-level Coq discharges: `CSTRoundTrip.Structure_lossless`
+  (2 hypotheses), `RewritePreservesCST.Rewrite_preserves` (1), and
+  `RewritePreservesSemantics.Semantic_preservation` (2). See
+  `proofs/ADMISSIBILITY_MAP.md` discharge-unit notes.
+- xelatex / lualatex `.aux` parser variants.
+- L3 AST migration (`docs/L3_ROADMAP.md`).
+
+### Semver
+
+Additive. `fix` defaults to `None`. Downstream consumers that
+constructed `Validators_common.result` record literals directly must
+migrate to `mk_result` / `mk_result_with_fix` (see
+`docs/MIGRATION_v26.2_to_v26.2.1.md`). The new CLI flag +
+env var are net-new; existing invocations are unaffected.
+
 ## [v26.2.0] — 2026-04-23
 
 v26.2 closes the memo §16.3 compile-guarantee stack and CST/rewrite

--- a/docs/MIGRATION_v26.2_to_v26.2.1.md
+++ b/docs/MIGRATION_v26.2_to_v26.2.1.md
@@ -1,0 +1,128 @@
+# Migrating from v26.2.0 to v26.2.1
+
+v26.2.1 is an additive patch release that closes the fix-producer
+track. The only consumer-visible change is the new
+`Validators_common.result.fix` field; downstream code that
+constructed `result` values directly as record literals must migrate
+to the new helpers. Everything else is backward-compatible.
+
+## What changed
+
+### `result` record gained a `fix` field
+
+```ocaml
+type result = {
+  id : string;
+  severity : severity;
+  message : string;
+  count : int;
+  fix : Cst_edit.t list option;   (* NEW in v26.2.1 *)
+}
+```
+
+Raw record literals `{ id = ...; severity = ...; message = ...;
+count = ... }` no longer typecheck — the compiler requires the new
+field. Two new constructors cover every case:
+
+```ocaml
+val mk_result :
+  id:string -> severity:severity -> message:string -> count:int -> result
+(** Sets [fix = None]. *)
+
+val mk_result_with_fix :
+  id:string -> severity:severity -> message:string -> count:int ->
+  fix:Cst_edit.t list -> result
+(** Sets [fix = Some fix]. Raises [Invalid_argument] on empty list
+    — use [mk_result] for the no-fix case. *)
+```
+
+### Type deviation from v26.2.0 CHANGELOG
+
+The v26.2.0 CHANGELOG announced the field as `Cst_edit.t option`
+(singular). The shipped type is `Cst_edit.t list option`. This was
+corrected in v26.2.1 because TYPO-002/003 aggregate `count` per
+document and need one edit per match — a single-edit shape could
+not represent that. No v26.2.0 release exposed the field, so the
+change is purely a plan/CHANGELOG correction.
+
+### New CLI mode: `--apply-fixes`
+
+```
+validators_cli --apply-fixes <file.tex>
+# or
+L0_APPLY_FIXES=1 validators_cli <file.tex>
+```
+
+Runs validators, flattens every `r.fix = Some edits`, applies the
+combined edit set via `Cst_edit.apply_all`, and emits the modified
+source to stdout. On overlapping fixes (not expected in practice;
+rule conflict resolution prevents most cases), emits
+`E.apply-fixes.overlap` to stderr and exits 2 without touching
+stdout.
+
+Decision per `specs/v26/V26_2_PLAN.md` §3.2 B3: all-or-nothing only.
+`--apply-fixes-for RULE-ID` remains v26.3 scope.
+
+### Rules that produce fixes
+
+v26.2.1 ships three exemplar producers. Every other rule continues
+to emit `fix = None` via `mk_result`.
+
+| Rule | Fix |
+|---|---|
+| STRUCT-001 | Insert `\documentclass{article}\n` at offset 0. |
+| TYPO-002 | For each non-overlapping `--`, replace with `–` (en-dash). |
+| TYPO-003 | For each non-overlapping `---`, replace with `—` (em-dash). |
+
+## Mechanical migration recipe
+
+If your code built `Validators_common.result` values as record
+literals:
+
+```diff
+-Some {
+-  id = "X-001";
+-  severity = Warning;
+-  message = "...";
+-  count = 1;
+-}
++Some
++  (Validators_common.mk_result
++     ~id:"X-001" ~severity:Warning ~message:"..." ~count:1)
+```
+
+Record **patterns** that destructured the result by field need a
+wildcard to absorb the new field:
+
+```diff
+-let { id; severity; message; count } = r in
++let { id; severity; message; count; _ } = r in
+```
+
+Emitting a fix:
+
+```ocaml
+let fix = [ Cst_edit.replace ~start_offset:s ~end_offset:e "…" ] in
+Validators_common.mk_result_with_fix
+  ~id:"X-042" ~severity:Warning ~message:"…" ~count:1 ~fix
+```
+
+The `scripts/tools/migrate_result_literals.py` one-shot script used
+by the repo for its own migration is available for reference; it
+handles OCaml strings, character literals, quoted strings
+(`{|...|}`), comments, and qualified field names.
+
+## New gate
+
+`scripts/tools/check_result_helpers.py` is wired into
+`pre_release_check.py` as gate #15. It rejects any raw four-field
+`result` record literal in `validators_*.ml` or test files. Use the
+helpers instead; if a new required field lands in a future release,
+only the helpers need updating.
+
+## Upstream references
+
+- `specs/v26/V26_2_1_PLAN.md` — PR slate + design decisions.
+- `docs/v26_2/FIX_STYLE_GUIDE.md` — author-facing style guide for
+  new fix producers (refreshed in v26.2.1).
+- `CHANGELOG.md` — `[v26.2.1]` entry with the five PR references.

--- a/latex-parse/src/dune
+++ b/latex-parse/src/dune
@@ -371,6 +371,11 @@
  (libraries latex_parse_lib test_helpers unix))
 
 (test
+ (name test_rule_fix_integration)
+ (modules test_rule_fix_integration)
+ (libraries latex_parse_lib test_helpers unix))
+
+(test
  (name test_validators_verb_cjk_cmd)
  (modules test_validators_verb_cjk_cmd)
  (libraries latex_parse_lib test_helpers unix))

--- a/latex-parse/src/test_rule_fix_integration.ml
+++ b/latex-parse/src/test_rule_fix_integration.ml
@@ -1,0 +1,79 @@
+(** E2E fix pipeline test (v26.2.1 PR #5).
+
+    For each exemplar rule (STRUCT-001, TYPO-002, TYPO-003), walk the pipeline:
+    source → `Validators.run_all` → collect fixes → `Cst_edit.apply_all` →
+    re-run validators and assert the same rule no longer fires on the output.
+
+    This is the semantic contract `--apply-fixes` promises: applying the fix set
+    removes the problem. *)
+
+open Test_helpers
+
+let apply_all s edits =
+  match Latex_parse_lib.Cst_edit.apply_all s edits with
+  | Ok out -> out
+  | Error _ -> failwith "overlapping fix edits"
+
+let pipeline rule_id src =
+  let edits = fix_edits rule_id src in
+  let out = apply_all src edits in
+  (edits, out)
+
+let () =
+  (* STRUCT-001: insert \documentclass at 0. After applying, the rule should not
+     re-fire. STRUCT-001 gating uses L0_VALIDATORS default (non-pilot), so no
+     env setup needed here. *)
+  run "E2E STRUCT-001: apply fix removes the problem" (fun tag ->
+      let src = "Body without a docclass line.\n" in
+      let edits, out = pipeline "STRUCT-001" src in
+      expect
+        (List.length edits = 1
+        && does_not_fire "STRUCT-001" out
+        && String.length out > String.length src)
+        (tag ^ ": fired once, applied, no longer fires"));
+
+  (* TYPO rules live in the pilot set. *)
+  Unix.putenv "L0_VALIDATORS" "pilot";
+
+  run "E2E TYPO-002: apply fix removes --" (fun tag ->
+      let src = "Alpha -- beta -- gamma.\n" in
+      let edits, out = pipeline "TYPO-002" src in
+      expect
+        (List.length edits = 2
+        && does_not_fire "TYPO-002" out
+        && out = "Alpha – beta – gamma.\n")
+        (tag ^ ": two edits applied, rule no longer fires"));
+
+  run "E2E TYPO-003: apply fix removes ---" (fun tag ->
+      let src = "Alpha --- beta --- gamma.\n" in
+      let edits, out = pipeline "TYPO-003" src in
+      expect
+        (List.length edits = 2
+        && does_not_fire "TYPO-003" out
+        && out = "Alpha — beta — gamma.\n")
+        (tag ^ ": two edits applied, rule no longer fires"));
+
+  (* Combined TYPO-002 + TYPO-002 elsewhere in the same source. The CLI's
+     `--apply-fixes` mode flattens multi-result fix lists. Here we verify that
+     [Cst_edit.apply_all] over the collected set yields a clean output where the
+     rule no longer fires.
+
+     Note: STRUCT-001 + TYPO-003 cannot fire simultaneously because STRUCT-001
+     is in `rules_basic` (L0_VALIDATORS unset) while TYPO-003 is in
+     `rules_pilot` (L0_VALIDATORS=pilot). The env gate is mutually exclusive by
+     design — see validators.ml:212. *)
+  run "E2E collect-all: TYPO-002 multi-match, one pass" (fun tag ->
+      let src = "Alpha -- beta. Gamma -- delta.\n" in
+      let results = Latex_parse_lib.Validators.run_all src in
+      let all_edits =
+        List.concat_map
+          (fun (r : Latex_parse_lib.Validators.result) ->
+            match r.fix with Some edits -> edits | None -> [])
+          results
+      in
+      let out = apply_all src all_edits in
+      expect
+        (does_not_fire "TYPO-002" out && out = "Alpha – beta. Gamma – delta.\n")
+        (tag ^ ": collected fixes apply, rule no longer fires"));
+
+  finalise "fix-integration"


### PR DESCRIPTION
## Summary

Final PR of the v26.2.1 fix-producer cycle. Stacks on PR #268.

- **`test_rule_fix_integration.ml`** (new, 4 cases) — E2E: source → validator → collect fixes → apply → re-validate.
- **`CHANGELOG.md`** — `[v26.2.1]` entry with the five PRs, the type deviation (`Cst_edit.t option` → `Cst_edit.t list option`), gate count (14 → 16), deferred v26.3 items.
- **`docs/MIGRATION_v26.2_to_v26.2.1.md`** (new) — consumer-facing migration guide.

## Known gate state

`check_release_integrity` FAILS in this intermediate state — documented behaviour per `v26_2_audit_lessons.md`. The release-bump PR (follow-up, `scripts/release.sh 26.2.1`) resolves it. All 15 other gates pass.

## Tests
- [x] `[fix-integration] PASS 4 cases` (new file)
- [x] `[typo-fix] PASS 6 cases`, `[validators-struct] PASS 11`, `[cli] PASS 28`
- [x] All pre-existing test suites green
- [x] `dune build` green

Depends on: #268
Refs: `specs/v26/V26_2_1_PLAN.md` §3 PR #5, §7 Release flow