### PR TITLE
fix(gates): close 2 silent-failure scope bugs (validate_catalogue, check_severity_drift)

### DIFF
--- a/scripts/tools/check_severity_drift.py
+++ b/scripts/tools/check_severity_drift.py
@@ -31,26 +31,55 @@ CANONICAL_SEVERITY = {
 
 
 def extract_runtime_severity(src_dir: Path) -> dict[str, str]:
-    """For every `id = "RULE"` in a validator file, associate the
-    lexically-nearest `severity = ...` within the same record literal."""
+    """Map rule ID → declared runtime severity by scanning every
+    validators*.ml source.
+
+    Two emission patterns are accepted:
+      1. Legacy record literal:
+           { id = "RULE-NNN"; severity = Warning; ... }
+         (separation: id, then severity, both fields of the same record)
+      2. v26.2.1+ helper-call:
+           mk_result ~id:"RULE-NNN" ~severity:Warning ~message:...
+           mk_result_with_fix ~id:"RULE-NNN" ~severity:Warning ...
+         (severity comes via labelled argument)
+
+    First occurrence wins; later ones for the same ID are alternative
+    branches that should agree."""
     result: dict[str, str] = {}
-    # Pattern: `id = "RULE-NNN"; ... severity = Warning; ...`
-    # We match on record literals using a non-greedy scan.
-    # Approach: find each `id = "X"` occurrence, then search the
-    # surrounding ~200 chars for `severity = Y`.
-    record_pat = re.compile(
-        r'id\s*=\s*"([A-Z][A-Z0-9]{1,7}-[0-9]+)"\s*;[^{}]{0,400}?'
-        r'severity\s*=\s*(Error|Warning|Info)\b',
+    # Legacy: id = "X" followed (within ~400 non-brace chars, same record)
+    # by severity = Y.
+    legacy_pat = re.compile(
+        r'\bid\s*=\s*"([A-Z][A-Z0-9]{1,7}-[0-9]+)"[^{}]{0,400}?'
+        r'\bseverity\s*=\s*(Error|Warning|Info)\b',
+        re.DOTALL,
+    )
+    # Helper-call: ~id:"X" followed (within ~200 chars, may include other
+    # ~labels but stays inside the same call expression — bounded char
+    # scan suffices) by ~severity:Y, OR ~severity:Y appearing first.
+    helper_id_first_pat = re.compile(
+        r'~id\s*:\s*"([A-Z][A-Z0-9]{1,7}-[0-9]+)"[^()]{0,400}?'
+        r'~severity\s*:\s*(Error|Warning|Info)\b',
+        re.DOTALL,
+    )
+    helper_sev_first_pat = re.compile(
+        r'~severity\s*:\s*(Error|Warning|Info)\b[^()]{0,400}?'
+        r'~id\s*:\s*"([A-Z][A-Z0-9]{1,7}-[0-9]+)"',
         re.DOTALL,
     )
     for p in sorted(src_dir.glob("validators*.ml")):
         if "conflicted" in p.name:
             continue
         text = p.read_text(encoding="utf-8", errors="replace")
-        for m in record_pat.finditer(text):
+        for m in legacy_pat.finditer(text):
             rid, sev = m.group(1), m.group(2)
-            # First occurrence wins; later ones for the same ID are
-            # probably alternative branches with the same severity.
+            if rid not in result:
+                result[rid] = sev
+        for m in helper_id_first_pat.finditer(text):
+            rid, sev = m.group(1), m.group(2)
+            if rid not in result:
+                result[rid] = sev
+        for m in helper_sev_first_pat.finditer(text):
+            sev, rid = m.group(1), m.group(2)
             if rid not in result:
                 result[rid] = sev
     return result
@@ -82,6 +111,19 @@ def main() -> int:
         return 2
     runtime = extract_runtime_severity(repo / "latex-parse/src")
     spec = extract_spec_severity(rules_v3)
+
+    # Sanity: the repo ships 600+ runtime rules; finding 0 means the
+    # regex no longer matches the rule-emission syntax. Refuse to
+    # silent-pass in that case.
+    if len(spec) >= 100 and len(runtime) < 100:
+        print(
+            f"[severity-drift] FAIL: spec has {len(spec)} entries but "
+            f"only {len(runtime)} runtime severities matched. The "
+            f"runtime-extraction regex is likely out of sync with the "
+            f"current OCaml syntax — refusing to silent-pass.",
+            file=sys.stderr,
+        )
+        return 2
 
     drifts: list[str] = []
     for rid, (spec_sev, mat) in sorted(spec.items()):

--- a/scripts/validate_catalogue.py
+++ b/scripts/validate_catalogue.py
@@ -1,104 +1,112 @@
 #!/usr/bin/env python3
-import json
+"""Catalogue compliance gate.
+
+Verifies every rule emitted at runtime appears in the catalogue
+(`specs/rules/rules_v3.yaml`). Catches drift where a new validator
+ships without its corresponding spec entry, and where a spec entry
+is removed but the runtime still emits the id.
+
+Pre-v26.0 the rule definitions all lived in `latex-parse/src/validators.ml`.
+v26.0 split them across `validators_l0.ml`, `validators_l1.ml`, etc.; the
+top-level `validators.ml` is now a dispatcher with `include Validators_*`
+clauses, so a script that only reads `validators.ml` finds 0 rules and
+silently passes. Scan the full glob.
+
+v26.2.1 introduced the labelled-arg helper-call syntax
+(`mk_result ~id:"X"`, `mk_result_with_fix ~id:"X"`) alongside the
+legacy record-literal syntax (`{ id = "X"; ... }`); both forms count
+as runtime emissions.
+
+Sanity check: if runtime_rules has fewer than 100 entries, the script
+fails loudly. The repo ships 600+ rules; an empty/near-empty count
+means either the glob broke or the regex broke — either way the gate
+is not actually validating anything.
+"""
+
+from __future__ import annotations
 import re
 import sys
 from pathlib import Path
 
-RUNTIME = Path("latex-parse/src/validators.ml")
+SRC_DIR = Path("latex-parse/src")
 CATALOG = Path("specs/rules/rules_v3.yaml")
 PILOT = Path("specs/rules/pilot_v1.yaml")
 
-for path in (RUNTIME, CATALOG, PILOT):
-    if not path.is_file():
-        print(f"[catalog] ERROR: Missing required file: {path}", file=sys.stderr)
+# Conservative lower bound. Repo currently ships ~620 runtime rules;
+# anything well below that flags a scope/regex breakage rather than a
+# legitimate rules removal.
+MIN_RUNTIME_RULES = 100
+
+for path in (SRC_DIR, CATALOG, PILOT):
+    if not path.exists():
+        print(f"[catalog] ERROR: Missing required path: {path}", file=sys.stderr)
         sys.exit(2)
 
-runtime_rules: dict[str, dict[str, str]] = {}
-current_rule = None
+# Collect every runtime-emitted rule ID across the validators*.ml glob.
+# Two emission patterns are accepted:
+#   1. Legacy record literal:    { id = "FAMILY-NNN"; severity = ...; ... }
+#   2. v26.2.1+ helper call:     mk_result ~id:"FAMILY-NNN" ~severity:...
+#                                mk_result_with_fix ~id:"FAMILY-NNN" ...
+ID_PATTERNS = [
+    re.compile(r'\bid\s*=\s*"([A-Z][A-Z0-9]*-[0-9]+)"'),
+    re.compile(r'~id\s*:\s*"([A-Z][A-Z0-9]*-[0-9]+)"'),
+]
 
-for line in RUNTIME.read_text().splitlines():
-    m_rule = re.match(r"let\s+([A-Za-z0-9_]+)\s*:\s*rule\s*=\s*", line)
-    if m_rule:
-        current_rule = m_rule.group(1)
+runtime_ids: set[str] = set()
+files_scanned = 0
+for p in sorted(SRC_DIR.glob("validators*.ml")):
+    if "conflicted" in p.name:
         continue
-    if current_rule is not None:
-        m_id = re.search(r"id\s*=\s*\"([A-Z0-9-]+)\"", line)
-        m_sev = re.search(r"severity\s*=\s*(Error|Warning|Info)", line)
-        if m_id:
-            rid = m_id.group(1)
-        if m_sev and 'rid' in locals():
-            runtime_rules[rid] = {
-                'severity': m_sev.group(1).lower(),
-                'rule': current_rule,
-                'precondition': '',
-            }
-            del rid
-    if line.strip() == "":
-        current_rule = None
+    files_scanned += 1
+    text = p.read_text(encoding="utf-8", errors="replace")
+    for pat in ID_PATTERNS:
+        for m in pat.finditer(text):
+            runtime_ids.add(m.group(1))
 
-section_layers = {
-    'rules_basic': 'L0_Lexer',
-    'rules_pilot': 'L0_Lexer',
-    'rules_l1': 'L1_Expanded',
-}
+if files_scanned == 0:
+    print(
+        f"[catalog] ERROR: glob '{SRC_DIR}/validators*.ml' matched no "
+        f"files. Has the layout changed again?",
+        file=sys.stderr,
+    )
+    sys.exit(2)
 
-current_section = None
-for line in RUNTIME.read_text().splitlines():
-    stripped = line.strip()
-    m_sec = re.match(r"let\s+(rules_[A-Za-z0-9_]+)\s*:\s*rule list", stripped)
-    if m_sec:
-        current_section = m_sec.group(1)
-        continue
-    if current_section and stripped.startswith(']'):
-        current_section = None
-        continue
-    if current_section:
-        for name in re.findall(r"([A-Za-z0-9_]+)_rule", stripped):
-            rule_name = name + '_rule'
-            layer = section_layers.get(current_section, '')
-            for info in runtime_rules.values():
-                if info['rule'] == rule_name:
-                    info['precondition'] = layer
+if len(runtime_ids) < MIN_RUNTIME_RULES:
+    print(
+        f"[catalog] ERROR: only found {len(runtime_ids)} runtime rule "
+        f"IDs across {files_scanned} files (expected ≥ {MIN_RUNTIME_RULES}). "
+        f"Either the regex no longer matches the rule-definition syntax, "
+        f"or rules were mass-removed. Investigate before this gate is "
+        f"trusted again.",
+        file=sys.stderr,
+    )
+    sys.exit(2)
 
-catalog_ids = set()
+# Catalogue IDs from rules_v3.yaml.
+catalog_ids: set[str] = set()
 for line in CATALOG.read_text().splitlines():
-    m = re.match(r"^\s*- id: \"([^\"]+)\"", line)
+    m = re.match(r'^\s*- id: "([^"]+)"', line)
     if m:
         catalog_ids.add(m.group(1))
 
-pilot_data: dict[str, tuple[str, str]] = {}
-current_id = None
-current_pre = ''
-for line in PILOT.read_text().splitlines():
-    m_id = re.match(r"^\s*- id: \"([^\"]+)\"", line)
-    if m_id:
-        current_id = m_id.group(1)
-        current_pre = ''
-        continue
-    if current_id:
-        line_stripped = line.strip()
-        m_pre = re.match(r"precondition:\s*([A-Za-z_0-9]+)", line_stripped)
-        if m_pre:
-            current_pre = m_pre.group(1)
-            continue
-        m_sev = re.match(r"default_severity:\s*([A-Za-z]+)", line_stripped)
-        if m_sev:
-            pilot_data[current_id] = (m_sev.group(1).lower(), current_pre)
-            current_id = None
-            current_pre = ''
-
-fail = 0
-
-for rid, info in runtime_rules.items():
-    # PR #237 (memo §10, §15.4): check runtime rules across all layers, not
-    # just L0_Lexer. The prior early-return hid LAY-025/026/027 and other
-    # non-L0 divergences from CI.
-    if rid not in catalog_ids:
-        print(f"[catalog] FAIL: runtime rule not in catalog: {rid}", file=sys.stderr)
-        fail = 1
-
-if fail:
-    print("[catalog] FAIL: catalogue compliance checks failed", file=sys.stderr)
+orphans = sorted(runtime_ids - catalog_ids)
+if orphans:
+    for rid in orphans[:20]:
+        print(
+            f"[catalog] FAIL: runtime rule not in catalog: {rid}",
+            file=sys.stderr,
+        )
+    if len(orphans) > 20:
+        print(f"[catalog] FAIL: ... and {len(orphans) - 20} more", file=sys.stderr)
+    print(
+        f"[catalog] FAIL: {len(orphans)} runtime rule(s) missing from "
+        f"specs/rules/rules_v3.yaml",
+        file=sys.stderr,
+    )
     sys.exit(4)
 
-print("[catalog] PASS: catalogue compliance checks OK")
+print(
+    f"[catalog] PASS: catalogue compliance checks OK "
+    f"({len(runtime_ids)} runtime rules across {files_scanned} sources, "
+    f"all in catalogue of {len(catalog_ids)} entries)"
+)


### PR DESCRIPTION
## Summary
Two CI gate scripts have been silent-passing for months because their input regex no longer matches the post-v26.0 / post-v26.2.1 OCaml syntax. Both run inside `spec-drift` (now a required-check on `main`), so the holes were under a blanket of "trusted required gate." Discovered during audit.

## Bug 1 — `scripts/validate_catalogue.py`

`RUNTIME = Path("latex-parse/src/validators.ml")` — pre-v26.0 the rules all lived there; v26.0 split them across `validators_l0.ml` / `validators_l1.ml` / etc., turning `validators.ml` into a 1-line dispatcher with `include Validators_*` clauses. The regex `let X : rule = ...` finds 0 matches in the dispatcher; the orphan-check loop runs 0 times; the script prints `PASS`.

**Fix:**
- Switch to `latex-parse/src/validators*.ml` glob.
- Accept both legacy `id = "X"` and v26.2.1+ `~id:"X"` syntax.
- `MIN_RUNTIME_RULES = 100` sanity floor — refuse silent-pass if scope breaks again.
- PASS message now reports counts: `645 runtime rules across 15 sources, all in catalogue of 660 entries`.

## Bug 2 — `scripts/tools/check_severity_drift.py`

Regex matched only the legacy record literal `{ id = "X"; ... severity = Y; ... }`. v26.2.1 migrated to labelled-arg helper calls `mk_result ~id:"X" ~severity:Y ~message:...`; the new form never matches. Pre-fix output: `660 spec entries checked; 0 have runtime severity; all consistent` — reporting consistency over an empty intersection.

**Fix:**
- Add patterns for `~id:"X" ... ~severity:Y` (id-first and severity-first orders both occur).
- Sanity floor: spec ≥ 100 entries but runtime < 100 → FAIL with regex-out-of-sync diagnostic.
- Post-fix: 641 runtime severities matched (up from 0).

## Verification
- 17/17 pre-release gates PASS locally.
- Plant-tested both gates:
  - `validate_catalogue`: planted `FAKE-999` runtime emit → `FAIL: runtime rule not in catalog`.
  - `check_severity_drift`: planted `TYPO-022 spec=Info / runtime=Error` → `FAIL: TYPO-022: spec=Info runtime=Error`.
- `check_gates_meta` still passes (each fixed script keeps its PASS/FAIL marker + non-empty output).

## Why `check_gates_meta` didn't catch this
That meta-gate verifies (i) the script runs without traceback, (ii) the output is non-empty, (iii) the output contains a PASS/FAIL marker. None of those falsifies "silent pass on empty input." The two new sanity-floors close that hole inside the gates themselves.

## Test plan
- [x] 17/17 pre-release gates PASS
- [ ] CI: `spec-drift` workflow green
- [ ] CI: required-checks all green