### PR TITLE
feat(v27 apply_edits_assoc Stage 3): sort idempotence + sorted equivalence

### DIFF
--- a/proofs/ApplyEditsAssoc.v
+++ b/proofs/ApplyEditsAssoc.v
@@ -222,3 +222,139 @@ Qed.
 (** ── Stage 2 zero-admit witness ───────────────────────────────────── *)
 
 Definition apply_edits_assoc_stage2_zero_admits : True := I.
+
+(** ─────────────────────────────────────────────────────────────────
+    v27 apply_edits_assoc STAGE 3 — sort idempotence + sorted equivalence
+    ─────────────────────────────────────────────────────────────────
+
+    Per V27_APPLY_EDITS_ASSOC_PLAN.md Stage 3, retargeted (the
+    original "parallel = concrete on non-overlapping" form is FALSE
+    in general — see Stage 2 file-header counter-example).
+
+    Stage 3 substantively delivers:
+    - [descending_sorted] predicate
+    - [insert_desc_into_sorted_extends] structural lemma
+    - [sort_by_start_desc_idempotent] (Qed)
+    - [sort_by_start_desc_id_when_sorted] (Qed) — sort is the
+      identity on already-sorted input
+    - [apply_edits_parallel_eq_concrete_when_sorted] (Qed) — the
+      original Stage 3 equivalence claim, correctly conditioned on
+      descending-sorted input. *)
+
+(** Predicate: list is sorted in descending order by [e_start].
+    Defined inductively on the standard cons-pattern. *)
+Inductive descending_sorted : list edit -> Prop :=
+  | descending_sorted_nil : descending_sorted []
+  | descending_sorted_singleton : forall e, descending_sorted [e]
+  | descending_sorted_cons :
+      forall e1 e2 rest,
+        e2.(e_start) <= e1.(e_start) ->
+        descending_sorted (e2 :: rest) ->
+        descending_sorted (e1 :: e2 :: rest).
+
+(** [insert_desc] places [e] at the head of an already-sorted list
+    iff [e.e_start >= head's e_start].  Standard insertion-sort
+    invariant. *)
+Lemma insert_desc_preserves_sorted :
+  forall e es,
+    descending_sorted es ->
+    descending_sorted (insert_desc e es).
+Proof.
+  intros e es Hes. induction Hes as [|e0|e1 e2 rest Hle Hsorted IH].
+  - simpl. constructor.
+  - simpl. destruct (Nat.leb (e_start e0) (e_start e)) eqn:Hle0.
+    + apply Nat.leb_le in Hle0.
+      apply descending_sorted_cons; [exact Hle0 | constructor].
+    + apply Nat.leb_nle in Hle0.
+      simpl. apply descending_sorted_cons.
+      * lia.
+      * constructor.
+  - simpl. destruct (Nat.leb (e_start e1) (e_start e)) eqn:Hle1.
+    + apply Nat.leb_le in Hle1.
+      apply descending_sorted_cons; [exact Hle1 |].
+      apply descending_sorted_cons; assumption.
+    + apply Nat.leb_nle in Hle1.
+      simpl in IH. simpl.
+      destruct (Nat.leb (e_start e2) (e_start e)) eqn:Hle2.
+      * apply Nat.leb_le in Hle2.
+        apply descending_sorted_cons; [lia |].
+        apply descending_sorted_cons; [exact Hle2 | exact Hsorted].
+      * apply Nat.leb_nle in Hle2.
+        apply descending_sorted_cons; [exact Hle | exact IH].
+Qed.
+
+(** Sort produces a descending-sorted list. *)
+Lemma sort_by_start_desc_sorted :
+  forall es, descending_sorted (sort_by_start_desc es).
+Proof.
+  induction es as [|e rest IH]; simpl.
+  - constructor.
+  - apply insert_desc_preserves_sorted. exact IH.
+Qed.
+
+(** [insert_desc] is the identity when the new element is greater
+    than or equal to the head of an already-sorted list. *)
+Lemma insert_desc_id_when_head_le :
+  forall e es,
+    descending_sorted es ->
+    (forall x, In x es -> x.(e_start) <= e.(e_start)) ->
+    insert_desc e es = e :: es.
+Proof.
+  intros e es Hes Hle. destruct es as [|x rest].
+  - reflexivity.
+  - simpl. assert (Hle' : x.(e_start) <= e.(e_start)).
+    { apply Hle. simpl. left. reflexivity. }
+    apply Nat.leb_le in Hle'. rewrite Hle'. reflexivity.
+Qed.
+
+(** Sort is the identity on already-descending-sorted lists.
+    Proved by induction on the sorted structure. *)
+Lemma sort_by_start_desc_id_when_sorted :
+  forall es, descending_sorted es -> sort_by_start_desc es = es.
+Proof.
+  intros es Hes. induction Hes as [|e0|e1 e2 rest Hle Hsorted IH].
+  - reflexivity.
+  - simpl. reflexivity.
+  - change (sort_by_start_desc (e1 :: e2 :: rest))
+      with (insert_desc e1 (sort_by_start_desc (e2 :: rest))).
+    rewrite IH.
+    cbn [insert_desc].
+    assert (Nat.leb (e_start e2) (e_start e1) = true) as Hleb.
+    { apply Nat.leb_le. exact Hle. }
+    rewrite Hleb. reflexivity.
+Qed.
+
+(** Sort is idempotent: sorting twice gives the same result as
+    sorting once. *)
+Lemma sort_by_start_desc_idempotent :
+  forall es,
+    sort_by_start_desc (sort_by_start_desc es) = sort_by_start_desc es.
+Proof.
+  intros es. apply sort_by_start_desc_id_when_sorted.
+  apply sort_by_start_desc_sorted.
+Qed.
+
+(** Stage 3 headline: [apply_edits_parallel] equals
+    [apply_edits_concrete] when the input is already sorted in
+    descending order by [e_start].  Trivial by definition (since
+    [apply_edits_parallel] applies [sort_by_start_desc] before
+    handing off to [apply_edits_concrete], and sort is the
+    identity on already-sorted input).
+
+    For pairwise-non-overlapping edits the descending sort yields
+    the same byte sequence as the byte-by-byte original-offset
+    semantic — this lemma documents the wire from parallel to
+    sequential. *)
+Lemma apply_edits_parallel_eq_concrete_when_sorted :
+  forall src es,
+    descending_sorted es ->
+    apply_edits_parallel src es = apply_edits_concrete src es.
+Proof.
+  intros src es Hes. unfold apply_edits_parallel.
+  rewrite (sort_by_start_desc_id_when_sorted es Hes).
+  reflexivity.
+Qed.
+
+(** ── Stage 3 zero-admit witness ───────────────────────────────────── *)
+
+Definition apply_edits_assoc_stage3_zero_admits : True := I.

--- a/specs/v27/V27_APPLY_EDITS_ASSOC_PLAN.md
+++ b/specs/v27/V27_APPLY_EDITS_ASSOC_PLAN.md
@@ -73,46 +73,74 @@ in order — this makes the offset bookkeeping straightforward.
 **Acceptance:** `apply_edits_parallel` defined; type-checks; one
 example test (apply 2 disjoint edits to a 10-byte string).
 
-### Stage 3 — Equivalence: parallel = sequential for non-overlapping
-**Branch:** `v27.0/apply-edits-stage3-equivalence`
+### Stage 3 — Sort idempotence + sorted equivalence (REVISED)
+**Branch:** `v27.0/apply-edits-stage3-equivalence` (PR #321)
 
-Prove:
+**Revision rationale:** the original Stage 3 form
+`apply_edits_parallel src edits = apply_edits_concrete src edits`
+under `pairwise_non_overlapping edits` is **false** in general —
+sequential application interprets each edit's offsets relative to
+the *current* (post-earlier-edits) buffer, not the original source.
+A pairwise-non-overlapping but not-yet-sorted edit list yields
+different sequential vs parallel results.  See PR #320 file-header
+counter-example.
+
+The revised Stage 3 ships the structural lemmas Stage 4 needs and
+the *correctly-conditioned* parallel-vs-concrete equivalence:
 
 ```coq
-Lemma apply_edits_parallel_equals_concrete :
-  forall (src : list nat) (edits : list edit),
-    pairwise_non_overlapping edits ->
-    apply_edits_parallel src edits = apply_edits_concrete src edits.
+Inductive descending_sorted : list edit -> Prop := ...
+
+Lemma insert_desc_preserves_sorted          : Qed
+Lemma sort_by_start_desc_sorted             : Qed  (* sort produces sorted *)
+Lemma insert_desc_id_when_head_le           : Qed
+Lemma sort_by_start_desc_id_when_sorted     : Qed  (* sort is id on sorted *)
+Lemma sort_by_start_desc_idempotent         : Qed
+Lemma apply_edits_parallel_eq_concrete_when_sorted : Qed
 ```
 
-Where `pairwise_non_overlapping := forall i j, i <> j -> non_overlapping (nth i) (nth j)`.
+The Stage 3 headline `apply_edits_parallel_eq_concrete_when_sorted`
+is trivial by definition (sort is the identity on already-sorted
+input).  Stage 4 carries the substantive content — permutation
+invariance for the parallel applier, which is what the v26.4
+deferral note actually wanted.
 
-**Acceptance:** Lemma Qed-proved by induction on the edit list.
+**Acceptance:** all 6 lemmas Qed; `Print Assumptions` Closed.
 
-### Stage 4 — Associativity / reorder
-**Branch:** `v27.0/apply-edits-stage4-assoc`
+### Stage 4 — Permutation invariance for the parallel applier (REVISED)
+**Branch:** `v27.0/apply-edits-stage4-perm`
 
-Prove the parallel form is order-independent (since it uses
-original-source offsets):
+**Revision rationale:** the original Stage 4 headline
+`apply_edits_concrete src [e1;e2] = apply_edits_concrete src [e2;e1]`
+under `non_overlapping e1 e2` is **false** in general (PR #320
+counter-example).  The substantive theorem the v26.4 deferral note
+wanted is permutation invariance for the *parallel* applier (which
+uses original-source offsets):
 
 ```coq
-Lemma apply_edits_parallel_perm :
+Theorem apply_edits_parallel_perm :
   forall (src : list nat) (edits1 edits2 : list edit),
     Permutation edits1 edits2 ->
-    pairwise_non_overlapping edits1 ->
+    distinct_starts edits1 ->         (* unique e_start; rules out
+                                         insertions at same point *)
     apply_edits_parallel src edits1 = apply_edits_parallel src edits2.
 ```
 
-Combined with Stage 3:
+`distinct_starts` (or a similar predicate) is required because
+two insertions at the same offset are technically pairwise
+non-overlapping per `non_overlapping_self_iff` but apply in
+order-dependent fashion.  For genuine non-empty edits with
+non-overlapping ranges, `distinct_starts` follows from
+`pairwise_non_overlapping`.
 
-```coq
-Theorem apply_edits_concrete_associative_subset :
-  forall (src : list nat) (e1 e2 : edit),
-    non_overlapping e1 e2 ->
-    apply_edits_concrete src [e1; e2] = apply_edits_concrete src [e2; e1].
-```
+**Proof sketch:** show `sort_by_start_desc edits1 = sort_by_start_desc
+edits2` when `Permutation edits1 edits2 /\ distinct_starts edits1`
+(insertion sort is determined by the multiset of keys when keys
+are unique).  Then `apply_edits_parallel = apply_edits_concrete o
+sort_by_start_desc` gives equality of outputs.
 
-**Acceptance:** Theorem Qed-proved. Closed under the global context.
+**Acceptance:** `apply_edits_parallel_perm` Qed; `Print Assumptions`
+Closed under the global context.
 
 ### Stage 5 — Wire into ADMISSIBILITY_MAP / docs
 **Branch:** `v27.0/apply-edits-stage5-docs`
@@ -129,14 +157,18 @@ Tag.
 `~/.claude/.../memory/v27_apply_edits_assoc_status.md` carries
 state.
 
-## Acceptance criteria
+## Acceptance criteria (state at end of Stage 3)
 
-- [ ] `non_overlapping` Definition + decidability lemma.
-- [ ] `apply_edits_parallel` Fixpoint defined.
-- [ ] `apply_edits_parallel_equals_concrete` Qed (parallel = sequential
-  on non-overlapping edits).
-- [ ] `apply_edits_parallel_perm` Qed (parallel is permutation-invariant).
-- [ ] `apply_edits_concrete_associative_subset` Qed (the headline).
-- [ ] `Print Assumptions` Closed under the global context.
-- [ ] ADMISSIBILITY_MAP updated.
-- [ ] CHANGELOG entry.
+- [x] `non_overlapping` Definition + decidability + symmetry +
+  consistency-with-`edits_conflict` lemmas (Stage 1, PR #319).
+- [x] `apply_edits_parallel` Fixpoint defined via
+  `sort_by_start_desc` + `apply_edits_concrete` (Stage 2, PR #320).
+- [x] Sort idempotence + identity-when-sorted + Stage 3 sorted-
+  equivalence headline (Stage 3, PR #321).
+- [ ] `apply_edits_parallel_perm` Qed — parallel is permutation-
+  invariant on `distinct_starts` inputs (Stage 4 — substantive
+  headline; replaces the original false `apply_edits_concrete_
+  associative_subset` form).
+- [ ] All `Print Assumptions` Closed under the global context.
+- [ ] ADMISSIBILITY_MAP updated (Stage 5).
+- [ ] CHANGELOG `[v27.0.x]` entry (Stage 6 release-bump).


### PR DESCRIPTION
## Summary

Per `specs/v27/V27_APPLY_EDITS_ASSOC_PLAN.md` Stage 3 (retargeted — the original "parallel = concrete on non-overlapping" form is FALSE in general, see Stage 2 PR #320 file-header counter-example). Stage 3 of 6.

## What Stage 3 delivers

Structural lemmas about `sort_by_start_desc` needed by Stage 4's permutation theorem:

```coq
Inductive descending_sorted : list edit -> Prop := ...

Lemma insert_desc_preserves_sorted          : Qed
Lemma sort_by_start_desc_sorted             : Qed  (* sort produces sorted *)
Lemma insert_desc_id_when_head_le           : Qed
Lemma sort_by_start_desc_id_when_sorted     : Qed  (* sort is id on sorted *)
Lemma sort_by_start_desc_idempotent         : Qed  (* sort^2 = sort *)
Lemma apply_edits_parallel_eq_concrete_when_sorted : Qed
```

The Stage 3 headline `apply_edits_parallel_eq_concrete_when_sorted` is trivial by definition (`apply_edits_parallel src es := apply_edits_concrete src (sort_by_start_desc es)`, and sort is the identity on already-sorted input). It's the structural lemmas that Stage 4 will actually leverage.

## Verification

| Check | Result |
|---|---|
| `dune build` | exit 0 |
| `Print Assumptions` on all 6 new lemmas | all "Closed under the global context" |
| Admits / Axioms in `ApplyEditsAssoc.v` | 0 / 0 |
| `pre_release_check.py --skip-build` | ALL CHECKS PASSED |
| Differential test vs v27.0.2 (330 corpus files) | **PASS — 0 diffs** (proof-only) |

## Stages remaining

- **Stage 4**: permutation invariance — `apply_edits_parallel src es1 = apply_edits_parallel src es2` for `Permutation es1 es2` with pairwise non-overlapping positive-range edits. Substantive headline closing the v26.4 deferral.
- **Stage 5**: wire into `proofs/ADMISSIBILITY_MAP.md` + `docs/MERGING_GUARANTEES.md` (or similar)
- **Stage 6**: release-bump (likely v27.0.3)

## Test plan

- [ ] proof-ci, unicode-smoke, l1-smoke, smoke-cli, rest-smoke, perf-ci, xxh-selfcheck, unit-tests, spec-drift all green
- [ ] dune build clean
- [ ] 0 admits / 0 axioms invariant maintained
- [ ] Differential 0 diffs vs v27.0.2