### PR TITLE
feat(v26.4): plan + conflict-aware rewrite merging (PR #1 of cycle)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,18 +13,19 @@ concurrency:
 jobs:
   format:
     runs-on: ubuntu-22.04
-    # v26.4 (2nd iteration): bumped 20→30 after an intermediate 15→20
-    # bump and a Coq-removal trim still left opam install hitting the
-    # cap on cache-miss runs. Even without Coq, ocamlformat + dune
-    # over a fresh switch can take 18-22 minutes on hosted runners
-    # with cold cache. 30m gives a real safety margin while keeping
-    # an upper bound for stuck jobs. The job remains non-required.
+    # v26.4: bumped 15→30. Coq must remain in the install set —
+    # `dune fmt` parses every dune file in the project, and `proofs/dune`
+    # contains a `(coq.theory ...)` stanza that dune can't understand
+    # without the Coq packages installed (errors out with
+    # "Hint: opam install coq"). A previous attempt to drop Coq for
+    # speed broke `dune fmt` itself; the right answer is more headroom,
+    # not a smaller install.
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-ocaml-env
         with:
-          opam-packages: ocamlformat.0.26.2 dune
+          opam-packages: ocamlformat.0.26.2 dune coq=8.18.0 coq-core=8.18.0
       - name: Pin formatter dependencies
         run: |
           opam pin add -y cmdliner 1.3.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,12 +13,13 @@ concurrency:
 jobs:
   format:
     runs-on: ubuntu-22.04
-    # v26.4: bumped 15→20 because opam install + ocamlformat installs
-    # were tipping over the 15-minute hard cap intermittently. The
-    # opam-packages list ALSO drops Coq (this job runs `dune fmt` on
-    # OCaml/dune files only — Coq packages are not needed here and were
-    # what was eating most of the wall time).
-    timeout-minutes: 20
+    # v26.4 (2nd iteration): bumped 20→30 after an intermediate 15→20
+    # bump and a Coq-removal trim still left opam install hitting the
+    # cap on cache-miss runs. Even without Coq, ocamlformat + dune
+    # over a fresh switch can take 18-22 minutes on hosted runners
+    # with cold cache. 30m gives a real safety margin while keeping
+    # an upper bound for stuck jobs. The job remains non-required.
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-ocaml-env

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,12 +13,17 @@ concurrency:
 jobs:
   format:
     runs-on: ubuntu-22.04
-    timeout-minutes: 15
+    # v26.4: bumped 15→20 because opam install + ocamlformat installs
+    # were tipping over the 15-minute hard cap intermittently. The
+    # opam-packages list ALSO drops Coq (this job runs `dune fmt` on
+    # OCaml/dune files only — Coq packages are not needed here and were
+    # what was eating most of the wall time).
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-ocaml-env
         with:
-          opam-packages: ocamlformat.0.26.2 dune coq=8.18.0 coq-core=8.18.0
+          opam-packages: ocamlformat.0.26.2 dune
       - name: Pin formatter dependencies
         run: |
           opam pin add -y cmdliner 1.3.0

--- a/latex-parse/src/cst_edit.ml
+++ b/latex-parse/src/cst_edit.ml
@@ -80,6 +80,36 @@ let apply_all src edits =
       if !cursor < n then Buffer.add_substring buf src !cursor (n - !cursor);
       Ok (Buffer.contents buf)
 
+(* v26.4 §1.1: conflict-aware merging. Walk the input edit list in order; an
+   edit lands in [applied] iff it doesn't conflict with anything already in
+   [applied]; otherwise it lands in [skipped]. The output is [apply_all src
+   applied] — guaranteed to succeed because applied was built to be pairwise
+   non-conflicting. *)
+let apply_best_effort src edits =
+  let rec partition acc_applied acc_skipped = function
+    | [] -> (List.rev acc_applied, List.rev acc_skipped)
+    | e :: rest ->
+        if List.exists (fun a -> conflicts e a) acc_applied then
+          partition acc_applied (e :: acc_skipped) rest
+        else partition (e :: acc_applied) acc_skipped rest
+  in
+  let applied, skipped = partition [] [] edits in
+  match apply_all src applied with
+  | Ok out -> (out, applied, skipped)
+  | Error _ ->
+      (* Internal invariant: [applied] is pairwise non-conflicting by
+         construction, so [apply_all] cannot return Overlap here. *)
+      invalid_arg
+        "Cst_edit.apply_best_effort: applied subset has conflicts (BUG)"
+
+let apply_with_priority src priority edits =
+  (* Stable sort by descending priority so equal-priority edits keep input
+     order. *)
+  let prioritised =
+    List.stable_sort (fun a b -> Int.compare (priority b) (priority a)) edits
+  in
+  apply_best_effort src prioritised
+
 let shift_after ~by ~at_or_after e =
   let shift x = if x >= at_or_after then x + by else x in
   {

--- a/latex-parse/src/cst_edit.mli
+++ b/latex-parse/src/cst_edit.mli
@@ -64,6 +64,29 @@ val apply_all : string -> t list -> (string, [ `Overlap of t * t ]) result
     before application. Returns [Error (`Overlap (a, b))] if any two edits
     conflict. *)
 
+val apply_best_effort : string -> t list -> string * t list * t list
+(** [apply_best_effort src edits] greedily applies as many edits as possible.
+    Returns [(output, applied, skipped)]:
+
+    - [output] is [src] with the [applied] edits applied in pre-edit
+      coordinates, equivalent to [Ok x = apply_all src applied; x].
+    - [applied] is the subset of [edits] that did not conflict with any
+      earlier-accepted edit; first-occurrence-wins (input order is the
+      conflict-resolution priority).
+    - [skipped] is the complementary subset, in the order they were encountered.
+
+    Pure insertions at the same offset are NOT conflicts (per {!conflicts}) and
+    all of them land in [applied] in input order. v26.4 §1.1 enables this as the
+    underlying primitive of the [--apply-fixes-best-effort] CLI mode. *)
+
+val apply_with_priority :
+  string -> (t -> int) -> t list -> string * t list * t list
+(** [apply_with_priority src priority edits] sorts [edits] by descending
+    [priority], then dispatches to [apply_best_effort]. Higher-priority edits
+    dominate conflicting lower-priority ones. The returned [applied] list
+    reflects the post-priority-sort order; [skipped] preserves the original
+    input order of the rejected edits. *)
+
 (** ── Shifting ────────────────────────────────────────────────────── *)
 
 val shift_after : by:int -> at_or_after:int -> t -> t

--- a/latex-parse/src/test_cst_edit.ml
+++ b/latex-parse/src/test_cst_edit.ml
@@ -140,4 +140,98 @@ let () =
       let e' = Cst_edit.shift_after ~by:10 ~at_or_after:20 e in
       expect (Cst_edit.equal e e') (tag ^ ": unchanged"));
 
+  (* v26.4 §1.1: conflict-aware merging tests. *)
+  run "apply_best_effort: no conflicts → all applied, none skipped" (fun tag ->
+      let src = "abcdefghij" in
+      let a = Cst_edit.replace ~start_offset:0 ~end_offset:2 "XX" in
+      let b = Cst_edit.replace ~start_offset:5 ~end_offset:7 "YY" in
+      let out, applied, skipped = Cst_edit.apply_best_effort src [ a; b ] in
+      expect
+        (out = "XXcdeYYhij"
+        && List.length applied = 2
+        && List.length skipped = 0)
+        (tag ^ ": both applied, output equals apply_all"));
+
+  run "apply_best_effort: first wins on conflict, second skipped" (fun tag ->
+      let src = "abcdefghij" in
+      let a = Cst_edit.replace ~start_offset:0 ~end_offset:5 "X" in
+      let b = Cst_edit.replace ~start_offset:3 ~end_offset:7 "Y" in
+      let out, applied, skipped = Cst_edit.apply_best_effort src [ a; b ] in
+      expect
+        (out = "Xfghij"
+        && List.length applied = 1
+        && List.length skipped = 1
+        && Cst_edit.equal (List.hd applied) a
+        && Cst_edit.equal (List.hd skipped) b)
+        (tag ^ ": a applied, b skipped"));
+
+  run "apply_best_effort: two pure insertions at same offset both applied"
+    (fun tag ->
+      let src = "ab" in
+      let a = Cst_edit.insert ~at:1 "X" in
+      let b = Cst_edit.insert ~at:1 "Y" in
+      let out, applied, skipped = Cst_edit.apply_best_effort src [ a; b ] in
+      expect
+        (List.length applied = 2
+        && List.length skipped = 0
+        && (out = "aXYb" || out = "aYXb"))
+        (tag ^ ": both inserts kept (input-order interleaved)"));
+
+  run "apply_best_effort: third edit conflicts with first, second is fine"
+    (fun tag ->
+      let src = "abcdefghij" in
+      let a = Cst_edit.replace ~start_offset:0 ~end_offset:3 "X" in
+      let b = Cst_edit.replace ~start_offset:5 ~end_offset:7 "Y" in
+      let c = Cst_edit.replace ~start_offset:1 ~end_offset:4 "Z" in
+      let out, applied, skipped = Cst_edit.apply_best_effort src [ a; b; c ] in
+      expect
+        (out = "XdeYhij"
+        && List.length applied = 2
+        && List.length skipped = 1
+        && Cst_edit.equal (List.hd skipped) c)
+        (tag ^ ": a + b applied, c skipped"));
+
+  run "apply_with_priority: higher-priority edit dominates" (fun tag ->
+      let src = "abcdefghij" in
+      let a = Cst_edit.replace ~start_offset:0 ~end_offset:5 "AAA" in
+      let b = Cst_edit.replace ~start_offset:3 ~end_offset:7 "BBB" in
+      let priority e =
+        if Cst_edit.equal e a then 1 else if Cst_edit.equal e b then 5 else 0
+      in
+      let out, applied, skipped =
+        Cst_edit.apply_with_priority src priority [ a; b ]
+      in
+      expect
+        (out = "abcBBBhij"
+        && List.length applied = 1
+        && Cst_edit.equal (List.hd applied) b
+        && List.length skipped = 1
+        && Cst_edit.equal (List.hd skipped) a)
+        (tag ^ ": b wins, a skipped"));
+
+  run "apply_with_priority: equal priority preserves input order" (fun tag ->
+      let src = "abcdefghij" in
+      let a = Cst_edit.replace ~start_offset:0 ~end_offset:3 "X" in
+      let b = Cst_edit.replace ~start_offset:1 ~end_offset:4 "Y" in
+      let out, applied, _ =
+        Cst_edit.apply_with_priority src (fun _ -> 0) [ a; b ]
+      in
+      expect
+        (out = "Xdefghij"
+        && List.length applied = 1
+        && Cst_edit.equal (List.hd applied) a)
+        (tag ^ ": input-order tiebreak — a wins"));
+
+  run "apply_best_effort agrees with apply_all on disjoint input" (fun tag ->
+      let src = "abcdefghij" in
+      let a = Cst_edit.replace ~start_offset:0 ~end_offset:2 "XX" in
+      let b = Cst_edit.replace ~start_offset:5 ~end_offset:7 "YY" in
+      let strict =
+        match Cst_edit.apply_all src [ a; b ] with
+        | Ok s -> s
+        | Error _ -> failwith "expected Ok"
+      in
+      let best, _, _ = Cst_edit.apply_best_effort src [ a; b ] in
+      expect (strict = best) (tag ^ ": both produce identical output"));
+
   finalise "cst-edit"

--- a/latex-parse/src/test_typo_fix.ml
+++ b/latex-parse/src/test_typo_fix.ml
@@ -208,4 +208,58 @@ let () =
         && apply_all src edits = "alpha\nbeta\nclean\ndone")
         (tag ^ ": both trailing-tab lines stripped"));
 
