### PR TITLE
feat(v27 T5 Stage 2): discharge rule_safety_rule + Section closure

### DIFF
--- a/proofs/T5_concrete.v
+++ b/proofs/T5_concrete.v
@@ -55,8 +55,55 @@ Definition pdflatex_no_static_violation_pred (_ : build_graph)
 
 Definition t5_concrete_stage1_zero_admits : True := I.
 
-(** Stage 2's discharge of `T5_wrapper.rule_safety_rule` against these
-    placeholders is intentionally trivial (conclusion is True).  The
-    Section closure produces a project-attached T5_safe theorem; with
-    placeholders that theorem is vacuous, but the structure is in
-    place for Stages 3–5 to refine without changing the wiring shape. *)
+(** ─────────────────────────────────────────────────────────────────
+    v27 T5 STAGE 2 — discharge rule_safety_rule + Section closure
+    ─────────────────────────────────────────────────────────────────
+
+    Per V27_T5_WIRING_PLAN.md Stage 2: discharge T5_wrapper's
+    rule_safety_rule hypothesis against the Stage-1 placeholders, and
+    apply the T5_rule_safe Section closure to produce a project-
+    attached T5_safe theorem.  With pdflatex_no_static_violation_pred
+    := True the discharge is trivial; the structure is in place for
+    Stages 3-4 to refine the predicates substantively without
+    changing the wiring shape. *)
+
+(** Project-attached "every rule in [rules] passes for project [p]". *)
+Definition pdflatex_all_rules_pass (p : build_graph) (rules : list rule_id)
+    : Prop :=
+  forall r, In r rules -> pdflatex_rule_passes_pred p r.
+
+(** Stage 2 discharge: rule_safety_rule for the Stage-1 placeholders.
+    With no_static_violation_pred := True the conclusion is trivial;
+    Stage 4 strengthens this to a meaningful "no rule fires" claim
+    that genuinely consumes the all-pass premise. *)
+Lemma pdflatex_rule_safety_rule_proof :
+  forall (p : build_graph) (rules : list rule_id),
+    pdflatex_all_rules_pass p rules ->
+    pdflatex_no_static_violation_pred p rules.
+Proof.
+  intros p rules _.
+  unfold pdflatex_no_static_violation_pred. exact I.
+Qed.
+
+(** Apply T5_wrapper.T5_rule_safe Section closure with our concrete
+    instantiations.  Produces the project-attached T5 safety theorem.
+    Stage 5 wires this into proofs/PdflatexModel.v's pdflatex_T5_safe
+    (currently True). *)
+Theorem pdflatex_T5_safe_stage2 :
+  forall (p : build_graph) (rules : list rule_id),
+    pdflatex_all_rules_pass p rules ->
+    pdflatex_no_static_violation_pred p rules.
+Proof.
+  intros p rules Hall.
+  apply (T5_rule_safe
+           rule_id
+           (pdflatex_rule_passes_pred p)
+           (pdflatex_no_static_violation_pred p)
+           (pdflatex_rule_safety_rule_proof p)
+           rules).
+  exact Hall.
+Qed.
+
+(** ── Stage 2 zero-admit witness ───────────────────────────────────── *)
+
+Definition t5_concrete_stage2_zero_admits : True := I.


### PR DESCRIPTION
## Summary

Per `specs/v27/V27_T5_WIRING_PLAN.md` Stage 2: discharge `T5_wrapper.rule_safety_rule` against the Stage-1 placeholders (PR #313), and apply the `T5_rule_safe` Section closure to produce a project-attached T5_safe theorem.

This closes Stage 2 of the 6-stage T5 plan. The wiring shape is now in place; Stages 3–4 will refine the predicates substantively without changing the Section-closure structure.

## Changes

`proofs/T5_concrete.v` adds:

- `Definition pdflatex_all_rules_pass (p : build_graph) (rules : list rule_id) : Prop := forall r, In r rules -> pdflatex_rule_passes_pred p r`
- `Lemma pdflatex_rule_safety_rule_proof` (Qed) — the `rule_safety_rule` discharge. Trivial under Stage-1 placeholders since `pdflatex_no_static_violation_pred := True`. Stage 4 strengthens this to a substantive proof.
- `Theorem pdflatex_T5_safe_stage2` (Qed) — `T5_rule_safe` Section closure applied with `rule_id := string` + Stage-1 placeholder predicates. Stage 5 wires this into `proofs/PdflatexModel.v::pdflatex_T5_safe`.
- Stage 2 zero-admit witness.

## Why placeholders still

Stage 2 is **structural wiring** — fix the Section closure shape so Stages 3–4 can substitute substantive predicates without disturbing the call sites. The current theorem is vacuous (conclusion `True`) but type-correct against `T5_wrapper.T5_rule_safe`, which is the hard part; refining `True` to a meaningful predicate is then a local edit.

## Verification

| Check | Result |
|---|---|
| `dune build` | exit 0 |
| `Print Assumptions pdflatex_T5_safe_stage2 / _proof / _all_rules_pass / _stage2_zero_admits` | all "Closed under the global context" |
| Admits / Axioms in `T5_concrete.v` | 0 / 0 |
| `pre_release_check.py --skip-build` | ALL CHECKS PASSED |
| Differential test vs v27.0.1 (330 corpus files) | **PASS — 0 diffs** (proof-only) |

## Stages remaining (per V27_T5_WIRING_PLAN.md)

- **Stage 3**: refine `pdflatex_rule_passes_pred` to dispatch on rule_id and link to per-rule QEDs in `proofs/generated/`.
- **Stage 4**: refine `pdflatex_no_static_violation_pred` to a meaningful "no rule fires" claim.
- **Stage 5**: wire into `proofs/PdflatexModel.v::pdflatex_T5_safe` (replace `True` with the substantive form, update `pdflatex_compile_safe` proof).
- **Stage 6**: release-bump (likely v27.0.2 patch).

## Test plan

- [ ] proof-ci, unicode-smoke, l1-smoke, smoke-cli, rest-smoke, perf-ci, xxh-selfcheck, unit-tests, spec-drift all green
- [ ] dune build clean
- [ ] 0 admits / 0 axioms invariant maintained
- [ ] Differential 0 diffs vs v27.0.1