### PR TITLE
feat(v26.5 §7): 4 boundary-tracked fix producers (cycle byproduct)

### DIFF
--- a/latex-parse/src/test_typo_fix.ml
+++ b/latex-parse/src/test_typo_fix.ml
@@ -262,4 +262,42 @@ let () =
         (List.length edits = 2 && apply_all src edits = "First. Second. Third.")
         (tag ^ ": both runs collapsed"));
 
+  (* v26.5 §7 cycle byproduct: 4 more fix producers. *)
+  run "TYPO-016 fix replaces space-before-cite with NBSP" (fun tag ->
+      let src = "see \\cite{x} and \\ref{y}." in
+      let edits = fix_edits "TYPO-016" src in
+      expect
+        (List.length edits = 2
+        && apply_all src edits = "see~\\cite{x} and~\\ref{y}.")
+        (tag ^ ": both spaces replaced with ~"));
+
+  run "TYPO-026 fix replaces en-dash in number range with --" (fun tag ->
+      let src = "pages 12\xe2\x80\x9320 and 30\xe2\x80\x9345" in
+      let edits = fix_edits "TYPO-026" src in
+      expect
+        (List.length edits = 2
+        && apply_all src edits = "pages 12--20 and 30--45")
+        (tag ^ ": both en-dashes replaced"));
+
+  run "SPC-008 fix strips leading whitespace from indented paragraph"
+    (fun tag ->
+      let src = "Para one.\n\n   Indented paragraph." in
+      let edits = fix_edits "SPC-008" src in
+      expect
+        (List.length edits = 1
+        && apply_all src edits = "Para one.\n\nIndented paragraph.")
+        (tag ^ ": leading whitespace stripped"));
+
+  run "SPC-008 fix leaves \\item lines alone" (fun tag ->
+      expect
+        (does_not_fire "SPC-008" "First line.\n\n  \\item bullet")
+        (tag ^ ": \\item exempt"));
+
+  run "SPC-011 fix strips trailing space inside $$…$$" (fun tag ->
+      let src = "$$\nx + y  \nz\n$$" in
+      let edits = fix_edits "SPC-011" src in
+      expect
+        (List.length edits = 1 && apply_all src edits = "$$\nx + y\nz\n$$")
+        (tag ^ ": trailing whitespace before \\n stripped inside display"));
+
   finalise "typo-fix"

--- a/latex-parse/src/validators_l0.ml
+++ b/latex-parse/src/validators_l0.ml
@@ -1493,30 +1493,59 @@ let r_spc_007 : rule =
 (* SPC-008: Paragraph starts with whitespace (indented first line after
    blank) *)
 let r_spc_008 : rule =
+  (* v26.5 §7: paragraph-starts-with-whitespace fix. Walks line spans in the
+     original source so fix offsets are exact. Skips lines that start with
+     `\item` after the leading whitespace (per the original count logic). *)
   let run s =
-    let has_indented_para line prev_blank =
-      prev_blank
-      && String.length line > 0
-      && (line.[0] = ' ' || line.[0] = '\t')
-      && (* skip \item lines *)
-      not
-        (let trimmed = String.trim line in
-         String.length trimmed >= 5 && String.sub trimmed 0 5 = "\\item")
+    let line_is_blank lstart lend =
+      let i = ref lstart in
+      while
+        !i < lend
+        &&
+        let c = s.[!i] in
+        c = ' ' || c = '\t' || c = '\r'
+      do
+        incr i
+      done;
+      !i = lend
     in
-    let lines = String.split_on_char '\n' s in
+    let leading_ws_end lstart lend =
+      let i = ref lstart in
+      while !i < lend && (s.[!i] = ' ' || s.[!i] = '\t') do
+        incr i
+      done;
+      !i
+    in
+    let starts_with_item lstart lend =
+      let trim = leading_ws_end lstart lend in
+      trim + 5 <= lend && String.sub s trim 5 = "\\item"
+    in
     let cnt = ref 0 in
+    let edits = ref [] in
     let prev_blank = ref true in