+  (* v26.4 §1.3: 5 more fix producers. *)
+  run "TYPO-014 fix removes space before percent" (fun tag ->
+      let src = "alpha %comment\nbeta %end" in
+      let edits = fix_edits "TYPO-014" src in
+      expect
+        (List.length edits = 2
+        && apply_all src edits = "alpha%comment\nbeta%end")
+        (tag ^ ": both spaces deleted"));
+
+  run "TYPO-021 fix inserts space after ASCII ellipsis" (fun tag ->
+      let src = "Hello...World" in
+      let edits = fix_edits "TYPO-021" src in
+      expect
+        (List.length edits = 1 && apply_all src edits = "Hello... World")
+        (tag ^ ": space inserted before W"));
+
+  run "TYPO-021 fix inserts space after Unicode ellipsis" (fun tag ->
+      let src = "End\xe2\x80\xa6Next" in
+      (* "End…Next" *)
+      let edits = fix_edits "TYPO-021" src in
+      expect
+        (List.length edits = 1 && apply_all src edits = "End\xe2\x80\xa6 Next")
+        (tag ^ ": space inserted before N"));
+
+  run "TYPO-025 fix removes space before en-dash in number range" (fun tag ->
+      let src = "see pp. 12 \xe2\x80\x9320 and 30 --45" in
+      (* "12 –20" *)
+      let edits = fix_edits "TYPO-025" src in
+      let out = apply_all src edits in
+      expect
+        (List.length edits = 2 && out = "see pp. 12\xe2\x80\x9320 and 30--45")
+        (tag ^ ": both space-runs collapsed"));
+
+  run "SPC-009 fix strips ASCII tilde at line start" (fun tag ->
+      let src = "~ alpha\n~beta" in
+      let edits = fix_edits "SPC-009" src in
+      expect
+        (List.length edits = 2 && apply_all src edits = " alpha\nbeta")
+        (tag ^ ": both ~ stripped"));
+
+  run "SPC-009 fix strips Unicode NBSP at line start" (fun tag ->
+      let src = "\xc2\xa0alpha\nbeta" in
+      let edits = fix_edits "SPC-009" src in
+      expect
+        (List.length edits = 1 && apply_all src edits = "alpha\nbeta")
+        (tag ^ ": NBSP stripped"));
+
+  run "SPC-010 fix collapses double space after period to single" (fun tag ->
+      let src = "First.  Second.  Third." in
+      let edits = fix_edits "SPC-010" src in
+      expect
+        (List.length edits = 2 && apply_all src edits = "First. Second. Third.")
+        (tag ^ ": both runs collapsed"));
+
   finalise "typo-fix"

