### PR TITLE
feat(v27 T5 Stage 3): catalogue-parametric rule_passes_pred via Section

### DIFF
--- a/proofs/T5_concrete.v
+++ b/proofs/T5_concrete.v
@@ -32,78 +32,91 @@ Import ListNotations.
     catalogue. *)
 Definition rule_id : Type := string.
 
-(** ── Stage 1 placeholder predicates ───────────────────────────────── *)
+(** ── Stage 3 refinement: catalogue-parametric rule_passes ────────── *)
 
-(** Stage 1 placeholder: every rule trivially passes.  Stage 3 refines
-    by case-analysing on the rule string: for each FAMILY-NNN with a
-    per-rule soundness QED, the predicate is the per-rule premise; for
-    unknown / unimplemented rules it falls back to True (vacuous).
-    Defined over `build_graph` to avoid depending on PdflatexModel.v
-    (which would create a circular dependency). *)
-Definition pdflatex_rule_passes_pred (_ : build_graph) (_ : rule_id) : Prop :=
-  True.
+(** The Section-parametric design keeps `T5_concrete.v` independent
+    of `LaTeXPerfectionist.Generated.Catalogue` (which depends on
+    `LaTeXPerfectionist`, the very theory `T5_concrete.v` lives in —
+    a direct import would create a circular theory dependency).  The
+    catalogue is exposed as a Section [Variable] so a downstream
+    wiring file (or the [pdflatex_compile_safe] consumer) can
+    instantiate it with [LaTeXPerfectionist.Generated.Catalogue.
+    all_proved_rule_ids] at the call site.  This shape also lets
+    distinct callers parametrise different rule sets (LP-Core only,
+    LP-Extended, etc.). *)
+Section pdflatex_T5_concrete_section.
 
