### PR TITLE
fix(gates): input-count assertions on 4 more pre-release gates

### DIFF
--- a/scripts/tools/check_code_quality.py
+++ b/scripts/tools/check_code_quality.py
@@ -48,10 +48,12 @@ LOAD_BEARING_PROOFS = [
 
 def gate_defined_audit(repo: Path) -> list[str]:
     failures: list[str] = []
+    files_scanned = 0
     for rel in LOAD_BEARING_PROOFS:
         path = repo / rel
         if not path.is_file():
             continue
+        files_scanned += 1
         for i, line in enumerate(path.read_text().splitlines(), 1):
             if re.match(r"^\s*Defined\.\s*$", line):
                 context_start = max(0, i - 5)
@@ -65,6 +67,16 @@ def gate_defined_audit(repo: Path) -> list[str]:
                     f"[Qed.] to keep proof term opaque, or mark with "
                     f"`(* DEFINED-OK: <reason> *)`."
                 )
+    # Silent-failure guard: refuse to report PASS if most LOAD_BEARING
+    # files were missing (would mean the gate scanned almost nothing).
+    min_required = max(1, (len(LOAD_BEARING_PROOFS) * 8) // 10)
+    if files_scanned < min_required:
+        failures.append(
+            f"only {files_scanned} of {len(LOAD_BEARING_PROOFS)} "
+            f"LOAD_BEARING_PROOFS files were found — update the list "
+            f"in this script to match the current layout. Refusing "
+            f"to silent-pass."
+        )
     return failures
 
 
@@ -83,6 +95,7 @@ EXN_SWALLOW_CEILING = 0  # P1.10 baseline — enforce zero new.
 def gate_exception_swallow(repo: Path) -> list[str]:
     failures: list[str] = []
     src_dir = repo / "latex-parse/src"
+    files_scanned = 0
     for p in sorted(src_dir.glob("*.ml")):
         if (
             p.name.startswith("test_")
@@ -90,6 +103,7 @@ def gate_exception_swallow(repo: Path) -> list[str]:
             or p.name in {"fault_injection.ml"}
         ):
             continue
+        files_scanned += 1
         lines = p.read_text().splitlines()
         for i, line in enumerate(lines, 1):
             # EXN-OK marker may be on this line or within the prior
@@ -105,6 +119,14 @@ def gate_exception_swallow(repo: Path) -> list[str]:
                     f"explicit exception name or mark with "
                     f"`(* EXN-OK: <reason> *)`."
                 )
+    # Silent-failure guard: latex-parse/src has tens of .ml files at
+    # any maturity. Empty glob means the directory moved/renamed.
+    if files_scanned < 10:
+        failures.append(
+            f"only {files_scanned} non-test .ml files found under "
+            f"latex-parse/src — has the layout changed? Refusing to "
+            f"silent-pass."
+        )
     return failures
 
 
@@ -133,9 +155,11 @@ def gate_test_triviality(repo: Path) -> list[str]:
     failures: list[str] = []
     smoke_count = 0
     src_dir = repo / "latex-parse/src"
+    files_scanned = 0
     for p in sorted(src_dir.glob("test_*.ml")):
         if "conflicted" in p.name:
             continue
+        files_scanned += 1
         for i, line in enumerate(p.read_text().splitlines(), 1):
             for pat in TRIVIAL_EXPECT_PATTERNS[1:]:
                 # Skip the first pattern (`expect true`) — it's the
@@ -149,6 +173,14 @@ def gate_test_triviality(repo: Path) -> list[str]:
                     break
             if TRIVIAL_EXPECT_PATTERNS[0].search(line):
                 smoke_count += 1
