### PR TITLE
feat(v27 apply_edits_assoc Stage 2): parallel-application Fixpoint

### DIFF
--- a/proofs/ApplyEditsAssoc.v
+++ b/proofs/ApplyEditsAssoc.v
@@ -25,7 +25,7 @@
     Zero admits, zero axioms. *)
 
 From Coq Require Import List Arith Lia.
-From LaTeXPerfectionist Require Import RewritePreservesCST.
+From LaTeXPerfectionist Require Import CSTRoundTrip RewritePreservesCST.
 Import ListNotations.
 
 (** ── Stage 1: non_overlapping predicate + sanity lemmas ──────────── *)
@@ -121,3 +121,104 @@ Definition pairwise_non_overlapping (es : list edit) : Prop :=
 (** ── Stage 1 zero-admit witness ───────────────────────────────────── *)
 
 Definition apply_edits_assoc_stage1_zero_admits : True := I.
+
+(** ─────────────────────────────────────────────────────────────────
+    v27 apply_edits_assoc STAGE 2 — parallel-application Fixpoint
+    ─────────────────────────────────────────────────────────────────
+
+    Per V27_APPLY_EDITS_ASSOC_PLAN.md Stage 2.
+
+    Critical observation: [apply_edits_concrete] applies edits
+    sequentially over a mutating buffer.  Each edit's [e_start] /
+    [e_end] are interpreted relative to the CURRENT buffer (post
+    earlier edits), NOT the original source.  So even for
+    pairwise-non-overlapping edits in the original source,
+    [apply_edits_concrete src [e1;e2]] generally differs from
+    [apply_edits_concrete src [e2;e1]] when the edits change buffer
+    length and the offsets shift.
+
+    Concrete counter-example:
+      src = [97;98;99;100;101;102]              (* "abcdef" *)
+      e1  = mk_edit 1 3 [88]                    (* replace "bc" with "X" *)
+      e2  = mk_edit 4 5 [89;90]                 (* replace "e" with "YZ" *)
+      [e1;e2]: after e1 buf="aXdef" (len 5); e2 with e_start=4 hits
+               byte 4 of "aXdef" = 'e' but post-edit drop 5 leaves [].
+      [e2;e1]: after e2 buf="abcdYZf" (len 7); e1 with e_start=1
+               hits 'b' as expected.
+      Results differ.
+
+    The "parallel" applier interprets every offset relative to the
+    ORIGINAL source.  Implementation: sort edits by [e_start]
+    descending, then apply sequentially.  Applying the rightmost
+    edit first leaves all smaller offsets unchanged in the
+    remaining buffer; iterate.  For pairwise-non-overlapping edits,
+    this matches the byte-by-byte original-offset semantic
+    (Stage 3 proves equivalence). *)
+
+(** Insert [e] into [es] at the position that maintains descending
+    order by [e_start].  Stable on equal keys (existing element
+    appears later than the inserted one). *)
+Fixpoint insert_desc (e : edit) (es : list edit) : list edit :=
+  match es with
+  | [] => [e]
+  | x :: rest =>
+      if Nat.leb x.(e_start) e.(e_start)
+      then e :: x :: rest
+      else x :: insert_desc e rest
+  end.
+
+(** Sort by [e_start] descending using insertion sort. *)
+Fixpoint sort_by_start_desc (es : list edit) : list edit :=
+  match es with
+  | [] => []
+  | e :: rest => insert_desc e (sort_by_start_desc rest)
+  end.
+
+(** The parallel applier: apply edits in original-source offset
+    semantics by sorting descending and using the sequential
+    applier from RewritePreservesCST. *)
+Definition apply_edits_parallel (src : bytes) (es : list edit) : bytes :=
+  apply_edits_concrete src (sort_by_start_desc es).
+
+(** Sanity Example: parallel application matches the byte-by-byte
+    original-offset semantic on a 6-byte source with two
+    non-overlapping edits. *)
+Example apply_edits_parallel_disjoint_example :
+  let src := [97; 98; 99; 100; 101; 102] in   (* "abcdef" *)
+  let e1 := mk_edit 1 3 [88] in                (* replace "bc" with "X" *)
+  let e2 := mk_edit 4 5 [89; 90] in            (* replace "e" with "YZ" *)
+  apply_edits_parallel src [e1; e2]
+    = [97; 88; 100; 89; 90; 102].              (* "aXdYZf" *)
+Proof. reflexivity. Qed.
+
+(** Sanity Example: order independence on the parallel applier
+    (Stage 4 generalises this to a permutation theorem). *)
+Example apply_edits_parallel_disjoint_swap :
+  let src := [97; 98; 99; 100; 101; 102] in
+  let e1 := mk_edit 1 3 [88] in
+  let e2 := mk_edit 4 5 [89; 90] in
+  apply_edits_parallel src [e1; e2] = apply_edits_parallel src [e2; e1].
+Proof. reflexivity. Qed.
+
+(** Length preservation: insert_desc grows the list by exactly 1. *)
+Lemma insert_desc_length :
+  forall e es, length (insert_desc e es) = S (length es).
+Proof.
+  intros e es. induction es as [|x rest IH]; simpl.
+  - reflexivity.
+  - destruct (Nat.leb (e_start x) (e_start e)); simpl;
+      [reflexivity | rewrite IH; reflexivity].
+Qed.
+
+(** Sort preserves length. *)
+Lemma sort_by_start_desc_length :
+  forall es, length (sort_by_start_desc es) = length es.
+Proof.
+  induction es as [|e rest IH]; simpl.
+  - reflexivity.
+  - rewrite insert_desc_length, IH. reflexivity.
+Qed.
+
+(** ── Stage 2 zero-admit witness ───────────────────────────────────── *)
+
+Definition apply_edits_assoc_stage2_zero_admits : True := I.