-(** Stage 1 placeholder: no rule list is in static violation.  Stage 4
-    refines to "no rule in the list fires on the project at any
-    catalogued span" once the runtime validator's emit-set is
-    formalised. *)
-Definition pdflatex_no_static_violation_pred (_ : build_graph)
-    (_ : list rule_id) : Prop :=
-  True.
+  (** The catalogue of rule_ids with per-rule soundness QEDs.  The
+      consumer (Stage 5 wiring or downstream theorem) instantiates
+      with `LaTeXPerfectionist.Generated.Catalogue.all_proved_rule_ids`. *)
+  Variable rule_catalogue : list rule_id.
+
+  (** Stage 3 refinement: rule r passes for project p iff r is in the
+      provided catalogue.  This replaces the Stage 1 [True] placeholder
+      with a substantive predicate: only catalogued rule_ids satisfy
+      it.  The project parameter is unused at this stage — catalogue
+      membership is project-independent.  Linking to the full per-rule
+      semantics (extracting project text and applying the per-rule
+      soundness theorems) requires a [build_graph -> list string]
+      accessor, which is Stage 4+ scope. *)
+  Definition pdflatex_rule_passes_pred (_ : build_graph) (r : rule_id) : Prop :=
+    In r rule_catalogue.
+
+  (** Stage 1 placeholder: no rule list is in static violation.  Stage 4
+      refines to "no rule in the list fires on the project at any
+      catalogued span" once the runtime validator's emit-set is
+      formalised. *)
+  Definition pdflatex_no_static_violation_pred (_ : build_graph)
+      (_ : list rule_id) : Prop :=
+    True.
+
+  (** ── v27 T5 STAGE 2 content (Section-parametric per Stage 3) ── *)
+
+  (** Project-attached "every rule in [rules] passes for project [p]". *)
+  Definition pdflatex_all_rules_pass (p : build_graph) (rules : list rule_id)
+      : Prop :=
+    forall r, In r rules -> pdflatex_rule_passes_pred p r.
+
+  (** Stage 2 discharge: rule_safety_rule for the placeholder
+      no_static_violation_pred (Stage 4 refines to substantive). *)
+  Lemma pdflatex_rule_safety_rule_proof :
+    forall (p : build_graph) (rules : list rule_id),
+      pdflatex_all_rules_pass p rules ->
+      pdflatex_no_static_violation_pred p rules.
+  Proof.
+    intros p rules _.
+    unfold pdflatex_no_static_violation_pred. exact I.
+  Qed.
+
+  (** Apply [T5_wrapper.T5_rule_safe] Section closure with our concrete
+      instantiations.  Produces the project-attached T5 safety theorem
+      parametric in the rule_catalogue.  Stage 5 wires this into
+      [proofs/PdflatexModel.v]'s [pdflatex_T5_safe]. *)
+  Theorem pdflatex_T5_safe_stage2 :
+    forall (p : build_graph) (rules : list rule_id),
+      pdflatex_all_rules_pass p rules ->
+      pdflatex_no_static_violation_pred p rules.
+  Proof.
+    intros p rules Hall.
+    apply (T5_rule_safe
+             rule_id
+             (pdflatex_rule_passes_pred p)
+             (pdflatex_no_static_violation_pred p)
+             (pdflatex_rule_safety_rule_proof p)
+             rules).
+    exact Hall.
+  Qed.
+
+End pdflatex_T5_concrete_section.
 
 (** ── Stage 1 zero-admit witness ───────────────────────────────────── *)
 
 Definition t5_concrete_stage1_zero_admits : True := I.
 
-(** ─────────────────────────────────────────────────────────────────
-    v27 T5 STAGE 2 — discharge rule_safety_rule + Section closure
-    ─────────────────────────────────────────────────────────────────
-
-    Per V27_T5_WIRING_PLAN.md Stage 2: discharge T5_wrapper's
-    rule_safety_rule hypothesis against the Stage-1 placeholders, and
-    apply the T5_rule_safe Section closure to produce a project-
-    attached T5_safe theorem.  With pdflatex_no_static_violation_pred
-    := True the discharge is trivial; the structure is in place for
-    Stages 3-4 to refine the predicates substantively without
-    changing the wiring shape. *)
-
-(** Project-attached "every rule in [rules] passes for project [p]". *)
-Definition pdflatex_all_rules_pass (p : build_graph) (rules : list rule_id)
-    : Prop :=
-  forall r, In r rules -> pdflatex_rule_passes_pred p r.
-
-(** Stage 2 discharge: rule_safety_rule for the Stage-1 placeholders.
-    With no_static_violation_pred := True the conclusion is trivial;
-    Stage 4 strengthens this to a meaningful "no rule fires" claim
-    that genuinely consumes the all-pass premise. *)
-Lemma pdflatex_rule_safety_rule_proof :
-  forall (p : build_graph) (rules : list rule_id),
-    pdflatex_all_rules_pass p rules ->
-    pdflatex_no_static_violation_pred p rules.
-Proof.
-  intros p rules _.
-  unfold pdflatex_no_static_violation_pred. exact I.
-Qed.
-
-(** Apply T5_wrapper.T5_rule_safe Section closure with our concrete
-    instantiations.  Produces the project-attached T5 safety theorem.
-    Stage 5 wires this into proofs/PdflatexModel.v's pdflatex_T5_safe
-    (currently True). *)
-Theorem pdflatex_T5_safe_stage2 :
-  forall (p : build_graph) (rules : list rule_id),
-    pdflatex_all_rules_pass p rules ->
-    pdflatex_no_static_violation_pred p rules.
-Proof.
-  intros p rules Hall.
-  apply (T5_rule_safe
-           rule_id
-           (pdflatex_rule_passes_pred p)
-           (pdflatex_no_static_violation_pred p)
-           (pdflatex_rule_safety_rule_proof p)
-           rules).
-  exact Hall.
-Qed.
-
 (** ── Stage 2 zero-admit witness ───────────────────────────────────── *)
 
 Definition t5_concrete_stage2_zero_admits : True := I.
+
+(** ── Stage 3 zero-admit witness ───────────────────────────────────── *)
+
+Definition t5_concrete_stage3_zero_admits : True := I.


### PR DESCRIPTION
## Summary

Per `specs/v27/V27_T5_WIRING_PLAN.md` Stage 3: refine `pdflatex_rule_passes_pred` from `True` (Stage 1 placeholder) to a substantive predicate that consults a rule catalogue. Stage 3 of 6.

## Architectural decision: Section-parametric catalogue

The natural source of truth for "rules with per-rule QEDs" is `LaTeXPerfectionist.Generated.Catalogue.all_proved_rule_ids`. But that lives in `LaTeXPerfectionist.Generated`, which **already depends on** `LaTeXPerfectionist` (where `T5_concrete.v` lives). Direct import would create a circular theory dependency.

Section-parametric design avoids the cycle:

```coq
Section pdflatex_T5_concrete_section.
  Variable rule_catalogue : list rule_id.

  Definition pdflatex_rule_passes_pred (_ : build_graph) (r : rule_id) : Prop :=
    In r rule_catalogue.

  Definition pdflatex_no_static_violation_pred (_ : build_graph)
      (_ : list rule_id) : Prop := True.    (* Stage 4 refines *)

  Definition pdflatex_all_rules_pass ...
  Lemma pdflatex_rule_safety_rule_proof ...   (* Qed *)
  Theorem pdflatex_T5_safe_stage2 ...         (* Qed *)
End.
```

After Section closure every definition takes `rule_catalogue : list rule_id` as its leading argument. Downstream consumers (Stage 5 wiring or a fresh `proofs/generated/PdflatexT5Wired.v`) instantiate with `Generated.Catalogue.all_proved_rule_ids`. The shape also lets distinct callers parametrise different rule sets (LP-Core only, LP-Extended, etc.) without re-deriving the proofs.

## What's substantive

`pdflatex_rule_passes_pred (rule_catalogue := C) p r := In r C` is no longer `True` universally — it's "rule r is in the supplied catalogue C", which fails for unknown strings. The discharge proof (`pdflatex_rule_safety_rule_proof`) still ignores the premise because `no_static_violation_pred` is still `True` (Stage 1 placeholder; Stage 4 refines).

## Inspection of Section closure

```
pdflatex_rule_passes_pred
  : list rule_id -> build_graph -> rule_id -> Prop

pdflatex_T5_safe_stage2
  : forall (rule_catalogue : list rule_id)
           (p : build_graph) (rules : list rule_id),
      pdflatex_all_rules_pass rule_catalogue p rules ->
      pdflatex_no_static_violation_pred rule_catalogue p rules
```

## Verification

| Check | Result |
|---|---|
| `dune build` | exit 0 |
| `Print Assumptions pdflatex_T5_safe_stage2` | "Closed under the global context" |
| Admits / Axioms in `T5_concrete.v` | 0 / 0 |
| `pre_release_check.py --skip-build` | ALL CHECKS PASSED |
| Differential test vs v27.0.1 (330 corpus files) | **PASS — 0 diffs** (proof-only) |

## Stages remaining

- **Stage 4**: refine `pdflatex_no_static_violation_pred` from `True` to a meaningful "no rule fires on project" claim.
- **Stage 5**: wire into `proofs/PdflatexModel.v::pdflatex_T5_safe` (instantiate the Section variable with `Generated.Catalogue.all_proved_rule_ids` via a downstream wiring file in `proofs/generated/`).
- **Stage 6**: release-bump v27.0.2.

## Test plan

- [ ] proof-ci, unicode-smoke, l1-smoke, smoke-cli, rest-smoke, perf-ci, xxh-selfcheck, unit-tests, spec-drift all green
- [ ] dune build clean
- [ ] 0 admits / 0 axioms invariant maintained
- [ ] Differential 0 diffs vs v27.0.1