### PR TITLE
feat(v27 WS8 Stage 1): plan + PdflatexModel scaffold (v26.5/cycle PR #1)

### DIFF
--- a/_CoqProject
+++ b/_CoqProject
@@ -79,3 +79,4 @@ proofs/SplitPreservesOrder.v
 -arg -w -arg -redundant-canonical-projection
 proofs/CSTRoundtripConcrete.v
 proofs/RewritePreservesSemanticsConcrete.v
+proofs/PdflatexModel.v

--- a/proofs/ADMISSIBILITY_MAP.md
+++ b/proofs/ADMISSIBILITY_MAP.md
@@ -72,7 +72,19 @@ header.
 **WS8 discharge:** no new work — all v26.2 Error-level rules have
 per-rule QEDs (see `rule_contracts.yaml` / `proofs/generated/`).
 
-### T6 — Compilation progress (HYPOTHESIS-PARAMETRIC)
+### T6 — Compilation progress (HYPOTHESIS-PARAMETRIC, v27 WS8 Stage 1 in flight)
+
+> **v26.5.0 / v27 WS8 Stage 1 STATUS.** `proofs/PdflatexModel.v`
+> instantiates the Section against concrete pdflatex carriers
+> (`pdflatex_project := build_graph`,
+> `pdflatex_profile := { engine; features }`) and ties T2 + T3 to
+> their existing concrete predicates (`project_closed`,
+> `profile_admits`). T0, T1, T4, T5 use `True` placeholders that
+> Stages 2–3 refine. The `compile_progress_rule` Hypothesis is
+> closed against the placeholders (trivially Qed-able for `True`
+> predicates); a substantive discharge against a concrete
+> pdflatex pass-iteration model lands in Stage 3 per
+> `specs/v27/V27_WS8_PLAN.md` §1 Stage 3.
 
 **File:** `proofs/CompileProgress.v`.
 **Section variables:**
@@ -109,7 +121,15 @@ per-rule QEDs (see `rule_contracts.yaml` / `proofs/generated/`).
 **Consumers:** `CompileWellFormed.v` (T7) takes `T6_compile_succeeds` as
 its premise.
 
-### T7 — Output well-formedness (HYPOTHESIS-PARAMETRIC)
+### T7 — Output well-formedness (HYPOTHESIS-PARAMETRIC, v27 WS8 Stage 1 in flight)
+
+> **v26.5.0 / v27 WS8 Stage 1 STATUS.** `proofs/PdflatexModel.v`
+> instantiates the Section against concrete pdflatex carriers and
+> a placeholder `pdflatex_artefact := list nat`; Stage 4 refines
+> to `pdf_artefact + log_artefact`. The `output_wellformed_rule`
+> Hypothesis is closed against the Stage-1 placeholders; a
+> substantive discharge using `valid_pdf_graph` and `log_no_fatal`
+> lands in Stage 5 per `specs/v27/V27_WS8_PLAN.md` §1 Stage 5.
 
 **File:** `proofs/CompileWellFormed.v`.
 **Section variables:**

--- a/proofs/PdflatexModel.v
+++ b/proofs/PdflatexModel.v
@@ -1,0 +1,283 @@
+(** * PdflatexModel — v27 WS8 discharge target (Stage 1: scaffold).
+
+    Per [proofs/ADMISSIBILITY_MAP.md] + `specs/v27/V27_WS8_PLAN.md`,
+    this file's mission is to instantiate the [Compile_progress] and
+    [Output_wellformed] Sections (in [CompileProgress.v] /
+    [CompileWellFormed.v]) against a concrete pdflatex toolchain
+    model, ultimately discharging both load-bearing hypotheses
+    ([compile_progress_rule] + [output_wellformed_rule]) and
+    producing an unconditional [pdflatex_compile_safe] theorem.
+
+    **Stage 1 (this commit, v26.5.0).**
+    Defines concrete carrier types and predicate instantiations,
+    invokes the upstream Sections with those instantiations, and
+    derives parametric-only-in-the-load-bearing-hypothesis variants.
+    T2 and T3 are tied to the EXISTING concrete predicates from
+    [ProjectClosure.v] / [BuildProfileSound.v]; T0, T1, T4, T5 use
+    [True] placeholders that Stages 2–5 refine to non-trivial claims
+    (per the plan's per-stage decomposition).
+
+    The Stage 1 top-level theorems
+    ([pdflatex_T6_modulo_compile_progress_rule],
+     [pdflatex_T7_modulo_output_wellformed_rule]) are strictly
+    stronger than the upstream Section's parametric form: they
+    bake in the concrete carriers + concrete T0–T5 instantiations,
+    leaving only the two load-bearing rules as parametric. v27 WS8
+    Stages 3 + 5 discharge those rules; Stage 6 closes
+    [pdflatex_compile_safe] unconditionally.
+
+    Zero admits, zero axioms (maintained throughout the staging). *)
+
+From Coq Require Import List Bool Arith.
+From LaTeXPerfectionist Require Import
+  ProjectClosure
+  BuildProfileSound
+  CompileProgress
+  CompileWellFormed.
+Import ListNotations.
+
+(** ── Concrete carriers ────────────────────────────────────────────── *)
+
+(** A pdflatex project is a build graph. Stage 1 reuses the existing
+    [ProjectClosure.build_graph] type; Stage 4 may extend with
+    artefact-specific metadata. *)
+Definition pdflatex_project : Type := build_graph.
+
+(** A pdflatex profile bundles an engine choice and a feature set.
+    Reuses [BuildProfileSound]'s [engine] and [feature] types. *)
+Record pdflatex_profile := mk_pdflatex_profile {
+  prof_engine : engine;
+  prof_features : list feature;
+}.
+
+(** Stage 1: artefact carrier is opaque (a placeholder byte stream).
+    Stage 4 refines to [pdf_artefact + log_artefact]. *)
+Definition pdflatex_artefact : Type := list nat.
+
+(** ── T0–T5 predicate instantiations ───────────────────────────────── *)
+
+(** T0 — parser acceptance.
+    Stage 1: trivially accepts every pdflatex_project (placeholder).
+    Stage 2 refines to: every Tex node in the build graph has a
+    parse-witness via [T0_wrapper.T0_parser_accepts]. *)
+Definition pdflatex_T0_accepts (_ : pdflatex_project) : Prop := True.
+
+(** T1 — expansion admissibility.
+    Stage 1: trivially admits.
+    Stage 2 refines to: the user macro registry is acyclic per
+    [T1_wrapper.T1_expansion_admissible_merge]. *)
+Definition pdflatex_T1_admissible (_ : pdflatex_project) : Prop := True.
+
+(** T2 — project closure. **CONCRETE** — uses
+    [ProjectClosure.project_closed]. *)
+Definition pdflatex_T2_closed (p : pdflatex_project) : Prop :=
+  project_closed p.
+
+(** T3 — profile admissibility. **CONCRETE** — uses
+    [BuildProfileSound.profile_admits], threading the profile's
+    feature list and engine. *)
+Definition pdflatex_T3_compatible (_ : pdflatex_project)
+    (pf : pdflatex_profile) : Prop :=
+  profile_admits pf.(prof_features) pf.(prof_engine).
+
+(** T4 — semantic coherence.
+    Stage 1: trivially coherent.
+    Stage 2 refines to: labels-unique via
+    [T4_wrapper.T4_labels_unique_packaged]. *)
+Definition pdflatex_T4_coherent (_ : pdflatex_project) : Prop := True.
+
+(** T5 — rule safety.
+    Stage 1: trivially safe.
+    Stage 2 refines to: every deployed Error-level rule QEDs
+    against the project's emitted spans. *)
+Definition pdflatex_T5_safe (_ : pdflatex_project) : Prop := True.
+
+(** ── Toolchain predicates (Stage 1 placeholders) ─────────────────── *)
+
+(** Bound on pdflatex pass count.
+    Stage 1: [True] placeholder.
+    Stage 2 introduces a concrete [pdflatex_pass_state] Fixpoint and
+    proves a 5-pass termination bound. *)
+Definition pdflatex_bounded_terminates
+    (_ : pdflatex_project) (_ : pdflatex_profile) : Prop := True.
+
+(** Compilation success — pdflatex exits cleanly with no fatal log.
+    Stage 1: [True] placeholder.
+    Stage 2 refines to [clean_exit /\ no_fatal_in_log]. *)
+Definition pdflatex_compilation_succeeds
+    (_ : pdflatex_project) (_ : pdflatex_profile) : Prop := True.
+
+(** ── Stage 1 partial discharge of the parametric Sections ────────── *)
+
+(** Apply [CompileProgress.Section_Compile_progress] with the
+    concrete pdflatex instantiations. The Section closure produces
+    a theorem parametric ONLY in [compile_progress_rule] — concretely:
+
+    [forall (rule : <type-of-compile_progress_rule>) ...
+     (T0..T5 + bounded → succeeds for the pdflatex carriers)]
+
+    Stage 3 will discharge [rule] as a Qed-proved lemma; this commit
+    just exposes the instantiated theorem skeleton. *)
+Theorem pdflatex_T6_modulo_compile_progress_rule :
+  (forall (p : pdflatex_project) (pf : pdflatex_profile),
+     pdflatex_T0_accepts p ->
+     pdflatex_T1_admissible p ->
+     pdflatex_T2_closed p ->
+     pdflatex_T3_compatible p pf ->
+     pdflatex_T4_coherent p ->
+     pdflatex_T5_safe p ->
+     pdflatex_bounded_terminates p pf ->
+     pdflatex_compilation_succeeds p pf) ->
+  forall (p : pdflatex_project) (pf : pdflatex_profile),
+    pdflatex_T0_accepts p ->
+    pdflatex_T1_admissible p ->
+    pdflatex_T2_closed p ->
+    pdflatex_T3_compatible p pf ->
+    pdflatex_T4_coherent p ->
+    pdflatex_T5_safe p ->
+    pdflatex_bounded_terminates p pf ->
+    pdflatex_compilation_succeeds p pf.
+Proof.
+  intros rule.
+  exact (T6_compile_progress_under_bound
+           pdflatex_project pdflatex_profile
+           pdflatex_T0_accepts
+           pdflatex_T1_admissible
+           pdflatex_T2_closed
+           pdflatex_T3_compatible
+           pdflatex_T4_coherent
+           pdflatex_T5_safe
+           pdflatex_bounded_terminates
+           pdflatex_compilation_succeeds
+           rule).
+Qed.
+
+(** Stage 1 also exposes a *trivial* discharge that closes T6
+    unconditionally for the placeholder predicates. This is honest
+    only because T0–T5 + bounded + succeeds are all [True]; once
+    Stages 2/3 refine to substantive predicates, the discharge will
+    require real proof content (which Stage 3 supplies). *)
+Theorem pdflatex_compile_progress_rule_trivial :
+  forall (p : pdflatex_project) (pf : pdflatex_profile),
+    pdflatex_T0_accepts p ->
+    pdflatex_T1_admissible p ->
+    pdflatex_T2_closed p ->
+    pdflatex_T3_compatible p pf ->
+    pdflatex_T4_coherent p ->
+    pdflatex_T5_safe p ->
+    pdflatex_bounded_terminates p pf ->
+    pdflatex_compilation_succeeds p pf.
+Proof.
+  intros p pf _ _ _ _ _ _ _.
+  unfold pdflatex_compilation_succeeds. exact I.
+Qed.
+
+(** Stage 1 unconditional T6 (with placeholder predicates).
+    Stage 2/3 will REPLACE this with a substantive discharge that
+    uses concrete [pdflatex_step] iteration semantics. *)
+Theorem pdflatex_T6_stage1 :
+  forall (p : pdflatex_project) (pf : pdflatex_profile),
+    pdflatex_T0_accepts p ->
+    pdflatex_T1_admissible p ->
+    pdflatex_T2_closed p ->
+    pdflatex_T3_compatible p pf ->
+    pdflatex_T4_coherent p ->
+    pdflatex_T5_safe p ->
+    pdflatex_bounded_terminates p pf ->
+    pdflatex_compilation_succeeds p pf.
+Proof.
+  exact (pdflatex_T6_modulo_compile_progress_rule
+           pdflatex_compile_progress_rule_trivial).
+Qed.
+
+(** ── T7 instantiation — Stage 1 ──────────────────────────────────── *)
+
+(** Produce-relation: Stage 1 placeholder (every project produces
+    every artefact). Stage 4 refines to a concrete tying based on
+    pdflatex_step output. *)
+Definition pdflatex_produces
+    (_ : pdflatex_project) (_ : pdflatex_profile)
+    (_ : pdflatex_artefact) : Prop := True.
+
+(** Output well-formedness predicate. Stage 1 placeholder.
+    Stage 4 refines to [valid_pdf_graph \/ log_no_fatal]. *)
+Definition pdflatex_output_format_well_formed
+    (_ : pdflatex_artefact) : Prop := True.
+
+(** Apply [CompileWellFormed.Section_Output_wellformed] with the
+    pdflatex instantiations. Parametric in [output_wellformed_rule];
+    Stage 5 discharges. *)
+Theorem pdflatex_T7_modulo_output_wellformed_rule :
+  (forall (p : pdflatex_project) (pf : pdflatex_profile)
+          (out : pdflatex_artefact),
+     pdflatex_compilation_succeeds p pf ->
+     pdflatex_produces p pf out ->
+     pdflatex_output_format_well_formed out) ->
+  forall (p : pdflatex_project) (pf : pdflatex_profile)
+         (out : pdflatex_artefact),
+    pdflatex_compilation_succeeds p pf ->
+    pdflatex_produces p pf out ->
+    pdflatex_output_format_well_formed out.
+Proof.
+  intros rule.
+  exact (T7_output_wellformed
+           pdflatex_project pdflatex_profile pdflatex_artefact
+           pdflatex_compilation_succeeds
+           pdflatex_produces
+           pdflatex_output_format_well_formed
+           rule).
+Qed.
+
+Theorem pdflatex_output_wellformed_rule_trivial :
+  forall (p : pdflatex_project) (pf : pdflatex_profile)
+         (out : pdflatex_artefact),
+    pdflatex_compilation_succeeds p pf ->
+    pdflatex_produces p pf out ->
+    pdflatex_output_format_well_formed out.
+Proof.
+  intros p pf out _ _.
+  unfold pdflatex_output_format_well_formed. exact I.
+Qed.
+
+Theorem pdflatex_T7_stage1 :
+  forall (p : pdflatex_project) (pf : pdflatex_profile)
+         (out : pdflatex_artefact),
+    pdflatex_compilation_succeeds p pf ->
+    pdflatex_produces p pf out ->
+    pdflatex_output_format_well_formed out.
+Proof.
+  exact (pdflatex_T7_modulo_output_wellformed_rule
+           pdflatex_output_wellformed_rule_trivial).
+Qed.
+
+(** ── Stage 1 capstone: the parametric pdflatex_compile_safe ─────── *)
+
+(** With Stage 1 placeholders, the compile-safe theorem closes
+    trivially. Stages 2–6 substitute substantive predicates and
+    rebuild this theorem against them; the final v27.0.0
+    [pdflatex_compile_safe] will replace this with the discharged
+    unconditional version against concrete pass-iteration semantics. *)
+Theorem pdflatex_compile_safe_stage1 :
+  forall (p : pdflatex_project) (pf : pdflatex_profile)
+         (out : pdflatex_artefact),
+    pdflatex_T0_accepts p ->
+    pdflatex_T1_admissible p ->
+    pdflatex_T2_closed p ->
+    pdflatex_T3_compatible p pf ->
+    pdflatex_T4_coherent p ->
+    pdflatex_T5_safe p ->
+    pdflatex_bounded_terminates p pf ->
+    pdflatex_produces p pf out ->
+    pdflatex_compilation_succeeds p pf /\
+    pdflatex_output_format_well_formed out.
+Proof.
+  intros p pf out H0 H1 H2 H3 H4 H5 Hbound Hproduces.
+  assert (Hsucc : pdflatex_compilation_succeeds p pf)
+    by (apply pdflatex_T6_stage1; assumption).
+  split.
+  - exact Hsucc.
+  - apply (pdflatex_T7_stage1 p pf out Hsucc Hproduces).
+Qed.
+
+(** ── Zero-admit witness ──────────────────────────────────────────── *)
+Definition pdflatex_model_stage1_zero_admits : True := I.

--- a/specs/v27/V27_WS8_PLAN.md
+++ b/specs/v27/V27_WS8_PLAN.md
@@ -1,0 +1,236 @@
+# V27 WS8 — Discharge T6 / T7 against `proofs/PdflatexModel.v`
+
+**Status:** draft, 2026-04-27. Successor to `V26_4_PLAN.md` §5
+commitment + `proofs/ADMISSIBILITY_MAP.md` "v27 WS8 discharge
+checklist".
+**Scope:** flip the last two `HYPOTHESIS-PARAMETRIC` entries in
+`ADMISSIBILITY_MAP.md` (T6 `compile_progress_rule` and T7
+`output_wellformed_rule`) to `DISCHARGED`, producing an unconditional
+`PdflatexModel.pdflatex_compile_safe` theorem with `Qed`.
+**Cadence:** **multi-session** (this is genuine multi-week formal-
+verification work — see `V27_REPO_EXACT_MASTER_SPEC.md` §9 timeline,
+WS8 in Phase 2). Memory carries state across sessions per the
+project's auto-memory convention; each session ships a tagged
+release if practical.
+
+## 0. Pre-conditions (verified 2026-04-27 on `main` `7b9a766`)
+
+- `v26.4.0` tagged; cycle PRs #281–#284 merged.
+- 17/17 pre-release gates PASS.
+- 1,291 theorems / 161 .v files / 0 admits / 0 axioms.
+- `proofs/ADMISSIBILITY_MAP.md` has only T6 + T7 still
+  `HYPOTHESIS-PARAMETRIC`; CSTRoundTrip / RewritePreservesCST /
+  RewritePreservesSemantics all unconditionally discharged in
+  v26.3/v26.3.1/v26.4.
+- `proofs/CompileProgress.v` (135 lines, T6 Section) and
+  `proofs/CompileWellFormed.v` (97 lines, T7 Section) are stable
+  per `docs/v26_2/adr/ADR-004-hypothesis-parametric-t6-t7.md` and
+  exporters' tests.
+- T0–T5 wrappers exist (`T0_wrapper.v`, `T1_wrapper.v`,
+  `ProjectClosure.v`, `BuildProfileSound.v`, `T4_wrapper.v`,
+  `T5_wrapper.v`); each provides at least the trivial discharge
+  witness, several have substantive supporting theorems.
+
+## 1. Multi-session roadmap
+
+The discharge decomposes into six numbered stages. Each stage is
+sized to fit a single working session and lands a tagged release
+when its content is closed. Memory at each session boundary
+captures: (a) what's done, (b) what's next, (c) what local
+state-of-mind is needed to resume.
+
+### Stage 1 (THIS cycle, target tag v26.5.0)
+
+**Deliverables:**
+- `specs/v27/V27_WS8_PLAN.md` — this file.
+- `proofs/PdflatexModel.v` — carriers + T0–T5 predicate
+  instantiations + invocation of `CompileProgress.Section` and
+  `CompileWellFormed.Section` with concrete arguments.
+  Section closure still leaves `compile_progress_rule` and
+  `output_wellformed_rule` as `Hypothesis` arguments, so the
+  Stage 1 top-level theorems are **PARAMETRIC ONLY in those two
+  hypotheses** — strictly stronger than the upstream Section's
+  parametric form.
+- `proofs/ADMISSIBILITY_MAP.md` annotations updated: T6 and T7
+  entries note "Stage 1 scaffolded in v26.5.0 / `PdflatexModel.v`;
+  full discharge in v27.0.0 final".
+- `_CoqProject` registers the new file.
+- 0 admits / 0 axioms maintained.
+- Stage 1 fits in a single session.
+
+### Stage 2 (next session, target tag v27.0.0-alpha1)
+
+**Deliverables:**
+- `proofs/PdflatexModel.v` extended with a concrete pass-iteration
+  model:
+  - `Record pdflatex_pass_state := { pass_count : nat; aux_state :
+    aux_image; log_state : log_image; converged : bool }`.
+  - `Definition pdflatex_step : pdflatex_pass_state ->
+    pdflatex_pass_state` — one pass.
+  - `Theorem pdflatex_pass_count_bounded :
+      forall s, exists k, k <= 5 /\
+      pdflatex_pass_state_after_k_steps s k = converged_state`.
+  This is the `bounded_build_terminates_for` discharge content.
+- T6 stage-2 progress: PdflatexModel exposes `pdflatex_bounded_terminates`
+  as a Qed-proved lemma; the parametric `compile_progress_rule` from
+  Stage 1 starts taking concrete shape.
+
+### Stage 3 (T6 capstone, target tag v27.0.0-alpha2)
+
+**Deliverables:**
+- `Lemma pdflatex_compile_progress_rule_proof :
+    forall p pf, T0_accepts p -> ... -> bounded_terminates p pf ->
+    compilation_succeeds p pf.`
+  Proof: induction on `pass_count`. Each pass either advances
+  (`converged := false`) or stops (`converged := true`); at
+  convergence, T5 (rule safety) + T0–T4 imply no fatal error
+  surfaces in the log image; therefore `compilation_succeeds`
+  (defined in Stage 2 as `clean_exit /\ no_fatal_in_log`) holds.
+- Apply this lemma to discharge `compile_progress_rule`.
+- ADMISSIBILITY_MAP: T6 flipped to `DISCHARGED`.
+
+### Stage 4 (artefact wellformedness predicates, target tag v27.0.0-alpha3)
+
+**Deliverables:**
+- `Inductive pdf_artefact := mk_pdf { pdf_objects : list pdf_object;
+    pdf_xref : list nat; pdf_trailer : trailer_record }.`
+- `Definition valid_pdf_graph : pdf_artefact -> Prop` — every object
+  reference resolves; `xref` and `trailer` are mutually consistent.
+- `Definition log_artefact := list nat.`
+- `Definition log_no_fatal : log_artefact -> Prop` — no fatal-marker
+  byte sequence appears.
+- `Definition produces : pdflatex_project -> pdflatex_profile ->
+    pdflatex_artefact -> Prop` — concrete tying to the pdflatex_step
+    model from Stage 2.
+
+### Stage 5 (T7 capstone, target tag v27.0.0-alpha4)
+
+**Deliverables:**
+- `Lemma pdflatex_output_wellformed_rule_proof :
+    forall p pf out,
+      pdflatex_T6_compile_succeeds p pf ->
+      produces p pf out ->
+      output_format_well_formed out.`
+  Proof: case-split on `out`'s artefact tag (PDF / LOG); for PDF,
+  Stage 4's xref/trailer consistency invariants are preserved by
+  pdflatex_step; for LOG, no fatal markers (Stage 3 conclusion).
+- Apply this lemma to discharge `output_wellformed_rule`.
+- ADMISSIBILITY_MAP: T7 flipped to `DISCHARGED`.
+
+### Stage 6 (capstone + release, target tag v27.0.0)
+
+**Deliverables:**
+- `Theorem pdflatex_compile_safe :
+    forall p pf,
+      project_well_typed p ->
+      profile_supported pf ->
+      exists out,
+        produces p pf out /\
+        compilation_succeeds p pf /\
+        output_format_well_formed out.`
+  Final unconditional theorem. Closes the entire compile-guarantee
+  stack.
+- `proofs/ADMISSIBILITY_MAP.md`: every `HYPOTHESIS-PARAMETRIC`
+  annotation removed; v27 WS8 discharge checklist all checked.
+- `docs/COMPILATION_GUARANTEE.md`: "v27 scope" boxes flipped to
+  "now proved for pdflatex".
+- `CHANGELOG.md`: `[v27.0.0]` entry lists the unconditional
+  theorems and any bounded-pass constants used.
+- Tag v27.0.0.
+
+## 2. Carriers + their instantiations
+
+Per `proofs/CompileProgress.v::Section Compile_progress` and
+`proofs/CompileWellFormed.v::Section Output_wellformed`, the
+Section parameters and their PdflatexModel instantiations are:
+
+| Section variable | PdflatexModel instantiation | Defined in |
+|---|---|---|
+| `Project : Type` | `pdflatex_project` (alias of `ProjectClosure.build_graph`) | Stage 1 |
+| `Profile : Type` | `pdflatex_profile` (record bundling `engine` + `list feature`) | Stage 1 |
+| `Artefact : Type` | `pdflatex_artefact` (sum of `pdf_artefact + log_artefact`) | Stage 4 |
+| `T0_accepts` | `T0_wrapper.parser_accepts` (already trivial Qed in v26.2) | Stage 1 |
+| `T1_admissible` | `T1_wrapper.expansion_admissible` (already Qed) | Stage 1 |
+| `T2_closed` | `ProjectClosure.project_closed` | Stage 1 |
+| `T3_compatible` | `BuildProfileSound.profile_admits` | Stage 1 |
+| `T4_coherent` | `T4_wrapper.labels_unique` | Stage 1 |
+| `T5_safe` | `T5_wrapper.rule_safe_predicate` | Stage 1 |
+| `bounded_build_terminates_for` | `pdflatex_bounded_terminates` (proved in Stage 2) | Stage 2 |
+| `compilation_succeeds` | `pdflatex_clean_exit /\ pdflatex_log_no_fatal` | Stage 2 |
+| `compile_progress_rule` | discharged as `pdflatex_compile_progress_rule_proof` | **Stage 3** |
+| `T6_compile_succeeds` | `pdflatex_compile_succeeds` (= compilation_succeeds) | Stage 4 |
+| `produces` | `pdflatex_produces` (concrete tying to `pdflatex_step`) | Stage 4 |
+| `output_format_well_formed` | `valid_pdf_graph \/ log_no_fatal` | Stage 4 |
+| `output_wellformed_rule` | discharged as `pdflatex_output_wellformed_rule_proof` | **Stage 5** |
+
+## 3. Memory protocol
+
+Each stage's session ends by writing a memory entry describing:
+
+1. **What's done** — concrete file:line markers for the new
+   theorems and definitions, with each Qed listed.
+2. **What's next** — the next stage's first concrete action.
+3. **Local state-of-mind** — proof obligations open, notation
+   choices made, any pitfalls encountered (e.g., dependent-type
+   issues, opam install flakes that affected the build).
+4. **Verification numbers** — theorem count delta, gate state.
+
+Stage 1's memory entry is written at the end of THIS session.
+Stages 2–6 each open with reading the memory + their predecessor's
+entry, and close with their own entry.
+
+The cross-session continuity rule:
+
+> Memory carries state. Sessions are stateless. Each session's
+> first concrete action is `git pull origin main && dune build &&
+> read proofs/ADMISSIBILITY_MAP.md && read this plan file +
+> v27_ws8_status.md`.
+
+## 4. ADMISSIBILITY_MAP discharge checklist (replicated for tracking)
+
+Per `proofs/ADMISSIBILITY_MAP.md` v27 WS8 section:
+
+- [ ] `proofs/PdflatexModel.v` created — Stage 1
+- [ ] `pdflatex_project / profile / artefact` types defined —
+      Stages 1 + 4
+- [ ] Each T0–T5 predicate instantiated — Stage 1
+- [ ] `bounded_build_terminates_for := pdflatex_passes_bounded`
+      proved — Stage 2
+- [ ] `compile_progress_rule` discharged as theorem — **Stage 3**
+- [ ] `output_format_well_formed := valid_pdf_graph` defined —
+      Stage 4
+- [ ] `output_wellformed_rule` discharged — **Stage 5**
+- [ ] `pdflatex_compile_safe` shipped with Qed — Stage 6
+- [ ] `proofs/ADMISSIBILITY_MAP.md` updated — Stage 6
+- [ ] `docs/COMPILATION_GUARANTEE.md` updated — Stage 6
+- [ ] `CHANGELOG.md` `[v27.0.0]` entry — Stage 6
+
+## 5. Acceptance criteria for v27.0.0 (the WS8 capstone)
+
+- All 17 pre-release gates green (no new gate; the existing
+  proof-ci gate covers the new theorems).
+- 0 admits / 0 axioms maintained (hard gate).
+- `proofs/ADMISSIBILITY_MAP.md` contains zero `HYPOTHESIS-PARAMETRIC`
+  annotations.
+- `pdflatex_compile_safe` is a Qed-closed theorem with a
+  fully-named hypothesis-free signature.
+- `docs/COMPILATION_GUARANTEE.md` mentions "unconditional for
+  pdflatex".
+- Theorem count is ≥ 1,400 (estimated +110 from Stages 2–6
+  combined; Stage 1 alone adds ~30).
+- Differential test 0 diffs (no runtime change).
+
+## 6. First concrete action — Stage 1, this session
+
+This file is being created on branch `v26.5/cycle`. The next commit
+on that branch is `proofs/PdflatexModel.v` Stage 1. After it lands,
+the cycle continues with rolling fix producers (§7) and ends at the
+v26.5.0 release-bump PR.
+
+## 7. Stage-1 cycle byproduct: small fix-producer batch
+
+While Stage 1 is the headline of the v26.5.0 cycle, the cycle also
+ships a small rolling-fix-producer batch (3–5 rules) — primarily
+the §1.3 leftover candidates from `V26_4_PLAN.md` that turned out
+tractable. Per the established pattern, fix producers are bounded
+incremental work and don't compete with the WS8 staging.


### PR DESCRIPTION
## Summary

Opens the v27 WS8 multi-session discharge per the plan committed in this PR. Stage 1 lands the scaffold; Stages 2-6 follow across multiple sessions per the memory-driven continuity protocol documented in `specs/v27/V27_WS8_PLAN.md` §3 + `~/.claude/.../memory/v27_ws8_status.md`.

## What's in this PR

- **`specs/v27/V27_WS8_PLAN.md`** — full 6-stage roadmap (~210 LoC). Each stage sized for a single session, with explicit deliverables, verification numbers, and cross-session memory-handoff protocol.
- **`proofs/PdflatexModel.v`** — Stage 1 scaffold (~290 LoC, 7 new theorems, 0 admits / 0 axioms):
  - Concrete carriers: `pdflatex_project := build_graph`, `pdflatex_profile := { engine; features }`, `pdflatex_artefact := list nat` (Stage 4 refines).
  - T2 + T3 tied to existing CONCRETE predicates (`project_closed`, `profile_admits`).
  - T0, T1, T4, T5 use `True` placeholders (Stage 2 refines).
  - `compile_progress_rule` and `output_wellformed_rule` discharged trivially (Stage 1's True-predicate degenerate discharge).
  - Section closure produces `pdflatex_T6_stage1`, `pdflatex_T7_stage1`, and `pdflatex_compile_safe_stage1` — placeholder-grade unconditional theorems that Stages 2-6 refine.
- **`proofs/ADMISSIBILITY_MAP.md`** — T6 + T7 entries annotated with Stage 1 status + the stage-by-stage refinement plan.
- **`_CoqProject`** — registers PdflatexModel.v.

## Honest disclaimer (replicated in file header)

Stage 1's `True`-predicate discharge is **degenerate**. The Section-closure surface is what matters here — it proves the architectural shape works without introducing admits. Stages 2-5 refine each placeholder predicate to substantive content; Stage 3 + Stage 5 supply the substantive discharges of `compile_progress_rule` and `output_wellformed_rule`. Stage 6 ships the capstone unconditional `pdflatex_compile_safe` at v27.0.0.

## Verification

- `dune build proofs` → 0 admits / 0 axioms maintained
- `generate_project_facts.py` → 1,298 theorems (was 1,291; +7)
- `pre_release_check.py --skip-build` → 17/17 PASS

## v26.5.0 cycle still pending

This is the cycle PR. Per `V27_WS8_PLAN.md` §7, the cycle also ships a small rolling-fix-producer batch (3-5 rules from V26_4_PLAN §1.3 leftovers) and ends at the v26.5.0 release-bump PR. v27 WS8 Stage 2 begins after v26.5.0 ships.

## Test plan
- [x] 17/17 pre-release gates locally
- [ ] CI: required-checks all green
- [ ] CI: spec-drift workflow green