+    # Silent-failure guard: the test_*.ml glob should match at least a
+    # handful of files. Zero means the layout changed.
+    if files_scanned < 5:
+        failures.append(
+            f"only {files_scanned} test_*.ml files found under "
+            f"latex-parse/src — has the layout changed? Refusing to "
+            f"silent-pass."
+        )
     if smoke_count > TRIVIAL_EXPECT_CEILING:
         failures.append(
             f"`expect true` smoke-test count {smoke_count} exceeds "

--- a/scripts/tools/check_doc_refs.py
+++ b/scripts/tools/check_doc_refs.py
@@ -175,6 +175,16 @@ def main() -> int:
             if any(pat in md.name or pat in str(md) for pat in EXCLUDED_PATTERNS):
                 continue
             doc_files.add(md)
+    # Silent-failure guard: docs/ + specs/ ship dozens of markdown
+    # files; empty doc_files means the roots moved or the rglob broke.
+    if len(doc_files) < 10:
+        print(
+            f"[doc-refs] FAIL: only {len(doc_files)} doc(s) discovered "
+            f"under {[str(r) for r in roots]} — has the layout changed? "
+            f"Refusing to silent-pass.",
+            file=sys.stderr,
+        )
+        return 2
     total_broken = 0
     for md in sorted(doc_files):
         broken = check_doc(md, repo)

--- a/scripts/tools/check_mli_doc_coverage.py
+++ b/scripts/tools/check_mli_doc_coverage.py
@@ -112,13 +112,25 @@ def main() -> int:
         return 2
     total_undoc = 0
     all_undoc: list[tuple[str, int, str]] = []
+    files_scanned = 0
     for mli in sorted(src_dir.glob("*.mli")):
         if mli.name.startswith("test_"):
             continue
+        files_scanned += 1
         undoc = check_file(mli)
         for line_no, name in undoc:
             total_undoc += 1
             all_undoc.append((mli.name, line_no, name))
+    # Silent-failure guard: latex-parse/src ships ~80 non-test .mli
+    # files. Empty/near-empty scan means the layout changed.
+    if files_scanned < 10:
+        print(
+            f"[mli-doc] FAIL: only {files_scanned} non-test .mli files "
+            f"under {src_dir} — has the layout changed? Refusing to "
+            f"silent-pass.",
+            file=sys.stderr,
+        )
+        return 2
     if total_undoc > ns.ceiling:
         for fname, line_no, name in all_undoc[:40]:
             print(
@@ -136,7 +148,8 @@ def main() -> int:
         )
         return 1
     print(
-        f"[mli-doc] PASS: {total_undoc} undocumented val(s) ≤ ceiling "
+        f"[mli-doc] PASS: {total_undoc} undocumented val(s) across "
+        f"{files_scanned} .mli files ≤ ceiling "
         f"{ns.ceiling}."
     )
     return 0

--- a/scripts/tools/check_proof_substance.py
+++ b/scripts/tools/check_proof_substance.py
@@ -191,10 +191,14 @@ def main() -> int:
     ns = ap.parse_args()
     repo = Path(ns.repo)
     any_flagged = False
+    files_scanned = 0
+    missing_files: list[str] = []
     for rel in LOAD_BEARING:
         path = repo / rel
         if not path.is_file():
+            missing_files.append(rel)
             continue
+        files_scanned += 1
         for line_no, body in check_file(path):
             any_flagged = True
             preview = body[:140].replace("\n", " ")
@@ -203,6 +207,21 @@ def main() -> int:
                 f"hypothesis-restatement pattern. Body: {preview!r}",
                 file=sys.stderr,
             )
+    # Silent-failure guard: if too many LOAD_BEARING files have moved
+    # or been renamed, the gate reports PASS without checking anything.
+    # Demand at least 80% of the declared files actually scanned.
+    min_required = max(1, (len(LOAD_BEARING) * 8) // 10)
+    if files_scanned < min_required:
+        print(
+            f"[proof-substance] FAIL: only {files_scanned} of "
+            f"{len(LOAD_BEARING)} declared load-bearing files were "
+            f"found. Missing: {missing_files[:5]}{'...' if len(missing_files) > 5 else ''}. "
+            f"Update LOAD_BEARING in this script to match the current "
+            f"layout, or restore the missing files. Refusing to "
+            f"silent-pass.",
+            file=sys.stderr,
+        )
+        return 2
     if any_flagged:
         print(
             "[proof-substance] Either add a substantive tactic "
@@ -213,8 +232,10 @@ def main() -> int:
             file=sys.stderr,
         )
         return 1
-    print("[proof-substance] PASS: no hypothesis-restatement patterns "
-          "found in load-bearing proof files.")
+    print(
+        f"[proof-substance] PASS: no hypothesis-restatement patterns "
+        f"found across {files_scanned} load-bearing proof files."
+    )
     return 0
 
 

--- a/scripts/tools/check_result_helpers.py
+++ b/scripts/tools/check_result_helpers.py
@@ -227,6 +227,17 @@ def main() -> int:
         | set(src.glob("test_edf_scheduler.ml"))
         | set(src.glob("test_evidence_scoring.ml"))
     )
+    # Silent-failure guard: the validators*.ml glob alone should match
+    # 10+ files at any maturity. Empty/near-empty target list means
+    # a layout change broke the gate.
+    if len(targets) < 5:
+        print(
+            f"[result-helpers] FAIL: only {len(targets)} target file(s) "
+            f"matched the glob set under latex-parse/src — has the "
+            f"layout changed? Refusing to silent-pass.",
+            file=sys.stderr,
+        )
+        return 2
     total_hits = 0
     for f in targets:
         hits = count_raw_literals(f)
@@ -245,7 +256,10 @@ def main() -> int:
             f"specs/v26/V26_2_1_PLAN.md §3 PR #1."
         )
         return 1
-    print("[result-helpers] PASS: no raw result record literals.")
+    print(
+        f"[result-helpers] PASS: no raw result record literals "
+        f"across {len(targets)} validator/test sources."
+    )
     return 0
 
 

--- a/scripts/tools/check_severity_drift.py
+++ b/scripts/tools/check_severity_drift.py
@@ -112,10 +112,21 @@ def main() -> int:
     runtime = extract_runtime_severity(repo / "latex-parse/src")
     spec = extract_spec_severity(rules_v3)
 
