### PR TITLE
feat(v26.3.1): plan + 10 mechanical fix producers (PR #1 of cycle)

### DIFF
--- a/_CoqProject
+++ b/_CoqProject
@@ -78,3 +78,4 @@ proofs/SplitPreservesOrder.v
 -arg -w -arg -notation-overridden
 -arg -w -arg -redundant-canonical-projection
 proofs/CSTRoundtripConcrete.v
+proofs/RewritePreservesSemanticsConcrete.v

--- a/_CoqProject
+++ b/_CoqProject
@@ -77,3 +77,4 @@ proofs/SplitPreservesOrder.v
 # Options
 -arg -w -arg -notation-overridden
 -arg -w -arg -redundant-canonical-projection
+proofs/CSTRoundtripConcrete.v

--- a/latex-parse/src/test_typo_fix.ml
+++ b/latex-parse/src/test_typo_fix.ml
@@ -128,7 +128,6 @@ let () =
         (tag ^ ": NBSP-prefixed punctuation"));
 
   (* v26.3.1 batch — 10 new fix producers. *)
-
   run "TYPO-006 fix replaces tabs with 4 spaces" (fun tag ->
       let src = "a\tb\tc" in
       let edits = fix_edits "TYPO-006" src in
@@ -182,8 +181,7 @@ let () =
       let src = "alpha\n   \nbeta\n\t\ngamma" in
       let edits = fix_edits "SPC-002" src in
       expect
-        (List.length edits = 2
-        && apply_all src edits = "alpha\n\nbeta\n\ngamma")
+        (List.length edits = 2 && apply_all src edits = "alpha\n\nbeta\n\ngamma")
         (tag ^ ": both ws-only lines emptied"));
 
   run "SPC-003 fix replaces leading tabs in mixed indent" (fun tag ->

--- a/latex-parse/src/test_typo_fix.ml
+++ b/latex-parse/src/test_typo_fix.ml
@@ -127,4 +127,87 @@ let () =
         && out = "Bonjour\xc2\xa0; au revoir\xc2\xa0: merci\xc2\xa0!")
         (tag ^ ": NBSP-prefixed punctuation"));
 
+  (* v26.3.1 batch — 10 new fix producers. *)
+
+  run "TYPO-006 fix replaces tabs with 4 spaces" (fun tag ->
+      let src = "a\tb\tc" in
+      let edits = fix_edits "TYPO-006" src in
+      expect
+        (List.length edits = 2 && apply_all src edits = "a    b    c")
+        (tag ^ ": two tabs replaced"));
+
+  run "TYPO-007 fix strips trailing spaces" (fun tag ->
+      let src = "alpha   \nbeta\t \ngamma" in
+      let edits = fix_edits "TYPO-007" src in
+      expect
+        (List.length edits = 2 && apply_all src edits = "alpha\nbeta\ngamma")
+        (tag ^ ": trailing whitespace stripped on both lines"));
+
+  run "TYPO-008 fix collapses 4 newlines to 2" (fun tag ->
+      let src = "a\n\n\n\nb" in
+      let edits = fix_edits "TYPO-008" src in
+      expect
+        (List.length edits = 1 && apply_all src edits = "a\n\nb")
+        (tag ^ ": run collapsed"));
+
+  run "TYPO-009 fix strips ~ at line start" (fun tag ->
+      let src = "~alpha\n~beta" in
+      let edits = fix_edits "TYPO-009" src in
+      expect
+        (List.length edits = 2 && apply_all src edits = "alpha\nbeta")
+        (tag ^ ": both leading ~ deleted"));
+
+  run "TYPO-013 fix replaces single backtick with curly opening quote"
+    (fun tag ->
+      let src = "`hello' and `world'" in
+      let edits = fix_edits "TYPO-013" src in
+      expect
+        (List.length edits = 2
+        && apply_all src edits = "\xe2\x80\x98hello' and \xe2\x80\x98world'")
+        (tag ^ ": both backticks replaced"));
+
+  run "TYPO-013 leaves double `` alone" (fun tag ->
+      expect
+        (does_not_fire "TYPO-013" "``opener'' is fine")
+        (tag ^ ": no fire on TeX double-backtick"));
+
+  run "TYPO-015 fix collapses double escaped percent" (fun tag ->
+      let src = "stray \\%\\% inline" in
+      let edits = fix_edits "TYPO-015" src in
+      expect
+        (List.length edits = 1 && apply_all src edits = "stray \\% inline")
+        (tag ^ ": double escape collapsed"));
+
+  run "SPC-002 fix empties whitespace-only lines" (fun tag ->
+      let src = "alpha\n   \nbeta\n\t\ngamma" in
+      let edits = fix_edits "SPC-002" src in
+      expect
+        (List.length edits = 2
+        && apply_all src edits = "alpha\n\nbeta\n\ngamma")
+        (tag ^ ": both ws-only lines emptied"));
+
+  run "SPC-003 fix replaces leading tabs in mixed indent" (fun tag ->
+      let src = " \tcode\nclean\n\t code2" in
+      let edits = fix_edits "SPC-003" src in
+      let out = apply_all src edits in
+      expect
+        (List.length edits = 2 && out = "     code\nclean\n     code2")
+        (tag ^ ": both mixed-indent lines normalised"));
+
+  run "SPC-004 fix replaces bare CR with LF" (fun tag ->
+      let src = "alpha\rbeta\r\ngamma\rdelta" in
+      let edits = fix_edits "SPC-004" src in
+      expect
+        (List.length edits = 2
+        && apply_all src edits = "alpha\nbeta\r\ngamma\ndelta")
+        (tag ^ ": CRs not in CRLF replaced"));
+
+  run "SPC-005 fix strips trailing tabs" (fun tag ->
+      let src = "alpha\t\nbeta\nclean\t\t\ndone" in
+      let edits = fix_edits "SPC-005" src in
+      expect
+        (List.length edits = 2
+        && apply_all src edits = "alpha\nbeta\nclean\ndone")
+        (tag ^ ": both trailing-tab lines stripped"));
+
   finalise "typo-fix"

--- a/latex-parse/src/validators_l0.ml
+++ b/latex-parse/src/validators_l0.ml
@@ -1253,16 +1253,17 @@ let r_spc_002 : rule =
         if is_ws_only_substr lstart (lend - lstart) then (
           incr matched;
           edits :=
-            Cst_edit.replace ~start_offset:lstart ~end_offset:lend ""
-            :: !edits));
+            Cst_edit.replace ~start_offset:lstart ~end_offset:lend "" :: !edits));
     if !matched > 0 then
       let fix = List.rev !edits in
       if fix = [] then
-        Some (mk_result ~id:"SPC-002" ~severity:Info ~message:"Line containing only whitespace" ~count:!matched)
+        Some
+          (mk_result ~id:"SPC-002" ~severity:Info
+             ~message:"Line containing only whitespace" ~count:!matched)
       else
         Some
-          (mk_result_with_fix ~id:"SPC-002" ~severity:Info ~message:"Line containing only whitespace"
-             ~count:!matched ~fix)
+          (mk_result_with_fix ~id:"SPC-002" ~severity:Info
+             ~message:"Line containing only whitespace" ~count:!matched ~fix)
     else None
   in
   { id = "SPC-002"; run; languages = [] }
@@ -1275,10 +1276,8 @@ let r_spc_003 : rule =
       let i = ref lstart in
       let has_tab = ref false in
       let has_space = ref false in
-      while
-        !i < lend && (s.[!i] = ' ' || s.[!i] = '\t')
-      do
-        (if s.[!i] = '\t' then has_tab := true else has_space := true);
+      while !i < lend && (s.[!i] = ' ' || s.[!i] = '\t') do
+        if s.[!i] = '\t' then has_tab := true else has_space := true;
         incr i
       done;
       let mixed = !has_tab && !has_space && !i < lend in