### PR DESCRIPTION
## Summary

Per `specs/v27/V27_APPLY_EDITS_ASSOC_PLAN.md` Stage 2: define `apply_edits_parallel` using sort-by-start-descending + the existing sequential applier from `RewritePreservesCST`. Stage 2 of 6.

## Critical observation that revised the Stage 4 plan goal

The sequential `apply_edits_concrete` is **NOT** order-invariant for non-overlapping edits, because each edit's `e_start` / `e_end` are interpreted relative to the CURRENT (post-earlier-edits) buffer, not the original source.

**Concrete counter-example** (documented in the file header):

```
src = [97;98;99;100;101;102]              ("abcdef")
e1  = mk_edit 1 3 [88]                    (replace "bc" with "X")
e2  = mk_edit 4 5 [89;90]                 (replace "e" with "YZ")
                                          (e1 and e2 are non-overlapping)

apply_edits_concrete src [e1;e2]
  → after e1, buf="aXdef" (len 5)
  → e2 with e_start=4 hits byte 4 of "aXdef" = 'e', drop 5 leaves []
  → result has e2's "YZ" appended at end, NOT at original position 4

apply_edits_concrete src [e2;e1]
  → after e2, buf="abcdYZf" (len 7)
  → e1 with e_start=1 hits 'b' as expected
  → result = "aXdYZf"

[e1;e2] ≠ [e2;e1]   (sequential is order-sensitive on non-overlapping)
```

So the V27_APPLY_EDITS_ASSOC_PLAN's original Stage 4 goal `apply_edits_concrete src [e1;e2] = apply_edits_concrete src [e2;e1]` is **false** as stated. Stage 4 is being revised: the substantive theorem is permutation invariance of the **parallel** applier (which uses original-source offsets).

## What Stage 2 delivers

The "parallel" applier interprets every offset relative to the original source. Implementation: sort edits by `e_start` descending, then apply sequentially. Applying the rightmost edit first leaves all smaller offsets unchanged in the remaining buffer; iterate.

```coq
Fixpoint insert_desc (e : edit) (es : list edit) : list edit := ...
Fixpoint sort_by_start_desc (es : list edit) : list edit := ...

Definition apply_edits_parallel (src : bytes) (es : list edit) : bytes :=
  apply_edits_concrete src (sort_by_start_desc es).

Example apply_edits_parallel_disjoint_example :
  apply_edits_parallel "abcdef" [e1; e2] = "aXdYZf".
Proof. reflexivity. Qed.

Example apply_edits_parallel_disjoint_swap :
  apply_edits_parallel src [e1; e2] = apply_edits_parallel src [e2; e1].
Proof. reflexivity. Qed.
```

Plus length-preservation lemmas for `insert_desc` and `sort_by_start_desc`.

## Verification

| Check | Result |
|---|---|
| `dune build` | exit 0 |
| `Print Assumptions` on all 5 new theorems/examples | all "Closed under the global context" |
| Admits / Axioms in `ApplyEditsAssoc.v` | 0 / 0 |
| `pre_release_check.py --skip-build` | ALL CHECKS PASSED |
| Differential test vs v27.0.2 (330 corpus files) | **PASS — 0 diffs** (proof-only) |

## Stages remaining

- **Stage 3**: `apply_edits_parallel_equals_concrete_when_sorted` — equivalence with sequential when input is already descending-sorted (trivial by definition; documents the relationship)
- **Stage 4**: `apply_edits_parallel_perm` — permutation invariance for the parallel applier; substantive headline content closing the v26.4 deferral.
- **Stage 5**: wire into `proofs/ADMISSIBILITY_MAP.md` + `docs/MERGING_GUARANTEES.md` (or similar)
- **Stage 6**: release-bump (likely v27.0.3)

## Test plan

- [ ] proof-ci, unicode-smoke, l1-smoke, smoke-cli, rest-smoke, perf-ci, xxh-selfcheck, unit-tests, spec-drift all green
- [ ] dune build clean
- [ ] 0 admits / 0 axioms invariant maintained
- [ ] Differential 0 diffs vs v27.0.2