-    # Sanity: the repo ships 600+ runtime rules; finding 0 means the
-    # regex no longer matches the rule-emission syntax. Refuse to
-    # silent-pass in that case.
-    if len(spec) >= 100 and len(runtime) < 100:
+    # Sanity floor 1: rules_v3.yaml ships 600+ entries. An empty/near-
+    # empty spec means the YAML moved or got truncated — refuse to
+    # silent-pass.
+    if len(spec) < 100:
+        print(
+            f"[severity-drift] FAIL: spec has only {len(spec)} entries "
+            f"(expected ≥ 100). rules_v3.yaml likely moved or the "
+            f"parser broke. Refusing to silent-pass.",
+            file=sys.stderr,
+        )
+        return 2
+
+    # Sanity floor 2: the repo ships 600+ runtime rules; finding 0
+    # means the regex no longer matches the rule-emission syntax.
+    if len(runtime) < 100:
         print(
             f"[severity-drift] FAIL: spec has {len(spec)} entries but "
             f"only {len(runtime)} runtime severities matched. The "

--- a/scripts/tools/check_unused_hypotheses.py
+++ b/scripts/tools/check_unused_hypotheses.py
@@ -141,10 +141,14 @@ def main() -> int:
     ns = ap.parse_args()
     repo = Path(ns.repo)
     any_flagged = False
+    files_scanned = 0
+    missing_files: list[str] = []
     for rel in LOAD_BEARING:
         path = repo / rel
         if not path.is_file():
+            missing_files.append(rel)
             continue
+        files_scanned += 1
         for line_no, n, preview in check_file(path):
             any_flagged = True
             print(
@@ -156,6 +160,19 @@ def main() -> int:
                 f"be load-bearing. Body preview: {preview!r}",
                 file=sys.stderr,
             )
+    # Silent-failure guard: refuse to PASS if most LOAD_BEARING files
+    # are missing (would mean the gate scanned almost nothing).
+    min_required = max(1, (len(LOAD_BEARING) * 8) // 10)
+    if files_scanned < min_required:
+        print(
+            f"[unused-hyps] FAIL: only {files_scanned} of "
+            f"{len(LOAD_BEARING)} declared load-bearing files were "
+            f"found. Missing: {missing_files[:5]}{'...' if len(missing_files) > 5 else ''}. "
+            f"Update LOAD_BEARING in this script to match the current "
+            f"layout. Refusing to silent-pass.",
+            file=sys.stderr,
+        )
+        return 2
     if any_flagged:
         print(
             "[unused-hyps] Rename the unused hypotheses (make them "
@@ -166,8 +183,9 @@ def main() -> int:
         )
         return 1
     print(
-        f"[unused-hyps] PASS: no load-bearing proof discards ≥{THRESHOLD} "
-        "hypotheses without justification."
+        f"[unused-hyps] PASS: {files_scanned} load-bearing proofs "
+        f"scanned; none discards ≥{THRESHOLD} hypotheses without "
+        f"justification."
     )
     return 0
 


### PR DESCRIPTION
## Summary
Continuation of the silent-failure-gate hardening cycle from PR #277.

PR #277 fixed 2 gates (`validate_catalogue.py`, `check_severity_drift.py`) where empty input → silent PASS. Audit of the remaining pre-release gates found 4 more with the same shape:

| Gate | Iterates | Silent-pass risk |
|------|----------|------------------|
| `check_proof_substance.py` | `LOAD_BEARING` (15 .v files) | If most missing, scans 0 files → PASS |
| `check_unused_hypotheses.py` | Same `LOAD_BEARING` list | Same |
| `check_code_quality.py::gate_defined_audit` | `LOAD_BEARING_PROOFS` | Same |
| `check_code_quality.py::gate_exception_swallow` | `*.ml` glob in `latex-parse/src` | Empty glob → 0 iterations → PASS |
| `check_code_quality.py::gate_test_triviality` | `test_*.ml` glob | Empty glob → PASS |
| `check_result_helpers.py` | `validators*.ml` + test glob | Empty glob → PASS |

## Pattern
Each gate now has an input-count guard:

```python
if files_scanned < min_required:
    FAIL("only N of M files found — layout probably changed; refusing to silent-pass.")
```

Threshold is 80% of declared LOAD_BEARING, or hardcoded floors (10 / 5) for the globs. This tolerates individual file moves but catches wholesale layout drift.

PASS messages now report counts ("across 15 load-bearing proofs", "across 49 validator/test sources").

## Verification
- 17/17 pre-release gates PASS locally.
- Plant-tests (empty `--repo` dir) fire the new FAIL paths on all 4 gates.
- No behaviour change on a healthy checkout.

## Why this matters
With `spec-drift` now a required-check (PR #276) and `messages-validate` strict (also PR #276), the protective effect of these gates is at its highest. A gate that silent-passes is worse than no gate — it gives false confidence. This commit closes the silent-failure family.

## Test plan
- [x] 17/17 pre-release gates green locally
- [ ] CI: required-checks all green
- [ ] CI: `spec-drift` green