-    (* start of file counts as after blank *)
-    List.iter
-      (fun line ->
-        let trimmed = String.trim line in
-        if has_indented_para line !prev_blank then incr cnt;
-        prev_blank := String.length trimmed = 0)
-      lines;
+    iter_line_spans s (fun lstart lend ->
+        let has_leading_ws =
+          lend > lstart && (s.[lstart] = ' ' || s.[lstart] = '\t')
+        in
+        if !prev_blank && has_leading_ws && not (starts_with_item lstart lend)
+        then (
+          incr cnt;
+          let trim = leading_ws_end lstart lend in
+          if trim > lstart then
+            edits :=
+              Cst_edit.replace ~start_offset:lstart ~end_offset:trim ""
+              :: !edits);
+        prev_blank := line_is_blank lstart lend);
     if !cnt > 0 then
-      Some
-        (mk_result ~id:"SPC-008" ~severity:Info
-           ~message:"Paragraph starts with whitespace" ~count:!cnt)
+      let fix = List.rev !edits in
+      if fix = [] then
+        Some
+          (mk_result ~id:"SPC-008" ~severity:Info
+             ~message:"Paragraph starts with whitespace" ~count:!cnt)
+      else
+        Some
+          (mk_result_with_fix ~id:"SPC-008" ~severity:Info
+             ~message:"Paragraph starts with whitespace" ~count:!cnt ~fix)
     else None
   in
   { id = "SPC-008"; run; languages = [] }
@@ -2026,9 +2055,14 @@ let r_spc_027 : rule =
 
 (* SPC-011: Space before newline inside $$…$$ display *)
 let r_spc_011 : rule =
+  (* v26.5 §7: strip the space/tab run immediately before each newline that lies
+     inside a $$…$$ display block. Maintains the existing toggle-on-$$ display
+     tracker; emits one delete edit per matched run (one or more contiguous
+     spaces/tabs before \n). *)
   let run s =
     let n = String.length s in
     let cnt = ref 0 in
+    let edits = ref [] in
     let in_display = ref false in
     let i = ref 0 in
     while !i < n - 1 do
@@ -2038,14 +2072,36 @@ let r_spc_011 : rule =
       else if
         !in_display && (s.[!i] = ' ' || s.[!i] = '\t') && s.[!i + 1] = '\n'
       then (
+        (* Found one ws byte before \n; walk back to find run start so
+           multi-byte ws runs collapse in a single edit. *)
+        let run_end = !i + 1 in
+        let run_start = ref !i in
+        while
+          !run_start > 0
+          &&
+          let c = s.[!run_start - 1] in
+          c = ' ' || c = '\t'
+        do
+          decr run_start
+        done;
+        edits :=
+          Cst_edit.replace ~start_offset:!run_start ~end_offset:run_end ""
+          :: !edits;
         incr cnt;
         i := !i + 2)
       else incr i
     done;
     if !cnt > 0 then
-      Some
-        (mk_result ~id:"SPC-011" ~severity:Warning
-           ~message:"Space before newline inside $$…$$ display" ~count:!cnt)
+      let fix = List.rev !edits in
+      if fix = [] then
+        Some
+          (mk_result ~id:"SPC-011" ~severity:Warning
+             ~message:"Space before newline inside $$…$$ display" ~count:!cnt)
+      else
+        Some
+          (mk_result_with_fix ~id:"SPC-011" ~severity:Warning
+             ~message:"Space before newline inside $$…$$ display" ~count:!cnt
+             ~fix)
     else None
   in
   { id = "SPC-011"; run; languages = [] }

--- a/latex-parse/src/validators_l0_typo.ml
+++ b/latex-parse/src/validators_l0_typo.ml
@@ -549,20 +549,33 @@ let r_typo_016 : rule =
   let re = Re_compat.regexp {| \\\(cite\|ref\)[^a-zA-Z]|} in
   let run s =
     let cnt = ref 0 in
+    let edits = ref [] in
     let i = ref 0 in
     (try
        while true do
          let _mr, _ = Re_compat.search_forward re s !i in
+         let mb = Re_compat.match_beginning _mr in
+         (* Match shape: " \cite[^a-zA-Z]" or " \ref[^a-zA-Z]". The leading
+            space is at offset mb. Replace the space with `~`. *)
+         edits :=
+           Cst_edit.replace ~start_offset:mb ~end_offset:(mb + 1) "~" :: !edits;
          incr cnt;
          i := Re_compat.match_end _mr
        done
      with Not_found -> ());
     let cnt = !cnt in
     if cnt > 0 then
