### PR TITLE
feat(v27 T5 Stage 1): concrete carrier scaffolding for T5_wrapper

### DIFF
--- a/_CoqProject
+++ b/_CoqProject
@@ -53,6 +53,7 @@ proofs/T0_wrapper.v
 proofs/T1_wrapper.v
 proofs/T4_wrapper.v
 proofs/T5_wrapper.v
+proofs/T5_concrete.v
 proofs/CSTRoundTrip.v
 proofs/RewritePreservesCST.v
 proofs/RewritePreservesSemantics.v

--- a/proofs/T5_concrete.v
+++ b/proofs/T5_concrete.v
@@ -1,0 +1,62 @@
+(** * T5_concrete — concrete carrier for T5_wrapper Section closure.
+
+    Per `specs/v27/V27_T5_WIRING_PLAN.md` Stage 1:
+
+    Pick a concrete `rule_id` and stage placeholder predicates that
+    Stages 2–4 refine to substantive forms tied to the per-rule QED
+    chain in `proofs/generated/`.
+
+    Stage 1 (this file): scaffolding only.  Concrete `rule_id := string`,
+    placeholder `pdflatex_rule_passes_pred := fun _ _ => True`, placeholder
+    `pdflatex_no_static_violation_pred := fun _ _ => True`.  Stage 2
+    discharges `T5_wrapper.rule_safety_rule` against the placeholders.
+    Stage 3 refines `pdflatex_rule_passes_pred` to consume the per-rule
+    soundness theorems for FAMILY-NNN rules with QEDs in
+    `proofs/generated/`.  Stage 4 refines
+    `pdflatex_no_static_violation_pred` to a meaningful "no rule fires
+    on the project" predicate.  Stage 5 wires the result into
+    `proofs/PdflatexModel.v`'s `pdflatex_T5_safe`.
+
+    Zero admits, zero axioms. *)
+
+From Coq Require Import List String.
+From LaTeXPerfectionist Require Import ProjectClosure T5_wrapper.
+Import ListNotations.
+
+(** ── Concrete rule_id carrier ─────────────────────────────────────── *)
+
+(** A rule identifier is a FAMILY-NNN string (e.g. "TYPO-001", "SPC-008")
+    drawn from `specs/rules/rule_contracts.yaml`.  Strings are used
+    rather than an inductive enumeration so the predicate can dispatch
+    on the rule name without requiring a Coq mirror of the entire
+    catalogue. *)
+Definition rule_id : Type := string.
+
+(** ── Stage 1 placeholder predicates ───────────────────────────────── *)
+
+(** Stage 1 placeholder: every rule trivially passes.  Stage 3 refines
+    by case-analysing on the rule string: for each FAMILY-NNN with a
+    per-rule soundness QED, the predicate is the per-rule premise; for
+    unknown / unimplemented rules it falls back to True (vacuous).
+    Defined over `build_graph` to avoid depending on PdflatexModel.v
+    (which would create a circular dependency). *)
+Definition pdflatex_rule_passes_pred (_ : build_graph) (_ : rule_id) : Prop :=
+  True.
+
+(** Stage 1 placeholder: no rule list is in static violation.  Stage 4
+    refines to "no rule in the list fires on the project at any
+    catalogued span" once the runtime validator's emit-set is
+    formalised. *)
+Definition pdflatex_no_static_violation_pred (_ : build_graph)
+    (_ : list rule_id) : Prop :=
+  True.
+
+(** ── Stage 1 zero-admit witness ───────────────────────────────────── *)
+
+Definition t5_concrete_stage1_zero_admits : True := I.
+
+(** Stage 2's discharge of `T5_wrapper.rule_safety_rule` against these
+    placeholders is intentionally trivial (conclusion is True).  The
+    Section closure produces a project-attached T5_safe theorem; with
+    placeholders that theorem is vacuous, but the structure is in
+    place for Stages 3–5 to refine without changing the wiring shape. *)


### PR DESCRIPTION
## Summary

Per `specs/v27/V27_T5_WIRING_PLAN.md` Stage 1: scaffold the concrete carrier (`rule_id := string`) and placeholder predicates that Stages 2–5 refine. This is the first of 6 stages closing the last "True" predicate (`pdflatex_T5_safe`) in the WS8 capstone.

## Changes

`proofs/T5_concrete.v`:
- `Definition rule_id : Type := string` (FAMILY-NNN format from `rule_contracts.yaml`)
- `Definition pdflatex_rule_passes_pred (_ : build_graph) (_ : rule_id) : Prop := True` — Stage 1 placeholder; Stage 3 dispatches per rule family to per-rule QEDs in `proofs/generated/`
- `Definition pdflatex_no_static_violation_pred (_ : build_graph) (_ : list rule_id) : Prop := True` — Stage 1 placeholder; Stage 4 refines to "no rule fires on the project"
- Stage 1 zero-admit witness

`_CoqProject`: registers `proofs/T5_concrete.v`.

Defined over `build_graph` (not `pdflatex_project`) to avoid circular dependency with `PdflatexModel.v`. Stage 5 wires this into PdflatexModel via the existing `pdflatex_project := build_graph` alias.

## Why placeholders

Stage 1 is **scaffolding**, not substantive content — the goal is to land the structural wiring before refining the predicates. Stage 2 discharges `T5_wrapper.rule_safety_rule` against these placeholders (Section closure produces a vacuous-but-typed project-attached T5_safe theorem). Stages 3–4 refine the predicates without changing the wiring shape.

This is the WS8 6-stage template applied to the T5 sub-workstream: scaffold → discharge → refine → refine → wire → release.

## Verification

| Check | Result |
|---|---|
| `dune build` | exit 0 |
| `Print Assumptions pdflatex_rule_passes_pred / pdflatex_no_static_violation_pred / t5_concrete_stage1_zero_admits` | all "Closed under the global context" |
| Admits / Axioms global | 0 / 0 |
| `pre_release_check.py --skip-build` | ALL CHECKS PASSED |
| Differential test vs v27.0.1 (330 corpus files) | **PASS — 0 diffs** (proof-only) |

## Stages remaining (per V27_T5_WIRING_PLAN.md)

- **Stage 2**: Discharge `T5_wrapper.rule_safety_rule` against the Stage-1 placeholders. Section closure produces a project-attached T5_safe theorem.
- **Stage 3**: Refine `pdflatex_rule_passes_pred` to dispatch on rule_id and link to per-rule QEDs in `proofs/generated/`.
- **Stage 4**: Refine `pdflatex_no_static_violation_pred` to a meaningful "no rule fires" claim.
- **Stage 5**: Wire into `proofs/PdflatexModel.v::pdflatex_T5_safe` (replace the `True` placeholder with the substantive form, update `pdflatex_compile_safe` proof).
- **Stage 6**: Release-bump (likely v27.0.x patch).

## Test plan

- [ ] proof-ci, unicode-smoke, l1-smoke, smoke-cli, rest-smoke, perf-ci, xxh-selfcheck, unit-tests, spec-drift all green
- [ ] dune build clean
- [ ] 0 admits / 0 axioms invariant maintained
- [ ] Differential 0 diffs vs v27.0.1