@@ -1290,8 +1289,8 @@ let r_spc_003 : rule =
         let mixed, indent_end = analyse_line lstart lend in
         if mixed then (
           incr matched;
-          (* Replace tabs in the indent run with 4 spaces, preserving any
-             space characters already in the indent. *)
+          (* Replace tabs in the indent run with 4 spaces, preserving any space
+             characters already in the indent. *)
           let buf = Buffer.create (indent_end - lstart) in
           for j = lstart to indent_end - 1 do
             if s.[j] = '\t' then Buffer.add_string buf "    "
@@ -1305,10 +1304,13 @@ let r_spc_003 : rule =
       let fix = List.rev !edits in
       if fix = [] then
         Some
-          (mk_result ~id:"SPC-003" ~severity:Warning ~message:"Hard tab precedes non‑tab text (mixed indent)" ~count:!matched)
+          (mk_result ~id:"SPC-003" ~severity:Warning
+             ~message:"Hard tab precedes non‑tab text (mixed indent)"
+             ~count:!matched)
       else
         Some
-          (mk_result_with_fix ~id:"SPC-003" ~severity:Warning ~message:"Hard tab precedes non‑tab text (mixed indent)"
+          (mk_result_with_fix ~id:"SPC-003" ~severity:Warning
+             ~message:"Hard tab precedes non‑tab text (mixed indent)"
              ~count:!matched ~fix)
     else None
   in
@@ -1329,11 +1331,13 @@ let r_spc_004 : rule =
     if !cnt > 0 then
       let fix = List.rev !edits in
       if fix = [] then
-        Some (mk_result ~id:"SPC-004" ~severity:Warning ~message:"Carriage return U+000D without LF" ~count:!cnt)
+        Some
+          (mk_result ~id:"SPC-004" ~severity:Warning
+             ~message:"Carriage return U+000D without LF" ~count:!cnt)
       else
         Some
-          (mk_result_with_fix ~id:"SPC-004" ~severity:Warning ~message:"Carriage return U+000D without LF"
-             ~count:!cnt ~fix)
+          (mk_result_with_fix ~id:"SPC-004" ~severity:Warning
+             ~message:"Carriage return U+000D without LF" ~count:!cnt ~fix)
     else None
   in
   { id = "SPC-004"; run; languages = [] }
@@ -1357,11 +1361,13 @@ let r_spc_005 : rule =
     if !matched > 0 then
       let fix = List.rev !edits in
       if fix = [] then
-        Some (mk_result ~id:"SPC-005" ~severity:Info ~message:"Trailing tab at end of line" ~count:!matched)
+        Some
+          (mk_result ~id:"SPC-005" ~severity:Info
+             ~message:"Trailing tab at end of line" ~count:!matched)
       else
         Some
-          (mk_result_with_fix ~id:"SPC-005" ~severity:Info ~message:"Trailing tab at end of line"
-             ~count:!matched ~fix)
+          (mk_result_with_fix ~id:"SPC-005" ~severity:Info
+             ~message:"Trailing tab at end of line" ~count:!matched ~fix)
     else None
   in
   { id = "SPC-005"; run; languages = [] }

--- a/latex-parse/src/validators_l0.ml
+++ b/latex-parse/src/validators_l0.ml
@@ -1219,25 +1219,50 @@ let r_spc_001 : rule =
   in
   { id = "SPC-001"; run; languages = [] }
 
+(* Walk source line by line, emitting (line_start, line_end_excl_newline)
+   offsets for each line. The trailing line without a newline counts. *)
+let iter_line_spans (s : string) (f : int -> int -> unit) : unit =
+  let n = String.length s in
+  let line_start = ref 0 in
+  let i = ref 0 in
+  while !i < n do
+    if s.[!i] = '\n' then (
+      f !line_start !i;
+      line_start := !i + 1;
+      incr i)
+    else incr i
+  done;
+  if !line_start < n then f !line_start n
+
 (* SPC-002: Line containing only whitespace *)
 let r_spc_002 : rule =
   let run s =
-    let is_ws_only line =
-      let len = String.length line in
+    let is_ws_only_substr ofs len =
       len > 0
       &&
       let ok = ref true in
-      for i = 0 to len - 1 do
-        let c = line.[i] in
+      for j = 0 to len - 1 do
+        let c = s.[ofs + j] in
         if c <> ' ' && c <> '\t' && c <> '\r' then ok := false
       done;
       !ok
     in
-    let _, matched = any_line_pred s is_ws_only in
-    if matched > 0 then
-      Some
-        (mk_result ~id:"SPC-002" ~severity:Info
-           ~message:"Line containing only whitespace" ~count:matched)
+    let matched = ref 0 in
+    let edits = ref [] in
+    iter_line_spans s (fun lstart lend ->
+        if is_ws_only_substr lstart (lend - lstart) then (
+          incr matched;
+          edits :=
+            Cst_edit.replace ~start_offset:lstart ~end_offset:lend ""
+            :: !edits));
+    if !matched > 0 then
+      let fix = List.rev !edits in
+      if fix = [] then
+        Some (mk_result ~id:"SPC-002" ~severity:Info ~message:"Line containing only whitespace" ~count:!matched)
+      else
+        Some
+          (mk_result_with_fix ~id:"SPC-002" ~severity:Info ~message:"Line containing only whitespace"
+             ~count:!matched ~fix)
     else None
   in
   { id = "SPC-002"; run; languages = [] }
@@ -1245,23 +1270,46 @@ let r_spc_002 : rule =
 (* SPC-003: Hard tab precedes non-tab text (mixed indent) *)
 let r_spc_003 : rule =
   let run s =
-    let is_mixed_indent line =
-      let len = String.length line in
-      let i = ref 0 in
+    (* Compute mixed-indent state and the indent length (chars to replace). *)
+    let analyse_line lstart lend =
+      let i = ref lstart in
       let has_tab = ref false in
       let has_space = ref false in
-      while !i < len && (line.[!i] = ' ' || line.[!i] = '\t') do
-        if line.[!i] = '\t' then has_tab := true else has_space := true;
+      while
+        !i < lend && (s.[!i] = ' ' || s.[!i] = '\t')
+      do
+        (if s.[!i] = '\t' then has_tab := true else has_space := true);
         incr i
       done;
-      !has_tab && !has_space && !i < len
+      let mixed = !has_tab && !has_space && !i < lend in
+      (mixed, !i)
     in
-    let _, matched = any_line_pred s is_mixed_indent in
-    if matched > 0 then
-      Some
-        (mk_result ~id:"SPC-003" ~severity:Warning
-           ~message:"Hard tab precedes non‑tab text (mixed indent)"
-           ~count:matched)
+    let matched = ref 0 in
+    let edits = ref [] in
+    iter_line_spans s (fun lstart lend ->
+        let mixed, indent_end = analyse_line lstart lend in
+        if mixed then (
+          incr matched;
+          (* Replace tabs in the indent run with 4 spaces, preserving any
+             space characters already in the indent. *)
+          let buf = Buffer.create (indent_end - lstart) in
+          for j = lstart to indent_end - 1 do
+            if s.[j] = '\t' then Buffer.add_string buf "    "
+            else Buffer.add_char buf s.[j]
+          done;
+          edits :=
+            Cst_edit.replace ~start_offset:lstart ~end_offset:indent_end
+              (Buffer.contents buf)
+            :: !edits));
+    if !matched > 0 then
+      let fix = List.rev !edits in
+      if fix = [] then
+        Some
+          (mk_result ~id:"SPC-003" ~severity:Warning ~message:"Hard tab precedes non‑tab text (mixed indent)" ~count:!matched)
+      else
+        Some
+          (mk_result_with_fix ~id:"SPC-003" ~severity:Warning ~message:"Hard tab precedes non‑tab text (mixed indent)"
+             ~count:!matched ~fix)
     else None
   in
   { id = "SPC-003"; run; languages = [] }
@@ -1271,14 +1319,21 @@ let r_spc_004 : rule =
   let run s =
     let n = String.length s in
     let cnt = ref 0 in
+    let edits = ref [] in
     for i = 0 to n - 1 do
-      if s.[i] = '\r' then
-        if i + 1 < n && s.[i + 1] = '\n' then () else incr cnt
+      if s.[i] = '\r' && not (i + 1 < n && s.[i + 1] = '\n') then (
+        incr cnt;
+        edits :=
+          Cst_edit.replace ~start_offset:i ~end_offset:(i + 1) "\n" :: !edits)
     done;
     if !cnt > 0 then
-      Some
-        (mk_result ~id:"SPC-004" ~severity:Warning
-           ~message:"Carriage return U+000D without LF" ~count:!cnt)
+      let fix = List.rev !edits in
+      if fix = [] then
+        Some (mk_result ~id:"SPC-004" ~severity:Warning ~message:"Carriage return U+000D without LF" ~count:!cnt)
+      else
+        Some
+          (mk_result_with_fix ~id:"SPC-004" ~severity:Warning ~message:"Carriage return U+000D without LF"
+             ~count:!cnt ~fix)
     else None
   in
   { id = "SPC-004"; run; languages = [] }
@@ -1286,15 +1341,27 @@ let r_spc_004 : rule =
 (* SPC-005: Trailing tab at end of line *)
 let r_spc_005 : rule =
   let run s =
-    let ends_with_tab line =
-      let len = String.length line in
-      len > 0 && line.[len - 1] = '\t'
-    in
-    let _, matched = any_line_pred s ends_with_tab in
-    if matched > 0 then
-      Some
-        (mk_result ~id:"SPC-005" ~severity:Info
-           ~message:"Trailing tab at end of line" ~count:matched)
+    let matched = ref 0 in
+    let edits = ref [] in
+    iter_line_spans s (fun lstart lend ->
+        if lend > lstart && s.[lend - 1] = '\t' then (
+          incr matched;
+          (* Strip the trailing tab run (tabs at end of line). *)
+          let trim_start = ref lend in
+          while !trim_start > lstart && s.[!trim_start - 1] = '\t' do
+            decr trim_start
+          done;
+          edits :=
+            Cst_edit.replace ~start_offset:!trim_start ~end_offset:lend ""
+            :: !edits));
+    if !matched > 0 then
+      let fix = List.rev !edits in
+      if fix = [] then
+        Some (mk_result ~id:"SPC-005" ~severity:Info ~message:"Trailing tab at end of line" ~count:!matched)
+      else
+        Some
+          (mk_result_with_fix ~id:"SPC-005" ~severity:Info ~message:"Trailing tab at end of line"
+             ~count:!matched ~fix)
     else None
   in
   { id = "SPC-005"; run; languages = [] }

--- a/latex-parse/src/validators_l0_typo.ml
+++ b/latex-parse/src/validators_l0_typo.ml
@@ -190,9 +190,19 @@ let r_typo_006 : rule =
   let run s =
     let cnt = count_char s '\t' in
     if cnt > 0 then
-      Some
-        (mk_result ~id:"TYPO-006" ~severity:Error
-           ~message:"Tab character U+0009 forbidden" ~count:cnt)
+      let n = String.length s in
+      let edits = ref [] in
+      for i = n - 1 downto 0 do
+        if s.[i] = '\t' then
+          edits := Cst_edit.replace ~start_offset:i ~end_offset:(i + 1) "    " :: !edits
+      done;
+      let fix = !edits in
+      if fix = [] then
+        Some (mk_result ~id:"TYPO-006" ~severity:Error ~message:"Tab character U+0009 forbidden" ~count:cnt)
+      else
+        Some
+          (mk_result_with_fix ~id:"TYPO-006" ~severity:Error ~message:"Tab character U+0009 forbidden" ~count:cnt
+             ~fix)
     else None
   in
   { id = "TYPO-006"; run; languages = [] }
@@ -230,19 +240,94 @@ let r_typo_007 : rule =
               last = ' ' || last = '\t')
         in
         if matched > 0 then
-          Some
-            (mk_result ~id:"TYPO-007" ~severity:Info
-               ~message:"Trailing spaces at end of line" ~count:matched)
+          (* Build fix edits: for each line ending in trailing whitespace, emit
+             a single delete spanning the whitespace run before the line break.
+             Walk the source linearly; trailing-WS at file end (no newline) is
+             handled by the final segment. *)
+          let n = String.length s in
+          let edits = ref [] in
+          let line_start = ref 0 in
+          let i = ref 0 in
+          while !i < n do
+            if s.[!i] = '\n' then (
+              let line_end = !i in
+              let trim_start = ref line_end in
+              while
+                !trim_start > !line_start
+                && (let c = s.[!trim_start - 1] in
+                    c = ' ' || c = '\t' || c = '\r')
+              do
+                decr trim_start
+              done;
+              if !trim_start < line_end then
+                edits :=
+                  Cst_edit.replace ~start_offset:!trim_start
+                    ~end_offset:line_end ""
+                  :: !edits;
+              line_start := !i + 1;
+              incr i)
+            else incr i
+          done;
+          (* Final line without trailing newline. *)
+          let trim_start = ref n in
+          while
+            !trim_start > !line_start
+            && (let c = s.[!trim_start - 1] in
+                c = ' ' || c = '\t' || c = '\r')
+          do
+            decr trim_start
+          done;
+          if !trim_start < n then
+            edits :=
+              Cst_edit.replace ~start_offset:!trim_start ~end_offset:n ""
+              :: !edits;
+          let fix = List.rev !edits in
+          if fix = [] then
+            Some
+              (mk_result ~id:"TYPO-007" ~severity:Info
+                 ~message:"Trailing spaces at end of line" ~count:matched)
+          else
+            Some
+              (mk_result_with_fix ~id:"TYPO-007" ~severity:Info
+                 ~message:"Trailing spaces at end of line" ~count:matched ~fix)
         else None
   in
   { id = "TYPO-007"; run; languages = [] }
 
 let r_typo_008 : rule =
+  (* Collapse runs of 3+ consecutive '\n' down to 2 by deleting the surplus. *)
+  let mk_fix_edits s =
+    let n = String.length s in
+    let edits = ref [] in
+    let i = ref 0 in
+    while !i < n do
+      if s.[!i] = '\n' then (
+        let run_start = !i in
+        while !i < n && s.[!i] = '\n' do
+          incr i
+        done;
+        let run_len = !i - run_start in
+        if run_len >= 3 then
+          edits :=
+            Cst_edit.replace ~start_offset:(run_start + 2)
+              ~end_offset:(run_start + run_len) ""
+            :: !edits)
+      else incr i
+    done;
+    List.rev !edits
+  in
+  let emit cnt fix =
+    if fix = [] then
+      Some (mk_result ~id:"TYPO-008" ~severity:Info ~message:"Multiple consecutive blank lines (> 2) in source" ~count:cnt)
+    else
+      Some
+        (mk_result_with_fix ~id:"TYPO-008" ~severity:Info ~message:"Multiple consecutive blank lines (> 2) in source" ~count:cnt
+           ~fix)
+  in
   let run s =
     match Sys.getenv_opt "L0_TOKEN_AWARE" with
     | Some ("1" | "true" | "on") ->
         let cnt =
-          (* Count sequences of 3 consecutive newlines *)
           let n = String.length s in
           let rec loop i acc =
             if i + 2 >= n then acc
@@ -255,34 +340,38 @@ let r_typo_008 : rule =
           in
           loop 0 0
         in
-        if cnt > 0 then
-          Some
-            (mk_result ~id:"TYPO-008" ~severity:Info
-               ~message:"Multiple consecutive blank lines (> 2) in source"
-               ~count:cnt)
-        else None
+        if cnt > 0 then emit cnt (mk_fix_edits s) else None
     | _ ->
         let cnt = count_substring s "\n\n\n" in
-        if cnt > 0 then
-          Some
-            (mk_result ~id:"TYPO-008" ~severity:Info
-               ~message:"Multiple consecutive blank lines (> 2) in source"
-               ~count:cnt)
-        else None
+        if cnt > 0 then emit cnt (mk_fix_edits s) else None
   in
   { id = "TYPO-008"; run; languages = [] }
 
 let r_typo_009 : rule =
   let run s =
-    let starts =
-      if String.length s > 0 && String.unsafe_get s 0 = '~' then 1 else 0
-    in
+    let n = String.length s in
+    let starts = if n > 0 && String.unsafe_get s 0 = '~' then 1 else 0 in
     let cnt = starts + count_substring s "\n~" in
     if cnt > 0 then
-      Some
-        (mk_result ~id:"TYPO-009" ~severity:Warning
-           ~message:"Non‑breaking space ~ used incorrectly at line start"
-           ~count:cnt)
+      let edits = ref [] in
+      if starts = 1 then
+        edits := Cst_edit.replace ~start_offset:0 ~end_offset:1 "" :: !edits;
+      let i = ref 0 in
+      while !i < n - 1 do
+        if String.unsafe_get s !i = '\n' && String.unsafe_get s (!i + 1) = '~'
+        then
+          edits :=
+            Cst_edit.replace ~start_offset:(!i + 1) ~end_offset:(!i + 2) ""
+            :: !edits;
+        incr i
+      done;
+      let fix = List.rev !edits in
+      if fix = [] then
+        Some (mk_result ~id:"TYPO-009" ~severity:Warning ~message:"Non‑breaking space ~ used incorrectly at line start" ~count:cnt)
+      else
+        Some
+          (mk_result_with_fix ~id:"TYPO-009" ~severity:Warning ~message:"Non‑breaking space ~ used incorrectly at line start"
+             ~count:cnt ~fix)
     else None
   in
   { id = "TYPO-009"; run; languages = [] }
@@ -377,18 +466,27 @@ let r_typo_013 : rule =
   let run s =
     let n = String.length s in
     let cnt = ref 0 in
+    let edits = ref [] in
     for i = 0 to n - 1 do
       if s.[i] = '`' then
         (* Only flag single backtick, not `` (TeX opening quote) *)
         let is_double =
           (i + 1 < n && s.[i + 1] = '`') || (i > 0 && s.[i - 1] = '`')
         in
-        if not is_double then incr cnt
+        if not is_double then (
+          incr cnt;
+          edits :=
+            Cst_edit.replace ~start_offset:i ~end_offset:(i + 1) "\xe2\x80\x98"
+            :: !edits)
     done;
     if !cnt > 0 then
-      Some
-        (mk_result ~id:"TYPO-013" ~severity:Warning
-           ~message:{|ASCII back‑tick ` used as opening quote|} ~count:!cnt)
+      let fix = List.rev !edits in
+      if fix = [] then
+        Some (mk_result ~id:"TYPO-013" ~severity:Warning ~message:"ASCII back‑tick ` used as opening quote" ~count:!cnt)
+      else
+        Some
+          (mk_result_with_fix ~id:"TYPO-013" ~severity:Warning ~message:"ASCII back‑tick ` used as opening quote"
+             ~count:!cnt ~fix)
     else None
   in
   { id = "TYPO-013"; run; languages = [] }
@@ -410,9 +508,13 @@ let r_typo_015 : rule =
   let run s =
     let cnt = count_substring s "\\%\\%" in
     if cnt > 0 then
-      Some
-        (mk_result ~id:"TYPO-015" ~severity:Warning
-           ~message:{|Double \% in source; likely stray percent|} ~count:cnt)
+      let fix = mk_replace_edits s "\\%\\%" "\\%" in
+      if fix = [] then
+        Some (mk_result ~id:"TYPO-015" ~severity:Warning ~message:{|Double \% in source; likely stray percent|} ~count:cnt)
+      else
+        Some
+          (mk_result_with_fix ~id:"TYPO-015" ~severity:Warning ~message:{|Double \% in source; likely stray percent|}
+             ~count:cnt ~fix)
     else None
   in
   { id = "TYPO-015"; run; languages = [] }

--- a/latex-parse/src/validators_l0_typo.ml
+++ b/latex-parse/src/validators_l0_typo.ml
@@ -189,20 +189,24 @@ let r_typo_005 : rule =
 let r_typo_006 : rule =
   let run s =
     let cnt = count_char s '\t' in
-    if cnt > 0 then
+    if cnt > 0 then (
       let n = String.length s in
       let edits = ref [] in
       for i = n - 1 downto 0 do
         if s.[i] = '\t' then
-          edits := Cst_edit.replace ~start_offset:i ~end_offset:(i + 1) "    " :: !edits
+          edits :=
+            Cst_edit.replace ~start_offset:i ~end_offset:(i + 1) "    "
+            :: !edits
       done;
       let fix = !edits in
       if fix = [] then
-        Some (mk_result ~id:"TYPO-006" ~severity:Error ~message:"Tab character U+0009 forbidden" ~count:cnt)
+        Some
+          (mk_result ~id:"TYPO-006" ~severity:Error
+             ~message:"Tab character U+0009 forbidden" ~count:cnt)
       else
         Some
-          (mk_result_with_fix ~id:"TYPO-006" ~severity:Error ~message:"Tab character U+0009 forbidden" ~count:cnt
-             ~fix)
+          (mk_result_with_fix ~id:"TYPO-006" ~severity:Error
+             ~message:"Tab character U+0009 forbidden" ~count:cnt ~fix))
     else None
   in
   { id = "TYPO-006"; run; languages = [] }
@@ -239,7 +243,7 @@ let r_typo_007 : rule =
               let last = String.unsafe_get line (len - 1) in
               last = ' ' || last = '\t')
         in
-        if matched > 0 then
+        if matched > 0 then (
           (* Build fix edits: for each line ending in trailing whitespace, emit
              a single delete spanning the whitespace run before the line break.
              Walk the source linearly; trailing-WS at file end (no newline) is
@@ -254,8 +258,9 @@ let r_typo_007 : rule =
               let trim_start = ref line_end in
               while
                 !trim_start > !line_start
-                && (let c = s.[!trim_start - 1] in
-                    c = ' ' || c = '\t' || c = '\r')
+                &&
+                let c = s.[!trim_start - 1] in
+                c = ' ' || c = '\t' || c = '\r'
               do
                 decr trim_start
               done;
@@ -272,8 +277,9 @@ let r_typo_007 : rule =
           let trim_start = ref n in
           while
             !trim_start > !line_start
-            && (let c = s.[!trim_start - 1] in
-                c = ' ' || c = '\t' || c = '\r')
+            &&
+            let c = s.[!trim_start - 1] in
+            c = ' ' || c = '\t' || c = '\r'
           do
             decr trim_start
           done;
@@ -289,7 +295,7 @@ let r_typo_007 : rule =
           else
             Some
               (mk_result_with_fix ~id:"TYPO-007" ~severity:Info
-                 ~message:"Trailing spaces at end of line" ~count:matched ~fix)
+                 ~message:"Trailing spaces at end of line" ~count:matched ~fix))
         else None
   in
   { id = "TYPO-007"; run; languages = [] }
@@ -318,11 +324,15 @@ let r_typo_008 : rule =
   in
   let emit cnt fix =
     if fix = [] then
-      Some (mk_result ~id:"TYPO-008" ~severity:Info ~message:"Multiple consecutive blank lines (> 2) in source" ~count:cnt)
+      Some
+        (mk_result ~id:"TYPO-008" ~severity:Info
+           ~message:"Multiple consecutive blank lines (> 2) in source"
+           ~count:cnt)
     else
       Some
-        (mk_result_with_fix ~id:"TYPO-008" ~severity:Info ~message:"Multiple consecutive blank lines (> 2) in source" ~count:cnt
-           ~fix)
+        (mk_result_with_fix ~id:"TYPO-008" ~severity:Info
+           ~message:"Multiple consecutive blank lines (> 2) in source"
+           ~count:cnt ~fix)
   in
   let run s =
     match Sys.getenv_opt "L0_TOKEN_AWARE" with
@@ -352,7 +362,7 @@ let r_typo_009 : rule =
     let n = String.length s in
     let starts = if n > 0 && String.unsafe_get s 0 = '~' then 1 else 0 in
     let cnt = starts + count_substring s "\n~" in
-    if cnt > 0 then
+    if cnt > 0 then (
       let edits = ref [] in
       if starts = 1 then
         edits := Cst_edit.replace ~start_offset:0 ~end_offset:1 "" :: !edits;
@@ -367,11 +377,15 @@ let r_typo_009 : rule =
       done;
       let fix = List.rev !edits in
       if fix = [] then
-        Some (mk_result ~id:"TYPO-009" ~severity:Warning ~message:"Non‑breaking space ~ used incorrectly at line start" ~count:cnt)
+        Some
+          (mk_result ~id:"TYPO-009" ~severity:Warning
+             ~message:"Non‑breaking space ~ used incorrectly at line start"
+             ~count:cnt)
       else
         Some
-          (mk_result_with_fix ~id:"TYPO-009" ~severity:Warning ~message:"Non‑breaking space ~ used incorrectly at line start"
-             ~count:cnt ~fix)
+          (mk_result_with_fix ~id:"TYPO-009" ~severity:Warning
+             ~message:"Non‑breaking space ~ used incorrectly at line start"
+             ~count:cnt ~fix))
     else None
   in
   { id = "TYPO-009"; run; languages = [] }
@@ -482,11 +496,13 @@ let r_typo_013 : rule =
     if !cnt > 0 then
       let fix = List.rev !edits in
       if fix = [] then
-        Some (mk_result ~id:"TYPO-013" ~severity:Warning ~message:"ASCII back‑tick ` used as opening quote" ~count:!cnt)
+        Some
+          (mk_result ~id:"TYPO-013" ~severity:Warning
+             ~message:"ASCII back‑tick ` used as opening quote" ~count:!cnt)
       else
         Some
-          (mk_result_with_fix ~id:"TYPO-013" ~severity:Warning ~message:"ASCII back‑tick ` used as opening quote"
-             ~count:!cnt ~fix)
+          (mk_result_with_fix ~id:"TYPO-013" ~severity:Warning
+             ~message:"ASCII back‑tick ` used as opening quote" ~count:!cnt ~fix)
     else None
   in
   { id = "TYPO-013"; run; languages = [] }
@@ -510,11 +526,14 @@ let r_typo_015 : rule =
     if cnt > 0 then
       let fix = mk_replace_edits s "\\%\\%" "\\%" in
       if fix = [] then
-        Some (mk_result ~id:"TYPO-015" ~severity:Warning ~message:{|Double \% in source; likely stray percent|} ~count:cnt)
+        Some
+          (mk_result ~id:"TYPO-015" ~severity:Warning
+             ~message:{|Double \% in source; likely stray percent|} ~count:cnt)
       else
         Some
-          (mk_result_with_fix ~id:"TYPO-015" ~severity:Warning ~message:{|Double \% in source; likely stray percent|}
-             ~count:cnt ~fix)
+          (mk_result_with_fix ~id:"TYPO-015" ~severity:Warning
+             ~message:{|Double \% in source; likely stray percent|} ~count:cnt
+             ~fix)
     else None
   in
   { id = "TYPO-015"; run; languages = [] }

--- a/proofs/ADMISSIBILITY_MAP.md
+++ b/proofs/ADMISSIBILITY_MAP.md
@@ -147,13 +147,16 @@ its premise.
   `builder : bytes -> list cst_abs` — opaque carriers + the abstract
   builder; v26.3 instantiates.
 
-> **Discharge unit note.** This Section has **two** hypotheses
-> (`builder_partitions` + `parse_serialize_is_id_on_subset`). In Coq you
-> cannot partially close a Section — to produce useful instantiated
-> theorems for v26.3+, BOTH hypotheses must be discharged together
-> against the same concrete carriers. Discharging only one yields a
-> strictly weaker "parametric in the other" theorem and doesn't unblock
-> runtime claims. Sized accordingly: this is a single discharge unit.
+> **DISCHARGED in v26.3.1** (PR #2 of the v26.3.1 cycle). The companion file
+> `proofs/CSTRoundtripConcrete.v` provides two concrete instantiations
+> (`Trivial_subset` and `Linewise_subset`). The latter is non-trivial:
+> a concrete byte-stream builder that splits at every line-feed
+> boundary and a concrete `parse := split_at_lf` projection. Both
+> hypotheses (`builder_partitions` and `parse_serialize_is_id_on_subset`)
+> close against this instantiation, so the file's two top-level
+> theorems (`cst_byte_lossless_concrete`, `cst_structure_lossless_concrete`)
+> are unconditional. The `in_subset` predicate becomes `no_nul_byte`,
+> matching the OCaml runtime's `String.t` invariant.
 
 **Hypotheses:**
 1. `builder_partitions` — every source has a byte-lossless

--- a/proofs/ADMISSIBILITY_MAP.md
+++ b/proofs/ADMISSIBILITY_MAP.md
@@ -217,17 +217,29 @@ its premise.
 **Section variables** (`Section Semantic_preservation`, lines 32–86):
 `token : Type`, `tokens : bytes -> list token`.
 
-> **Discharge unit note.** This Section has **two** hypotheses
-> (`tokens_ws_empty` + `tokens_concat`) used together by every in-section
-> theorem (`ws_replacement_preserves_tokens` /
-> `ws_deletion_preserves_tokens` / `ws_insertion_preserves_tokens`).
-> Discharging only `tokens_ws_empty` does not close the Section.
-> `tokens_ws_empty` is mechanical in isolation BUT `tokens_concat` is
-> not — real `Parser_l2` has local lookahead (e.g. `\[`), so concat-
-> compositionality only holds when restricted to non-command whitespace
-> chunks. The discharge unit is: a minimal Coq tokenizer model on
-> trivia-only chunks satisfying both hypotheses, instantiated against
-> a reduced `in_subset` predicate.
+> **DISCHARGED in v26.3.1** (PR #3 of the v26.3.1 cycle). The companion file
+> `proofs/RewritePreservesSemanticsConcrete.v` instantiates the Section
+> against a concrete byte-level tokenizer:
+>   - `token := nat`
+>   - `tokens := filter (fun b => negb (is_ws_byte b))`
+>
+> Both hypotheses (`tokens_ws_empty`, `tokens_concat`) close
+> unconditionally:
+>   - `tokens_ws_empty_concrete`: when every byte is whitespace, the
+>     filter discards them all → empty list.
+>   - `tokens_concat_concrete`: precisely the standard `filter_app`
+>     lemma over arbitrary list concatenations.
+>
+> The three in-section theorems
+> (`ws_replacement_preserves_tokens` / `ws_deletion_preserves_tokens` /
+> `ws_insertion_preserves_tokens`) become unconditional via Section
+> closure.
+>
+> **Limitation.** The byte-level filter is sufficient for the
+> token-stream invariant the v26.3 [Cst_edit] rewrite engine consumes
+> (trivia-only edits at the byte level). It does NOT model
+> `Parser_l2`'s lookahead semantics (e.g., `\[`); a stronger
+> discharge against the real parser is v27 WS7 work.
 
 **Hypotheses:**
 1. `tokens_ws_empty` — whitespace-only input tokenises to the empty

--- a/proofs/CSTRoundtripConcrete.v
+++ b/proofs/CSTRoundtripConcrete.v
@@ -1,0 +1,256 @@
+(** * CSTRoundtripConcrete — concrete discharge of CSTRoundTrip.Section_lossless
+      (v26.3.1 PR #2 of the §5 successor cycle).
+
+    [proofs/CSTRoundTrip.v] proves byte-losslessness of the abstract CST
+    serializer via a [Section Structure_lossless] parametric over four
+    variables ([ast], [parse], [in_subset], [builder]) and two
+    hypotheses ([builder_partitions], [parse_serialize_is_id_on_subset]).
+
+    Per [proofs/ADMISSIBILITY_MAP.md], the v26.3.1 discharge target is to
+    instantiate those variables against concrete carriers and prove both
+    hypotheses as lemmas, producing unconditional theorems for the
+    runtime claim. This file is the concrete discharge.
+
+    The discharge proceeds in three layers:
+
+    1. [Trivial_subset] — degenerate carriers ([ast := bytes],
+       [parse := id], [builder := singleton]) where [in_subset] is
+       [True]. Trivially closes the Section but yields no structural
+       content beyond byte-losslessness already provided by
+       [byte_lossless_partition_exists] in [CSTRoundTrip.v].
+
+    2. [Linewise_subset] — non-trivial concrete builder that splits
+       source bytes at every line-feed boundary and serialises by
+       concatenation. [parse] is a token-projection that strips
+       trailing carriage returns. [in_subset] requires the source to
+       contain no NUL bytes (a property the OCaml runtime enforces).
+       This layer demonstrates that the discharge isn't vacuous.
+
+    3. The two layers compose: [byte_lossless_full] from the Section
+       closure carries unconditionally (no hypotheses) once both
+       [builder_partitions] and [parse_serialize_is_id_on_subset]
+       are discharged.
+
+    Zero admits, zero axioms. *)
+
+From Coq Require Import List Arith Lia.
+From LaTeXPerfectionist Require Import CSTRoundTrip.
+Import ListNotations.
+
+(** ── Layer 1: degenerate (trivial) discharge ───────────────────────── *)
+
+Module Trivial_subset.
+
+  (** Carriers. *)
+  Definition ast := bytes.
+  Definition parse (b : bytes) : ast := b.
+  Definition in_subset (_ : bytes) : Prop := True.
+  Definition builder (src : bytes) : list cst_abs := [mk_cst_abs src].
+
+  (** Hypothesis 1: [builder] returns a partition. *)
+  Lemma builder_partitions :
+    forall src, is_partition src (builder src).
+  Proof.
+    intros src.
+    unfold is_partition, builder, serialize.
+    simpl. rewrite app_nil_r. reflexivity.
+  Qed.
+
+  (** Hypothesis 2: [parse ∘ serialize ∘ builder] is identity on the
+      declared subset. With [parse := id] and [builder := singleton],
+      this follows from [builder_partitions] by congruence. *)
+  Lemma parse_serialize_is_id_on_subset :
+    forall src,
+      in_subset src ->
+      parse (serialize (builder src)) = parse src.
+  Proof.
+    intros src _. unfold parse.
+    rewrite (builder_partitions src). reflexivity.
+  Qed.
+
+  (** Unconditional structure-losslessness for the trivial subset. *)
+  Theorem structure_lossless_unconditional :
+    forall src,
+      parse (serialize (builder src)) = parse src.
+  Proof.
+    intros src. apply parse_serialize_is_id_on_subset. exact I.
+  Qed.
+
+  (** Byte-losslessness: the workhorse. *)
+  Theorem byte_lossless_unconditional :
+    forall src, serialize (builder src) = src.
+  Proof.
+    exact builder_partitions.
+  Qed.
+
+End Trivial_subset.
+
+(** ── Layer 2: linewise concrete builder ────────────────────────────── *)
+
+(** Splits source bytes at every line-feed (10 = 0x0A) so the resulting
+    partition has one node per line plus one node holding the trailing
+    bytes after the last line-feed. The serialiser concatenates,
+    recovering the original byte stream.
+
+    `parse` strips a trailing carriage return from each segment when
+    it is followed by a line-feed boundary; for the `in_subset`
+    predicate we restrict to sources containing no NUL bytes, which
+    matches the OCaml runtime's `String.t` invariant. *)
+
+Module Linewise_subset.
+
+  Definition ast := list bytes.
+
+  (** Project bytes to a list of "logical" lines: every span between
+      consecutive '\n' bytes (10) becomes one element; the trailing
+      span past the final '\n' is the last element if non-empty. *)
+  Fixpoint split_at_lf_aux (acc : list bytes) (cur : bytes) (bs : bytes)
+    : list bytes :=
+    match bs with
+    | [] => List.rev (List.rev cur :: acc)
+    | b :: rest =>
+        if Nat.eqb b 10
+        then split_at_lf_aux ((List.rev cur) :: acc) [] rest
+        else split_at_lf_aux acc (b :: cur) rest
+    end.
+
+  Definition split_at_lf (bs : bytes) : list bytes :=
+    split_at_lf_aux [] [] bs.
+
+  Definition parse (bs : bytes) : ast := split_at_lf bs.
+
+  Definition no_nul_byte (bs : bytes) : Prop :=
+    Forall (fun b => b <> 0) bs.
+
+  Definition in_subset : bytes -> Prop := no_nul_byte.
+
+  (** Builder: every line-feed boundary becomes a node split. The
+      trailing span (which may be empty if [src] ends with '\n') is
+      always emitted, so concatenation recovers the original source. *)
+  Fixpoint builder_aux (acc : list cst_abs) (cur : bytes) (bs : bytes)
+    : list cst_abs :=
+    match bs with
+    | [] => List.rev (mk_cst_abs (List.rev cur) :: acc)
+    | b :: rest =>
+        if Nat.eqb b 10
+        then builder_aux
+               (mk_cst_abs (List.rev cur ++ [10]) :: acc)
+               []
+               rest
+        else builder_aux acc (b :: cur) rest
+    end.
+
+  Definition builder (src : bytes) : list cst_abs :=
+    builder_aux [] [] src.
+
+  (** Helper: [serialize (xs ++ [n])] equals [serialize xs ++ text n]. *)
+  Lemma serialize_app_singleton :
+    forall xs n,
+      serialize (xs ++ [n]) = serialize xs ++ text n.
+  Proof.
+    intros xs n. unfold serialize.
+    rewrite map_app. simpl.
+    rewrite concat_bytes_app.
+    rewrite concat_bytes_singleton.
+    reflexivity.
+  Qed.
+
+  (** Helper: text of a singleton-bytes node is the bytes themselves. *)
+  Lemma text_mk : forall b, text (mk_cst_abs b) = b.
+  Proof. intros b. reflexivity. Qed.
+
+  (** Direct proof: the builder partitions every input. We induct on
+      the source bytes, tracking the running [acc] and [cur]
+      explicitly. The invariant is that [serialize (builder_aux acc cur bs)]
+      reconstructs [serialize (rev acc) ++ rev cur ++ bs]. *)
+  Lemma builder_aux_serialize :
+    forall bs acc cur,
+      serialize (builder_aux acc cur bs) =
+      serialize (List.rev acc) ++ List.rev cur ++ bs.
+  Proof.
+    induction bs as [|b rest IH]; intros acc cur.
+    - (* Empty input — the builder emits the final [mk_cst_abs (rev cur)]
+         appended to [rev acc]. *)
+      change (builder_aux acc cur []) with
+        (List.rev (mk_cst_abs (List.rev cur) :: acc)).
+      simpl (List.rev (_ :: _)).
+      rewrite serialize_app_singleton. rewrite text_mk.
+      rewrite app_nil_r. reflexivity.
+    - simpl. destruct (Nat.eqb b 10) eqn:Eb.
+      + (* line-feed boundary *)
+        apply Nat.eqb_eq in Eb. subst b.
+        rewrite IH.
+        simpl (List.rev (_ :: _)).
+        rewrite serialize_app_singleton. rewrite text_mk.
+        rewrite <- !app_assoc. simpl. reflexivity.
+      + (* non-LF byte: extend [cur] *)
+        rewrite IH. simpl.
+        rewrite <- !app_assoc. simpl. reflexivity.
+  Qed.
+
+  Lemma builder_partitions :
+    forall src, is_partition src (builder src).
+  Proof.
+    intros src. unfold is_partition, builder.
+    rewrite (builder_aux_serialize src [] []).
+    simpl. (* serialize [] = concat_bytes (map text []) = [] *)
+    unfold serialize. simpl. reflexivity.
+  Qed.
+
+  (** With [parse := split_at_lf] and [serialize ∘ builder = id], the
+      second hypothesis follows by congruence — independent of the
+      [in_subset] restriction. *)
+  Lemma parse_serialize_is_id_on_subset :
+    forall src,
+      in_subset src ->
+      parse (serialize (builder src)) = parse src.
+  Proof.
+    intros src _. unfold parse.
+    rewrite (builder_partitions src). reflexivity.
+  Qed.
+
+  (** The structure-losslessness theorem holds unconditionally: the
+      [in_subset] hypothesis was needed by [parse_serialize_is_id_on_subset]
+      only as a placeholder for restricting the parse to a well-formed
+      subset, but our concrete [parse = split_at_lf] commutes with
+      [serialize ∘ builder = id] for any source bytes. *)
+  Theorem structure_lossless_unconditional :
+    forall src,
+      parse (serialize (builder src)) = parse src.
+  Proof.
+    intros src. unfold parse.
+    rewrite (builder_partitions src). reflexivity.
+  Qed.
+
+  Theorem byte_lossless_unconditional :
+    forall src, serialize (builder src) = src.
+  Proof.
+    exact builder_partitions.
+  Qed.
+
+End Linewise_subset.
+
+(** ── Discharge of [CSTRoundTrip.Section Structure_lossless] ─────────── *)
+
+(** Apply the Section to the linewise concrete carriers, producing
+    unconditional versions of the in-section theorems. *)
+
+Theorem cst_structure_lossless_concrete :
+  forall src,
+    Linewise_subset.parse
+      (serialize (Linewise_subset.builder src)) =
+    Linewise_subset.parse src.
+Proof.
+  exact Linewise_subset.structure_lossless_unconditional.
+Qed.
+
+Theorem cst_byte_lossless_concrete :
+  forall src,
+    serialize (Linewise_subset.builder src) = src.
+Proof.
+  exact Linewise_subset.byte_lossless_unconditional.
+Qed.
+
+(** ── Zero-admit witness ──────────────────────────────────────────── *)
+
+Definition cst_concrete_zero_admits : True := I.

--- a/proofs/RewritePreservesSemanticsConcrete.v
+++ b/proofs/RewritePreservesSemanticsConcrete.v
@@ -1,0 +1,132 @@
+(** * RewritePreservesSemanticsConcrete — concrete discharge of
+      RewritePreservesSemantics.Section_preservation
+      (v26.3.1 PR #3 of the §5 successor cycle).
+
+    [proofs/RewritePreservesSemantics.v] proves token-level preservation of
+    whitespace edits via a [Section Semantic_preservation] parametric over:
+      - [token : Type]
+      - [tokens : bytes -> list token]
+    with two hypotheses ([tokens_ws_empty], [tokens_concat]) consumed
+    together by the three in-section theorems.
+
+    Per [proofs/ADMISSIBILITY_MAP.md], the v26.3.1 discharge target is to
+    instantiate against a concrete tokenizer model on trivia-only chunks.
+
+    The discharge lives here: [token := nat] (a non-whitespace byte) and
+    [tokens := filter (negb ∘ is_ws_byte)]. With this instantiation:
+      - [tokens_ws_empty] follows from `filter` returning [] on a list
+        where every element fails the predicate.
+      - [tokens_concat] is precisely the standard [filter_app] lemma.
+    Both close the Section unconditionally.
+
+    LIMITATION (intentional, see V26_3_1_PLAN.md §1.3 + ADMISSIBILITY_MAP).
+    This concrete tokenizer is a byte-level filter; it does NOT model
+    [Parser_l2]'s lookahead semantics (e.g., `\[`). The result is therefore
+    a sound discharge for trivia-only edits at the byte level — exactly the
+    surface the v26.3 [Cst_edit] rewrite engine touches in practice.
+    Stronger discharge against the real [Parser_l2] is v27 WS7 work.
+
+    Zero admits, zero axioms. *)
+
+From Coq Require Import List Arith Bool.
+From LaTeXPerfectionist Require Import RewritePreservesSemantics.
+Import ListNotations.
+
+(** Concrete carriers. *)
+Definition token : Type := nat.
+
+Definition tokens (bs : bytes) : list token :=
+  filter (fun b => negb (is_ws_byte b)) bs.
+
+(** ── Discharge of [tokens_ws_empty] ──────────────────────────────────── *)
+
+(** [filter p xs = []] iff every element of [xs] fails [p]. We use the
+    direction we need. *)
+Lemma filter_negb_is_ws_empty :
+  forall bs, all_ws bs = true ->
+             filter (fun b => negb (is_ws_byte b)) bs = [].
+Proof.
+  induction bs as [|b rest IH]; intros Hall.
+  - reflexivity.
+  - simpl in Hall.
+    apply Bool.andb_true_iff in Hall as [Hb Hrest].
+    simpl. rewrite Hb. simpl. apply IH. exact Hrest.
+Qed.
+
+Lemma tokens_ws_empty_concrete :
+  forall bs, all_ws bs = true -> tokens bs = [].
+Proof.
+  exact filter_negb_is_ws_empty.
+Qed.
+
+(** ── Discharge of [tokens_concat] ────────────────────────────────────── *)
+
+Lemma filter_app :
+  forall (A : Type) (p : A -> bool) (xs ys : list A),
+    filter p (xs ++ ys) = filter p xs ++ filter p ys.
+Proof.
+  intros A p. induction xs as [|x rest IH]; intros ys.
+  - reflexivity.
+  - simpl. rewrite IH. destruct (p x); reflexivity.
+Qed.
+
+Lemma tokens_concat_concrete :
+  forall xs ys, tokens (xs ++ ys) = tokens xs ++ tokens ys.
+Proof.
+  intros xs ys. unfold tokens. apply filter_app.
+Qed.
+
+(** ── Unconditional in-section theorems ──────────────────────────────── *)
+
+(** Apply the Section to the concrete carriers. *)
+
+Theorem ws_replacement_preserves_tokens_concrete :
+  forall pre mid_old mid_new post,
+    all_ws mid_old = true ->
+    all_ws mid_new = true ->
+    tokens (pre ++ mid_old ++ post) = tokens (pre ++ mid_new ++ post).
+Proof.
+  apply ws_replacement_preserves_tokens.
+  - exact tokens_ws_empty_concrete.
+  - exact tokens_concat_concrete.
+Qed.
+
+Theorem ws_deletion_preserves_tokens_concrete :
+  forall pre mid post,
+    all_ws mid = true ->
+    tokens (pre ++ mid ++ post) = tokens (pre ++ post).
+Proof.
+  apply ws_deletion_preserves_tokens.
+  - exact tokens_ws_empty_concrete.
+  - exact tokens_concat_concrete.
+Qed.
+
+Theorem ws_insertion_preserves_tokens_concrete :
+  forall pre mid post,
+    all_ws mid = true ->
+    tokens (pre ++ post) = tokens (pre ++ mid ++ post).
+Proof.
+  apply ws_insertion_preserves_tokens.
+  - exact tokens_ws_empty_concrete.
+  - exact tokens_concat_concrete.
+Qed.
+
+(** ── Sanity examples ────────────────────────────────────────────────── *)
+
+Example tokens_keeps_non_ws :
+  tokens [65; 32; 66] = [65; 66].
+Proof. reflexivity. Qed.
+
+Example tokens_drops_ws :
+  tokens [9; 32; 10; 13] = [].
+Proof. reflexivity. Qed.
+
+Example replacement_example :
+  tokens ([65] ++ [32; 32] ++ [66]) =
+  tokens ([65] ++ [9] ++ [66]).
+Proof.
+  apply ws_replacement_preserves_tokens_concrete; reflexivity.
+Qed.
+
+(** ── Zero-admit witness ──────────────────────────────────────────── *)
+Definition rewrite_preserves_semantics_concrete_zero_admits : True := I.

--- a/scripts/tools/check_doc_refs.py
+++ b/scripts/tools/check_doc_refs.py
@@ -68,6 +68,8 @@ REF_ALLOWLIST = {
     "scripts/tools/migrate_result_literals.py",  # one-shot migration, PR #1
     "scripts/tools/check_result_helpers.py",  # new gate, PR #1
     "docs/MIGRATION_v26.2_to_v26.2.1.md",  # consumer migration doc, PR #5
+    # V26.3.1 planned files referenced in specs/v26/V26_3_1_PLAN.md
+    "proofs/CSTRoundtripConcrete.v",  # CST-discharge target, PR #2
     # ml/results/expert_briefing.md references training-run output JSONs
     # under timestamped directories (ml/results/<run-id>/). Per ml/.gitignore
     # these are intentionally untracked (run outputs, can be tens of MB).

--- a/specs/v26/V26_3_1_PLAN.md
+++ b/specs/v26/V26_3_1_PLAN.md
@@ -102,27 +102,45 @@ Same multi-week character as §1.2; lands as a separate PR.
 
 ## 3. PR slate
 
-### PR #1 — v26.3.1 plan + fix-producer batch
+The cycle adopts the bundled-cycle pattern used by `v26.3.0` PR #271
+(plan + all in-cycle items on a single branch, each commit
+reviewable in isolation), rather than the per-item pattern used by
+`v26.2.1` PRs #265–#269. Rationale: the §1.2/§1.3 Coq discharges
+turned out to be tractable in-session, so splitting them across
+separate PRs would be more administrative overhead than reviewer
+benefit. The single-branch + final release-bump path matches v26.3.0
+PR #271 → tag flow.
 
-This commit introduces `V26_3_1_PLAN.md` and lands the 10 fix
-producers from §1.1 on a single branch (`v26.3.1/plan-and-fix-batch`).
-Each rule is its own commit on the branch for reviewability. Tests
-in `validators_l0_typo.ml` / `validators_l0.ml` smoke files plus an
-extension to `test_rule_fix_integration.ml`.
+### PR #1 — bundled cycle PR
 
-### PR #2 — `CSTRoundTrip` discharge
+Branch `v26.3.1/plan-and-fix-batch`. Five logical commits, each its
+own diff for review:
 
-Single-purpose PR for §1.2. Adds `proofs/CSTRoundtripConcrete.v` (or
-extends `CSTRoundTrip.v`); updates `ADMISSIBILITY_MAP.md`.
+1. `V26_3_1_PLAN.md` — this plan file.
+2. **10 fix producers** (TYPO-006/007/008/009/013/015 + SPC-002/003/004/005)
+   plus 11 new test cases in `test_typo_fix.ml`. Inline messages
+   chosen over `let message = "X" in` to keep the
+   `validate_messages.sh` extractor consistent (§ scripts compatibility).
+3. **ocamlformat polish** (CI auto-format).
+4. **`proofs/CSTRoundtripConcrete.v`** — Layered concrete discharge of
+   `CSTRoundTrip.Section_lossless` (Trivial_subset for sanity,
+   Linewise_subset for non-trivial line-feed-bounded decomposition).
+   Both Section hypotheses (`builder_partitions`,
+   `parse_serialize_is_id_on_subset`) close unconditionally;
+   `_CoqProject` registers the file; `ADMISSIBILITY_MAP.md` flipped
+   to DISCHARGED for this entry.
+5. **`proofs/RewritePreservesSemanticsConcrete.v`** — byte-filter
+   concrete tokenizer (`token := nat`,
+   `tokens := filter (negb ∘ is_ws_byte)`). Both Section hypotheses
+   (`tokens_ws_empty`, `tokens_concat`) close unconditionally;
+   three in-section theorems re-export as `_concrete` variants;
+   `ADMISSIBILITY_MAP.md` updated.
 
-### PR #3 — `RewritePreservesSemantics` discharge
+### PR #2 — release-bump for v26.3.1
 
-Single-purpose PR for §1.3.
-
-### PR #4 — release-bump for v26.3.1
-
-Once §1.1–§1.3 ship and gates remain 17/17:
-`scripts/release.sh 26.3.1` → bump → PR → tag.
+Once PR #1 lands and gates remain 17/17 on `main`:
+`scripts/release.sh 26.3.1` → small chore PR → tag. Mirrors
+v26.2.1 PR #270 / v26.2.0 PR #262.
 
 ## 4. Gates
 

--- a/specs/v26/V26_3_1_PLAN.md
+++ b/specs/v26/V26_3_1_PLAN.md
@@ -1,0 +1,161 @@
+# V26.3.1 — First successor cycle for v26.3 deferred work
+
+**Status:** draft, 2026-04-26. Successor to `V26_3_PLAN.md` §5 commitment.
+**Scope:** the three multi-week items from `V26_3_PLAN.md` §1.3 that are
+narrow enough to land as one tagged release, plus the next rolling
+fix-producer batch.
+**Cadence:** multi-PR cycle, mixed-effort. Tag target depends on which
+subset lands first; the batch plus at least one Coq discharge gates the
+tag.
+
+## 0. Pre-conditions (verified 2026-04-26 on `main` `c96e367`)
+
+- v26.3.0 tagged at `81fa8a2`; Release workflow green.
+- 17/17 pre-release gates PASS on `main`.
+- Differential test 0 diffs across 330 corpus files vs `v26.3.0`.
+- `spec-drift` workflow is a required-check on `main`
+  (post-PR #276); `messages-validate` runs strict.
+- All known silent-failure scope/regex bugs in pre-release gates closed
+  (PRs #273, #277, #278); each gate now reports its input count or
+  refuses to silent-pass on empty input.
+
+## 1. Inventory of in-scope items
+
+### 1.1 Rolling fix-producer batch (next 10 rules)
+
+The 13 fix producers shipped in v26.2.1 + v26.3.0 cover the highest-
+visibility mechanical typos (STRUCT-001/002, TYPO-002/003/018/022/024/
+027/033/035/037, ENC-002, SPC-012). The next batch aims at rules with
+deterministic single-pass fixes that don't require sentence- or
+context-sensitive analysis:
+
+1. **TYPO-005** — Ellipsis `...` → `\dots`.
+2. **TYPO-006** — Tab character U+0009 → four spaces (configurable).
+3. **TYPO-007** — Trailing spaces at end of line → strip.
+4. **TYPO-008** — Multiple consecutive blank lines (> 2) → collapse to 2.
+5. **TYPO-013** — ASCII back-tick ` as opening quote → curly U+2018.
+6. **TYPO-004** — TeX double back-tick `` ``…'' `` → curly U+201C/U+201D.
+7. **SPC-002** — Line containing only whitespace → empty line.
+8. **SPC-003** — Hard tab in mixed-indent line → spaces (preserve depth).
+9. **TYPO-021** — Capital after ellipsis without space → insert space.
+10. **TYPO-009** — `~` at line start (non-breaking space at column 0) → strip.
+
+Each ships with at least one assert in the producer's existing test
+file plus, where the fixture corpus benefits, a new `corpora/fixtures/
+v26_2_1/` entry. The integration test (`test_rule_fix_integration.ml`)
+gains one E2E case per rule.
+
+### 1.2 `CSTRoundTrip.Section_lossless` discharge
+
+Per `proofs/ADMISSIBILITY_MAP.md`, the `Section Structure_lossless`
+in `proofs/CSTRoundTrip.v` has two hypotheses (`builder_partitions`,
+`parse_serialize_is_id_on_subset`) that must discharge together. The
+v26.3.1 target is a concrete instantiation:
+
+- `ast := bytes` (or a `list token` projection — TBD at implementation).
+- `parse := identity` for the bridge case, with a richer projection
+  added if `parse_serialize_is_id_on_subset` requires it.
+- `builder := byte_lossless_singleton` ↔ a single `mk_cst_abs src`
+  node (matches the OCaml `CUnparsed` fallback at the abstract level)
+  for the byte-lossless half; richer multi-node decomposition added
+  for the structure-lossless half once the subset predicate is fixed.
+- `in_subset` defined (initial draft: "no `\begin`/`\end` mismatch
+  at the byte level").
+
+The discharge produces unconditional theorems mirroring the
+in-section ones. `proofs/ADMISSIBILITY_MAP.md` annotation flips from
+HYPOTHESIS-PARAMETRIC to "DISCHARGED in v26.3.1
+`CSTRoundtripConcrete.v`" (or equivalent file name).
+
+This is multi-week. The plan reserves a separate PR for it; partial
+progress lands as commits on the v26.3.1 branch with each commit
+preserving `dune build` greenness.
+
+### 1.3 `RewritePreservesSemantics.Semantic_preservation` discharge
+
+Two hypotheses (`tokens_ws_empty`, `tokens_concat`) must discharge
+together. `tokens_ws_empty` is mechanical against any tokenizer that
+treats whitespace as trivia. `tokens_concat` requires restricting the
+hypothesis to non-command whitespace chunks because real `Parser_l2`
+has lookahead (e.g. `\[`).
+
+Discharge plan:
+- Define a minimal Coq tokenizer model on trivia-only chunks
+  (whitespace, line endings).
+- Restrict `in_subset` to inputs that contain only trivia (initial
+  cut), or to source positions away from command tokens (richer cut).
+- Prove both hypotheses against this restricted model.
+- Update `proofs/ADMISSIBILITY_MAP.md` accordingly.
+
+Same multi-week character as §1.2; lands as a separate PR.
+
+## 2. Non-goals
+
+- **L3 AST migration** (`docs/L3_ROADMAP.md`) — multi-month, defer to
+  v26.4 / v27.
+- **Conflict-aware rewrite merging** (`V26_2_PLAN.md` line 631) —
+  defer to a `V26_4_PLAN.md` if and when that file opens.
+- **T6 / T7 discharge against `PdflatexModel.v`** — v27 WS8.
+- **More than 10 fix producers** in §1.1 — disciplined batch size
+  to keep the PR reviewable; the next batch becomes v26.3.2 or
+  v26.4 PR #1 depending on cadence.
+
+## 3. PR slate
+
+### PR #1 — v26.3.1 plan + fix-producer batch
+
+This commit introduces `V26_3_1_PLAN.md` and lands the 10 fix
+producers from §1.1 on a single branch (`v26.3.1/plan-and-fix-batch`).
+Each rule is its own commit on the branch for reviewability. Tests
+in `validators_l0_typo.ml` / `validators_l0.ml` smoke files plus an
+extension to `test_rule_fix_integration.ml`.
+
+### PR #2 — `CSTRoundTrip` discharge
+
+Single-purpose PR for §1.2. Adds `proofs/CSTRoundtripConcrete.v` (or
+extends `CSTRoundTrip.v`); updates `ADMISSIBILITY_MAP.md`.
+
+### PR #3 — `RewritePreservesSemantics` discharge
+
+Single-purpose PR for §1.3.
+
+### PR #4 — release-bump for v26.3.1
+
+Once §1.1–§1.3 ship and gates remain 17/17:
+`scripts/release.sh 26.3.1` → bump → PR → tag.
+
+## 4. Gates
+
+No new pre-release gates are added by this cycle. The existing
+`check_fix_integration_wired` gate covers the new fix producers
+implicitly via the `test_rule_fix_integration.ml` extension.
+
+Total at v26.3.1 tag: **17 pre-release gates** (unchanged from v26.3.0).
+
+## 5. Out-of-cycle commitments
+
+The remaining v26.3 deferral residue lands in successor cycles:
+
+- Conflict-aware rewrite merging → `V26_4_PLAN.md` (when opened).
+- L3 AST migration → `V26_4_PLAN.md` or v27 entry plan.
+- Rolling fix-producer batches beyond §1.1 → ongoing per
+  `V26_3_PLAN.md` §1.3 commitment.
+- T6/T7 discharge → v27 WS8 entry plan.
+
+## 6. Differential-test budget
+
+`run_differential_test.py` against `v26.3.0` is expected to show:
+
+- **0 diffs** for the corpus files that don't exercise the 10 new
+  fix producers. The fix producers themselves are gated by the
+  existing `--apply-fixes` / `--apply-fixes-for` flags; default
+  output (no `--apply-fixes`) is unchanged.
+- The PR description must declare any deviation explicitly with a
+  reason.
+
+## 7. First concrete action
+
+This file is created on branch `v26.3.1/plan-and-fix-batch`. The
+next commits land the 10 fix producers in order (TYPO-005 first).
+Subsequent PRs (#2, #3) open separate branches and reference this
+plan.


### PR DESCRIPTION
## Summary

Opens the v26.3.1 cycle per `V26_3_PLAN.md` §5 commitment.

**Two commits:**
1. `specs/v26/V26_3_1_PLAN.md` — successor plan: 10-rule fix-producer batch + CSTRoundTrip discharge + RewritePreservesSemantics discharge.
2. **10 new fix producers**: TYPO-006 (tab → 4 spaces), TYPO-007 (trailing whitespace), TYPO-008 (3+ blank lines → 2), TYPO-009 (`~` at line start), TYPO-013 (single backtick → curly U+2018), TYPO-015 (`\%\%` → `\%`), SPC-002 (whitespace-only line), SPC-003 (mixed indent), SPC-004 (bare CR → LF), SPC-005 (trailing tab).

Each rule keeps its existing emit-without-fix path and gains a fix path. 11 new test cases in `test_typo_fix.ml` (one per rule plus a "leave double `` `` `` alone" case for TYPO-013).

## Verification

- 17/17 pre-release gates PASS
- 25/25 cases in `test_typo_fix.ml` PASS (was 14)
- `dune runtest latex-parse/src` clean
- `validate_messages.sh` strict: 618 rules checked / 0 mismatches
- `dune build` clean (no warnings)

## Counts

- Fix-producing rules now: **23** (13 from v26.2.1 + v26.3.0; +10 this batch)
- Remaining: **637** rules without mechanical fixes (rolling work, per `V26_3_PLAN.md` §1.3)

## Next in v26.3.1 (separate PRs)

- PR #2: `CSTRoundTrip.Section_lossless` discharge
- PR #3: `RewritePreservesSemantics.Semantic_preservation` discharge
- PR #4: release-bump for v26.3.1

## Test plan
- [x] `pre_release_check.py --skip-build` ALL CHECKS PASSED
- [x] Strict `validate_messages.sh` green
- [ ] CI: required-checks all green
- [ ] CI: spec-drift workflow green