-      Some
-        (mk_result ~id:"TYPO-016" ~severity:Info
-           ~message:{|Non‑breaking space ~ missing before \cite / \ref|}
-           ~count:cnt)
+      let fix = List.rev !edits in
+      if fix = [] then
+        Some
+          (mk_result ~id:"TYPO-016" ~severity:Info
+             ~message:{|Non‑breaking space ~ missing before \cite / \ref|}
+             ~count:cnt)
+      else
+        Some
+          (mk_result_with_fix ~id:"TYPO-016" ~severity:Info
+             ~message:{|Non‑breaking space ~ missing before \cite / \ref|}
+             ~count:cnt ~fix)
     else None
   in
   { id = "TYPO-016"; run; languages = [] }
@@ -866,18 +879,33 @@ let r_typo_026 : rule =
   let re = Re_compat.regexp {|[0-9]–[0-9]|} in
   let run s =
     let cnt = ref 0 in
+    let edits = ref [] in
     let i = ref 0 in
     (try
        while true do
          let _mr, _ = Re_compat.search_forward re s !i in
+         let mb = Re_compat.match_beginning _mr in
+         (* The en-dash (U+2013) is 3 UTF-8 bytes (E2 80 93). It sits at offset
+            mb+1, between the two digits. Replace those 3 bytes with the LaTeX
+            double-hyphen `--`. *)
+         edits :=
+           Cst_edit.replace ~start_offset:(mb + 1) ~end_offset:(mb + 4) "--"
+           :: !edits;
          incr cnt;
          i := Re_compat.match_end _mr
        done
      with Not_found -> ());
     if !cnt > 0 then
-      Some
-        (mk_result ~id:"TYPO-026" ~severity:Warning
-           ~message:{|Wrong dash in page range – should use --|} ~count:!cnt)
+      let fix = List.rev !edits in
+      if fix = [] then
+        Some
+          (mk_result ~id:"TYPO-026" ~severity:Warning
+             ~message:{|Wrong dash in page range – should use --|} ~count:!cnt)
+      else
+        Some
+          (mk_result_with_fix ~id:"TYPO-026" ~severity:Warning
+             ~message:{|Wrong dash in page range – should use --|} ~count:!cnt
+             ~fix)
     else None
   in
   { id = "TYPO-026"; run; languages = [] }


### PR DESCRIPTION
## Summary

Per `V27_WS8_PLAN.md` §7, the v26.5.0 cycle ships a small rolling-fix-producer batch alongside Stage 1. This PR is that batch.

## What's new (4 fix producers)

- **`TYPO-016`** space before `\cite/\ref` → replace with `~` (NBSP).
- **`TYPO-026`** en-dash between digits in page range → `--` (LaTeX double-hyphen).
- **`SPC-008`** indented paragraph-start (line after blank line, starts with whitespace) → strip leading whitespace. `\item` lines exempt (matches existing rule semantics).
- **`SPC-011`** trailing whitespace before `\n` inside `$$…$$` displays → strip the run. Single edit per matched run; multi-byte runs collapse.

## Tests (5 new cases in `test_typo_fix.ml`)

- TYPO-016: two `\cite/\ref` instances both replaced
- TYPO-026: two en-dashes both replaced
- SPC-008: leading whitespace stripped after blank line
- SPC-008 negative: `\item` lines exempt (`does_not_fire`)
- SPC-011: trailing whitespace before `\n` stripped inside display

Total: **37 cases** (was 32). Total fix-producing rules now: **32** (was 28).

## Verification
- `dune build` clean.
- `dune runtest latex-parse/src/test_typo_fix.exe` → 37/37 PASS.
- `pre_release_check.py --skip-build` → 17/17 PASS.
- `validate_messages.sh` strict → 618 rules, 0 mismatches.

## Cycle status post-merge
v26.5.0 cycle PRs: #285 (Stage 1), this PR (§7 fix producers), pending release-bump PR. After release-bump, tag v26.5.0 + Stage 2 (next session).

## Test plan
- [x] 17/17 pre-release gates locally
- [x] 37/37 typo-fix cases
- [ ] CI: required-checks all green
- [ ] CI: spec-drift workflow green