### PR TITLE
fix(ci): tighten gates — required-checks +spec-drift, messages-validate strict

### DIFF
--- a/.github/required-status-checks.json
+++ b/.github/required-status-checks.json
@@ -7,6 +7,7 @@
     {"context": "rest-smoke",     "app_id": 15368},
     {"context": "perf-ci",        "app_id": 15368},
     {"context": "xxh-selfcheck",  "app_id": 15368},
-    {"context": "unit-tests",     "app_id": 15368}
+    {"context": "unit-tests",     "app_id": 15368},
+    {"context": "spec-drift",     "app_id": 15368}
   ]
 }

--- a/.github/workflows/messages-validate.yml
+++ b/.github/workflows/messages-validate.yml
@@ -17,6 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Validate messages (warn only)
-        run: |
-          bash scripts/validate_messages.sh || true
+      - name: Validate messages (strict)
+        env:
+          FAIL_ON_MISMATCH: "1"
+        run: bash scripts/validate_messages.sh


### PR DESCRIPTION
## Summary
Two CI hardening changes unblocked by PR #275 landing.

### 1. Add `spec-drift` to required-checks
- Updates `.github/required-status-checks.json` (the source of truth — `Configure Branch Protection` workflow re-applies this on every push, so a manual API PATCH would be reverted).
- After merge, all PRs targeting `main` must pass `spec-drift` (14 gate steps) before they can merge.
- Authorized by user post-#273.

### 2. Flip `messages-validate.yml` to strict
- Removes `|| true` and sets `FAIL_ON_MISMATCH=1`.
- With the `runtime_message` field on `main` (PR #275), catalogue↔runtime drift is now an actionable failure.
- Remedy when triggered: `python3 scripts/tools/sync_runtime_messages.py` regenerates the YAML.

## Local verification
- `FAIL_ON_MISMATCH=1 bash scripts/validate_messages.sh` → `618 rules checked, 0 mismatches`, exit 0
- Workflow YAML parses cleanly under `yaml.safe_load`
- 17/17 pre-release gates green on `main` post-PR #275

## Test plan
- [x] Strict messages-validate green locally
- [ ] CI: `messages-validate / messages` job green on this PR
- [ ] CI: `spec-drift` green on this PR