--- a/latex-parse/src/validators_cli.ml
+++ b/latex-parse/src/validators_cli.ml
@@ -154,27 +154,49 @@ let env_flag_on name =
 
 (** v26.2.1 PR #4 + v26.3 item B: run validators, collect fix edits (optionally
     filtered to a single rule via [filter_id]), apply them via
-    [Rewrite_engine.apply], emit modified source. *)
-let run_apply_fixes ?filter_id ~path ~src () =
+    [Rewrite_engine.apply], emit modified source.
+
+    v26.4 §1.1 [best_effort]: when [true], conflicting fixes are NOT a hard
+    error — the caller gets the maximal non-conflicting subset applied to
+    stdout, with the skipped subset reported on stderr. Exit code 0 in that case
+    (the partial-fix output is the contract). When [false] (default), behaviour
+    is unchanged: any overlap returns exit 2 with no stdout. *)
+let run_apply_fixes ?filter_id ?(best_effort = false) ~path ~src () =
   let _tier, features = resolve_profile ~requested:`Auto ~src in
   print_profile_banner _tier features;
   let _bp = setup_all ~path ~src ~log_path:None in
   Fun.protect ~finally:cleanup (fun () ->
       let results = Latex_parse_lib.Validators.run_all src in
       let edits = collect_fix_edits ?filter_id results in
-      match Latex_parse_lib.Rewrite_engine.apply ~source:src ~edits with
-      | Ok out ->
-          print_string out;
-          0
-      | Error (`Overlap (a, b)) ->
-          eprintf
-            "E.apply-fixes.overlap: two rule fixes affect overlapping source \
-             ranges; refusing to apply.\n\
-             # first edit:  %s\n\
-             # second edit: %s\n"
-            (Latex_parse_lib.Cst_edit.to_string a)
-            (Latex_parse_lib.Cst_edit.to_string b);
-          2)
+      if best_effort then (
+        let out, applied, skipped =
+          Latex_parse_lib.Cst_edit.apply_best_effort src edits
+        in
+        print_string out;
+        if skipped <> [] then (
+          eprintf "# apply-fixes-best-effort: %d edit(s) applied, %d skipped\n"
+            (List.length applied) (List.length skipped);
+          List.iter
+            (fun e ->
+              eprintf "# skipped: %s\n" (Latex_parse_lib.Cst_edit.to_string e))
+            skipped);
+        0)
+      else
+        match Latex_parse_lib.Rewrite_engine.apply ~source:src ~edits with
+        | Ok out ->
+            print_string out;
+            0
+        | Error (`Overlap (a, b)) ->
+            eprintf
+              "E.apply-fixes.overlap: two rule fixes affect overlapping source \
+               ranges; refusing to apply.\n\
+               # first edit:  %s\n\
+               # second edit: %s\n\
+               # hint: re-run with --apply-fixes-best-effort to apply the \
+               maximal non-conflicting subset.\n"
+              (Latex_parse_lib.Cst_edit.to_string a)
+              (Latex_parse_lib.Cst_edit.to_string b);
+            2)
 
 (* ── Entry point ─────────────────────────────────────────────────── *)
 
@@ -190,6 +212,12 @@ let () =
   | [ _; "--apply-fixes-for"; rule_id; path ] ->
       let src = read_all path in
       exit (run_apply_fixes ~filter_id:rule_id ~path ~src ())
+  | [ _; "--apply-fixes-best-effort"; path ] ->
+      let src = read_all path in
+      exit (run_apply_fixes ~best_effort:true ~path ~src ())
+  | [ _; "--apply-fixes-best-effort-for"; rule_id; path ] ->
+      let src = read_all path in
+      exit (run_apply_fixes ~best_effort:true ~filter_id:rule_id ~path ~src ())
   | [ _; path ] when apply_env_on ->
       let src = read_all path in
       exit (run_apply_fixes ~path ~src ())
@@ -292,9 +320,11 @@ let () =
             ps.file_states)
   | _ ->
       eprintf
-        "Usage: %s [--apply-fixes | --apply-fixes-for RULE-ID] [--profile \
-         auto|lp-core|lp-extended|lp-foreign] [--advisory] [--project \
-         <root.tex>] [--layer l0|l1|l2|l3|l4] [--log <file.log>] <file.tex>\n\n\
+        "Usage: %s [--apply-fixes | --apply-fixes-for RULE-ID | \
+         --apply-fixes-best-effort | --apply-fixes-best-effort-for RULE-ID] \
+         [--profile auto|lp-core|lp-extended|lp-foreign] [--advisory] \
+         [--project <root.tex>] [--layer l0|l1|l2|l3|l4] [--log <file.log>] \
+         <file.tex>\n\n\
          --apply-fixes  run validators, apply every rule's fix edits via \
          Cst_edit.apply_all,\n\
         \               and emit the modified source to stdout. \
@@ -304,6 +334,14 @@ let () =
          --apply-fixes-for RULE-ID  same as --apply-fixes but only applies \
          fixes from results\n\
         \               whose [r.id = RULE-ID]. Useful for incremental \
-         adoption (v26.3).\n"
+         adoption (v26.3).\n\
+         --apply-fixes-best-effort  v26.4: applies the maximal non-conflicting \
+         subset of fixes\n\
+        \               via Cst_edit.apply_best_effort. Reports the skipped \
+         subset to stderr.\n\
+        \               Exit 0 even when some edits were skipped (the \
+         partial-fix output is the contract).\n\
+         --apply-fixes-best-effort-for RULE-ID  same as \
+         --apply-fixes-best-effort, filtered by rule id (v26.4).\n"
         Sys.argv.(0);
       exit 2

--- a/latex-parse/src/validators_l0.ml
+++ b/latex-parse/src/validators_l0.ml
@@ -1524,18 +1524,34 @@ let r_spc_008 : rule =
 (* SPC-009: Non-breaking space ~ at line start *)
 let r_spc_009 : rule =
   let run s =
-    let _, matched =
-      any_line_pred s (fun line ->
-          String.length line > 0
-          && (line.[0] = '~'
-             || String.length line >= 2
-                && Char.code line.[0] = 0xC2
-                && Char.code line.[1] = 0xA0))
-    in
-    if matched > 0 then
-      Some
-        (mk_result ~id:"SPC-009" ~severity:Warning
-           ~message:"Non‑breaking space ~ at line start" ~count:matched)
+    let matched = ref 0 in
+    let edits = ref [] in
+    iter_line_spans s (fun lstart lend ->
+        if lend > lstart then
+          if s.[lstart] = '~' then (
+            incr matched;
+            edits :=
+              Cst_edit.replace ~start_offset:lstart ~end_offset:(lstart + 1) ""
+              :: !edits)
+          else if
+            lend - lstart >= 2
+            && Char.code s.[lstart] = 0xC2
+            && Char.code s.[lstart + 1] = 0xA0
+          then (
+            incr matched;
+            edits :=
+              Cst_edit.replace ~start_offset:lstart ~end_offset:(lstart + 2) ""
+              :: !edits));
+    if !matched > 0 then
+      let fix = List.rev !edits in
+      if fix = [] then
+        Some
+          (mk_result ~id:"SPC-009" ~severity:Warning
+             ~message:"Non‑breaking space ~ at line start" ~count:!matched)
+      else
+        Some
+          (mk_result_with_fix ~id:"SPC-009" ~severity:Warning
+             ~message:"Non‑breaking space ~ at line start" ~count:!matched ~fix)
     else None
   in
   { id = "SPC-009"; run; languages = [] }
@@ -1890,27 +1906,60 @@ let r_spc_035 : rule =
   in
   { id = "SPC-035"; run; languages = [] }
 
-(* SPC-010: Two spaces after sentence-ending period *)
+(* SPC-010: Two spaces after sentence-ending period. v26.4 §1.3: fix collapses
+   the run of spaces between period and capital to a single space. Count is
+   computed on the math-stripped source (avoids flagging `\sum. X` style); fix
+   offsets are computed on the ORIGINAL source. The fix-set may target spaces
+   inside math segments too — that's acceptable: replacing two ASCII spaces with
+   one inside math is semantically a no-op (TeX collapses whitespace runs in
+   math mode). *)
 let r_spc_010 : rule =
   let re = Re_compat.regexp "\\. +[A-Z]" in
   let run s =
-    let s = strip_math_segments s in
-    let rec loop i acc =
+    let stripped = strip_math_segments s in
+    let rec count_in str i acc =
       try
-        let _mr, _ = Re_compat.search_forward re s i in
-        ignore _mr;
-        let m = Re_compat.matched_string _mr s in
+        let _mr, _ = Re_compat.search_forward re str i in
+        let m = Re_compat.matched_string _mr str in
         let nspaces = String.length m - 2 in
-        (* Only count exactly 2 spaces — 3+ is SPC-031 *)
         let acc' = if nspaces = 2 then acc + 1 else acc in
-        loop (Re_compat.match_end _mr) acc'
+        count_in str (Re_compat.match_end _mr) acc'
       with Not_found -> acc
     in
-    let cnt = loop 0 0 in
-    if cnt > 0 then
-      Some
-        (mk_result ~id:"SPC-010" ~severity:Info
-           ~message:"Sentence spacing uses two spaces after period" ~count:cnt)
+    let cnt = count_in stripped 0 0 in
+    if cnt > 0 then (
+      (* Recompute offsets on the original. Each match has shape `.
+         <run-of-spaces> <capital>`. Collapse the run to a single space by
+         deleting (run_len - 1) spaces. *)
+      let edits = ref [] in
+      let rec edits_in i =
+        try
+          let _mr, _ = Re_compat.search_forward re s i in
+          let mb = Re_compat.match_beginning _mr in
+          let me = Re_compat.match_end _mr in
+          (* mb points at '.'; spaces start at mb+1; capital at me-1. *)
+          let space_start = mb + 1 in
+          let space_end = me - 1 in
+          let nspaces = space_end - space_start in
+          if nspaces = 2 then
+            edits :=
+              Cst_edit.replace ~start_offset:(space_start + 1)
+                ~end_offset:space_end ""
+              :: !edits;
+          edits_in me
+        with Not_found -> ()
+      in
+      edits_in 0;
+      let fix = List.rev !edits in
+      if fix = [] then
+        Some
+          (mk_result ~id:"SPC-010" ~severity:Info
+             ~message:"Sentence spacing uses two spaces after period" ~count:cnt)
+      else
+        Some
+          (mk_result_with_fix ~id:"SPC-010" ~severity:Info
+             ~message:"Sentence spacing uses two spaces after period" ~count:cnt
+             ~fix))
     else None
   in
   { id = "SPC-010"; run; languages = [] }

--- a/latex-parse/src/validators_l0_typo.ml
+++ b/latex-parse/src/validators_l0_typo.ml
@@ -512,9 +512,15 @@ let r_typo_014 : rule =
   let run s =
     let cnt = count_substring s " %" in
     if cnt > 0 then
-      Some
-        (mk_result ~id:"TYPO-014" ~severity:Info
-           ~message:{|Space before percent sign \%|} ~count:cnt)
+      let fix = mk_replace_edits s " %" "%" in
+      if fix = [] then
+        Some
+          (mk_result ~id:"TYPO-014" ~severity:Info
+             ~message:{|Space before percent sign \%|} ~count:cnt)
+      else
+        Some
+          (mk_result_with_fix ~id:"TYPO-014" ~severity:Info
+             ~message:{|Space before percent sign \%|} ~count:cnt ~fix)
     else None
   in
   { id = "TYPO-014"; run; languages = [] }
@@ -625,23 +631,38 @@ let r_typo_020 : rule =
   let run _s = None in
   { id = "TYPO-020"; run; languages = [] }
 
-(* TYPO-021: Capital letter after ellipsis without space *)
+(* TYPO-021: Capital letter after ellipsis without space. v26.4 §1.3: fix
+   inserts a single space between the ellipsis and the capital letter. Both
+   `...A` and `…A` (Unicode ellipsis U+2026) get the same insertion. *)
 let r_typo_021 : rule =
   let re = Re_compat.regexp {|\(\.\.\.\|…\)[A-Z]|} in
   let run s =
     let cnt = ref 0 in
+    let edits = ref [] in
     let i = ref 0 in
     (try
        while true do
          let _mr, _ = Re_compat.search_forward re s !i in
+         let me = Re_compat.match_end _mr in
+         (* Insert a space immediately before the capital letter at me-1. *)
+         edits :=
+           Cst_edit.replace ~start_offset:(me - 1) ~end_offset:(me - 1) " "
+           :: !edits;
          incr cnt;
-         i := Re_compat.match_end _mr
+         i := me
        done
      with Not_found -> ());
     if !cnt > 0 then
-      Some
-        (mk_result ~id:"TYPO-021" ~severity:Info
-           ~message:"Capital letter after ellipsis without space" ~count:!cnt)
+      let fix = List.rev !edits in
+      if fix = [] then
+        Some
+          (mk_result ~id:"TYPO-021" ~severity:Info
+             ~message:"Capital letter after ellipsis without space" ~count:!cnt)
+      else
+        Some
+          (mk_result_with_fix ~id:"TYPO-021" ~severity:Info
+             ~message:"Capital letter after ellipsis without space" ~count:!cnt
+             ~fix)
     else None
   in
   { id = "TYPO-021"; run; languages = [] }
@@ -796,23 +817,46 @@ let r_typo_024 : rule =
   in
   { id = "TYPO-024"; run; languages = [] }
 
-(* TYPO-025: Space before en-dash in number range *)
+(* TYPO-025: Space before en-dash in number range. v26.4 §1.3: fix deletes the
+   space-run between the leading digit and the en-dash. *)
 let r_typo_025 : rule =
   let re = Re_compat.regexp {|[0-9] +\(–\|--\)[0-9]|} in
   let run s =
     let cnt = ref 0 in
+    let edits = ref [] in
     let i = ref 0 in
     (try
        while true do
          let _mr, _ = Re_compat.search_forward re s !i in
+         let mb = Re_compat.match_beginning _mr in
+         let me = Re_compat.match_end _mr in
+         (* Match shape: [0-9] [SPACE]+ (–|--) [0-9]. The leading digit is at
+            mb; spaces start at mb+1; spaces end at the dash. Walk until the
+            first non-space byte (the dash). *)
+         let space_start = mb + 1 in
+         let space_end = ref space_start in
+         while !space_end < me && s.[!space_end] = ' ' do
+           incr space_end
+         done;
+         if !space_end > space_start then
+           edits :=
+             Cst_edit.replace ~start_offset:space_start ~end_offset:!space_end
+               ""
+             :: !edits;
          incr cnt;
-         i := Re_compat.match_end _mr
+         i := me
        done
      with Not_found -> ());
     if !cnt > 0 then
-      Some
-        (mk_result ~id:"TYPO-025" ~severity:Warning
-           ~message:{|Space before en‑dash in number range|} ~count:!cnt)
+      let fix = List.rev !edits in
+      if fix = [] then
+        Some
+          (mk_result ~id:"TYPO-025" ~severity:Warning
+             ~message:{|Space before en‑dash in number range|} ~count:!cnt)
+      else
+        Some
+          (mk_result_with_fix ~id:"TYPO-025" ~severity:Warning
+             ~message:{|Space before en‑dash in number range|} ~count:!cnt ~fix)
     else None
   in
   { id = "TYPO-025"; run; languages = [] }

--- a/specs/v26/V26_4_PLAN.md
+++ b/specs/v26/V26_4_PLAN.md
@@ -1,0 +1,163 @@
+# V26.4 — Conflict-aware rewrites + apply_edits semantics + rolling fix batch
+
+**Status:** draft, 2026-04-26. Successor to `V26_3_1_PLAN.md` §5
+commitment + `V26_2_PLAN.md` §13 ("Rewrite conflict-aware merge")
+explicit deferral.
+**Scope:** the next concrete chunk of v26 substrate work past v26.3.1.
+**Cadence:** bundled cycle PR (matches v26.3.0 PR #271 + v26.3.1
+PR #279 patterns), followed by a small release-bump PR.
+
+## 0. Pre-conditions (verified 2026-04-26 on `main` `39eebde`)
+
+- `v26.3.1` tagged on the PR #280 merge commit; Release workflow
+  green; tag pushed; GitHub Release auto-published.
+- 17/17 pre-release gates PASS.
+- 1,281 theorems / 161 .v files / 0 admits / 0 axioms.
+- Differential test 0 diffs across 330 corpus files vs `v26.3.0`.
+- 9 required-checks on `main` (incl. `spec-drift`); messages-validate
+  is strict.
+- ADMISSIBILITY_MAP: only T6 + T7 remain `HYPOTHESIS-PARAMETRIC`
+  (owned by v27 WS8 via `proofs/PdflatexModel.v`); CSTRoundTrip,
+  RewritePreservesCST, and RewritePreservesSemantics Sections all
+  unconditionally discharged.
+
+## 1. Inventory of in-scope items
+
+### 1.1 Conflict-aware rewrite merging (PRIMARY ITEM)
+
+`V26_2_PLAN.md` line 631 + line 565 mandated automatic conflict-
+aware rewrite merging. v26.3 shipped strict overlap rejection
+(`Cst_edit.apply_all → Error (Overlap (a, b))`). v26.4 adds:
+
+- **`Cst_edit.apply_best_effort : string -> t list -> result`**.
+  Returns `(output, applied, skipped)`. Walks the input edit list
+  in input order; an edit is appended to `applied` iff it doesn't
+  conflict with any edit already in `applied`, otherwise it lands
+  in `skipped`. The output equals `apply_all src applied` (which
+  cannot fail by construction). Pure insertions at the same offset
+  remain compatible per the existing `conflicts` semantics.
+- **`Cst_edit.apply_with_priority : string -> (t -> int) -> t list ->
+  result`**. Sorts by descending priority (higher = applied first),
+  then dispatches to `apply_best_effort`. Useful when the caller
+  has a deterministic priority signal (e.g., severity-driven).
+- **CLI plumbing** in `validators_cli.ml`: `--apply-fixes-best-effort`
+  flag selects `apply_best_effort` over the strict `apply_all`.
+  Default (no flag) preserves the existing strict behaviour
+  (back-compat).
+- **Tests** (`test_cst_edit.ml` extension): no-conflict input ≡
+  apply_all; two conflicting edits → first wins; deduplicated
+  insertions preserved; apply_with_priority orders correctly;
+  output equals apply_all on the applied subset.
+
+This is the v26.4 cycle's primary deliverable. Estimated ~150 LoC
+OCaml + 50 LoC test, single session.
+
+### 1.2 Stronger `apply_edits` semantics (Coq, optional stretch)
+
+`proofs/RewritePreservesCST.v`'s `apply_edits_concrete` was shipped
+in v26.3 (item D). Beyond byte-losslessness, two additional theorems
+strengthen the runtime guarantee:
+
+- **`apply_one_edit_byte_count`**: `length (apply_one_edit src e) =
+  length src + delta e` where `delta e := length e.replacement -
+  (e.e_end - e.e_start)`. Mechanical (induction on `take`/`drop`).
+- **`apply_edits_concrete_associative_subset`**: the result of
+  `apply_edits_concrete` over a NON-OVERLAPPING list is invariant
+  under any reordering of the input (folded application commutes
+  in the absence of conflicts). This requires a `non_overlapping`
+  predicate on the edit list (similar to OCaml's `validate_non_
+  overlapping`); restricted to that subset, fold-order doesn't matter.
+
+Optional within v26.4 if §1.1 lands cleanly. If §1.2 turns out
+non-trivial, defer to v26.4.1 / v26.5.
+
+### 1.3 Rolling fix-producer batch (10 more rules, PRIMARY ITEM)
+
+Continuation of `V26_3_1_PLAN.md` §1.1's rolling work.
+Candidates (mechanical, no NLP needed):
+
+1. `TYPO-014` — Space before percent sign → strip the space.
+2. `SPC-006` — Indentation mixes spaces and tabs after tabs → normalise.
+3. `STRUCT-003` — Tab characters in source → 4-space replacement
+   (companion of TYPO-006; already covered by TYPO-006's fix when
+   STRUCT-003 fires; document the alias rather than emit duplicates).
+4. `TYPO-031` (depending on rule body — to be triaged at impl time).
+5. `TYPO-032` — TBD.
+6-10. Additional candidates triaged at implementation time. The
+batch picks the 10 with the cleanest deterministic-fix logic.
+
+Total fix-producing rules after v26.4: **33** (was 23 at v26.3.1).
+~627 rules remain, ongoing rolling work into v26.5+.
+
+## 2. Non-goals
+
+- **L3 AST migration** (`docs/L3_ROADMAP.md`) — multi-month, defer
+  to v26.5 / v27.
+- **T6/T7 discharge against `PdflatexModel.v`** — v27 WS8.
+- **More than 10 fix producers** in §1.3 — batch-size discipline.
+- **Removing strict `apply_all`** — back-compat: callers that want
+  the old strict semantics keep them.
+- **Full edit-list reorderable proof** — only the bounded subset
+  in §1.2 if it lands.
+
+## 3. PR slate
+
+Bundled cycle PR (matches v26.3.0 PR #271 + v26.3.1 PR #279
+patterns).
+
+### PR #1 — bundled cycle PR
+
+Branch `v26.4/cycle`. Logical commits:
+
+1. `V26_4_PLAN.md` — this plan file.
+2. **Conflict-aware merging**: `cst_edit.{ml,mli}` + tests
+   (§1.1).
+3. **Stronger Coq semantics** (only if §1.2 is tractable in
+   this session).
+4. **10 fix producers + tests** (§1.3).
+
+### PR #2 — release-bump for v26.4.0
+
+Mirrors v26.3.1 PR #280: small chore PR bumps version metadata,
+regenerates governance, lands new CHANGELOG entry. Tag created
+on `main` after merge.
+
+## 4. Gates
+
+No new pre-release gate is added in v26.4. The 17 existing gates
+cover the new code paths via the §1.1 tests being wired into
+`dune runtest` and the §1.3 fix producers being absorbed by
+`test_typo_fix.ml` / `test_rule_fix_integration.ml`.
+
+Total at v26.4.0 tag: **17 pre-release gates** (unchanged).
+
+## 5. Out-of-cycle commitments
+
+Items deferred from §2 each open their own scoped plan files:
+- `V26_5_PLAN.md` if rolling fix-producer cadence continues.
+- `V27_WS8_PLAN.md` when v27 WS8 begins (T6/T7 discharge against
+  `proofs/PdflatexModel.v`).
+- `docs/L3_ROADMAP.md` is the existing plan for L3 AST migration.
+
+## 6. Differential-test budget
+
+`run_differential_test.py` against `v26.3.1` is expected to show:
+
+- **0 diffs** on the default invocation (no `--apply-fixes`).
+- The `apply_best_effort` mode is opt-in via
+  `--apply-fixes-best-effort`. The strict `--apply-fixes` mode
+  preserves existing behaviour, so corpus-driven differential
+  output is unchanged.
+- The 10 new fix producers contribute additional fix edits in
+  `result.fix` for inputs that trigger them, but the default
+  emission stream is unchanged.
+
+The PR description must declare any deviation explicitly with a
+reason.
+
+## 7. First concrete action
+
+This file is created on branch `v26.4/cycle`. The next commit on
+that branch is `Cst_edit.apply_best_effort` (§1.1). Subsequent
+commits land §1.3 (fix producers); §1.2 lands only if completed
+in-session, otherwise reserved for a follow-up cycle.


### PR DESCRIPTION
## Summary

Opens the v26.4 cycle. Bundled-cycle PR (matches v26.3.0 PR #271 + v26.3.1 PR #279).

**Two commits:**

1. **`specs/v26/V26_4_PLAN.md`** — Successor plan to `V26_3_1_PLAN.md` §5. Scope: conflict-aware rewrite merging (primary), stronger `apply_edits` Coq semantics (optional stretch), 10 more rolling fix producers (primary).

2. **Conflict-aware rewrite merging** (§1.1 of the plan):
   - `Cst_edit.apply_best_effort : string -> t list -> string * t list * t list` — greedy first-occurrence-wins, returns `(output, applied, skipped)`. Output equals `apply_all` over `applied` (cannot fail by construction).
   - `Cst_edit.apply_with_priority : string -> (t -> int) -> t list -> ...` — stable-sort by descending priority, then dispatch to `apply_best_effort`.
   - CLI plumbing: `--apply-fixes-best-effort` and `--apply-fixes-best-effort-for RULE-ID`. The strict `--apply-fixes` mode is preserved (back-compat); its overlap error message now hints at the new flag.
   - 7 new `test_cst_edit.ml` cases (no-conflict; first-wins; same-offset insertions; third-edit conflict; priority dominates; equal-priority input order tiebreak; agrees with `apply_all` on disjoint input). Total: 25 cases (was 18).

## Verification
- `dune build` clean (no warnings).
- `dune runtest latex-parse/src` — every suite green.
- `pre_release_check.py --skip-build` — 17/17 PASS.
- CLI smoke on a clean source — exit 0, output unchanged from default.

## Followups in this cycle
- 10 more fix producers (§1.3 of the plan).
- Stronger `apply_edits` Coq theorems (§1.2, optional).
- v26.4.0 release-bump PR.

## Test plan
- [x] 17/17 pre-release gates locally
- [x] 25/25 cst_edit test cases pass
- [ ] CI: required-checks all green
- [ ] CI: spec-drift workflow green