### PR TITLE
feat(v27 cursor-universal Stage 1): sort-asc permutation + sortedness lemmas

### DIFF
--- a/docs/v26_2/adr/ADR-004-hypothesis-parametric-t6-t7.md
+++ b/docs/v26_2/adr/ADR-004-hypothesis-parametric-t6-t7.md
@@ -1,6 +1,6 @@
 # ADR-004: T6/T7 proofs use Section + Variable (not Parameter / Axiom)
 
-- **Status:** Accepted (2026-04-22)
+- **Status:** Accepted (2026-04-22); **Discharged for pdflatex profile in v27.0.0** (`pdflatex_compile_safe` Qed at commit `492ff90`); T0/T1/T4/T5 wired in v27.0.1 / v27.0.2 (PRs #312 / #313→#317).
 - **Context owner:** v26.2 architectural decisions (plan §2.4)
 
 ## Context
@@ -64,3 +64,37 @@ are *not* axioms — they become parameters of the final theorem after
   `admit-audit` on it.
 - `proofs/ADMISSIBILITY_MAP.md` (created in A3) lists every Hypothesis
   T6/T7 rely on, serving as the entry point for v27 WS8 implementers.
+
+## Discharge log (post-v26.2)
+
+- **v27.0.0** (commit `492ff90`, PR #310 + #311 release-bump): WS8
+  capstone delivered.  `proofs/PdflatexModel.v` instantiates both
+  Section's Variables; both `compile_progress_rule` and
+  `output_wellformed_rule` discharged via Qed-proved lemmas
+  (`pdflatex_compile_progress_rule_proof`,
+  `pdflatex_output_wellformed_rule_proof`).  Headline
+  `pdflatex_compile_safe` Qed; `Print Assumptions` returns "Closed
+  under the global context".  Engine-generic aliases
+  `xelatex_compile_safe` / `lualatex_compile_safe` ship in v27.0.1.
+- **v27.0.1** (PR #312): T0/T1/T4 wired to LP-Core wrappers
+  (`T0_wrapper.T0_parser_accepts`,
+  `T1_wrapper.T1_expansion_admissible_merge`,
+  `T4_wrapper.T4_labels_unique_packaged`); discharge lemmas
+  `pdflatex_T{0,1,4}_*_holds` Qed.
+- **v27.0.2** (PRs #313→#317): T5 substantively wired via
+  `proofs/T5_concrete.v` Section-parametric carriers + downstream
+  `proofs/generated/PdflatexT5Wired.v` against
+  `Generated.Catalogue.all_proved_rule_ids`.
+- **v27.0.3** (PRs #319→#324): apply_edits associative-reorder
+  cycle (orthogonal to T6/T7 but builds on the same rewrite
+  engine — closes the v26.4-deferred
+  `apply_edits_concrete_associative_subset` under the corrected
+  name `apply_edits_parallel_perm`).
+
+The compile-guarantee stack T0–T7 is now substantively discharged
+end-to-end for the pdflatex profile; the engine-agnostic aliases
+extend the carrier-level result to xelatex / lualatex profiles.
+The faithful operational semantics (extending the abstract
+counter-bounded pass model to real aux/log evolution) is queued
+as `specs/v27/V27_FAITHFUL_SEMANTICS_PLAN.md` (target tag
+v27.1.0).

--- a/proofs/ApplyEditsAssoc.v
+++ b/proofs/ApplyEditsAssoc.v
@@ -681,3 +681,175 @@ Qed.
 (** ── Stage 5b zero-admit witness ──────────────────────────────────── *)
 
 Definition apply_edits_assoc_stage5b_zero_admits : True := I.
+
+(** ─────────────────────────────────────────────────────────────────
+    v27 cursor-universal STAGE 1 — sort-asc permutation lemmas
+    ─────────────────────────────────────────────────────────────────
+
+    Per `specs/v27/V27_APPLY_EDITS_CURSOR_UNIVERSAL_PLAN.md` Stage 1.
+    Symmetric ascending-sort versions of the existing Stage 4
+    descending-sort lemmas (PRs #319→#322).  These prerequisites
+    feed Stage 4's substantive sequential-descending shape lemma
+    (which reduces both algorithms to a canonical byte mapping). *)
+
+(** Symmetric to [insert_desc_swap_distinct]: insertions via
+    [insert_asc] commute when the inserted edits have distinct
+    start keys.  Same proof structure as the descending version. *)
+Lemma insert_asc_swap_distinct :
+  forall a b s,
+    a.(e_start) <> b.(e_start) ->
+    insert_asc a (insert_asc b s) = insert_asc b (insert_asc a s).
+Proof.
+  intros a b s Hneq. induction s as [|x rest IH].
+  - (* s = [] *)
+    simpl.
+    destruct (Nat.lt_ge_cases (e_start a) (e_start b)) as [Hlt | Hge].
+    + assert (e_start a <=? e_start b = true) as -> by (apply Nat.leb_le; lia).
+      assert (e_start b <=? e_start a = false) as -> by (apply Nat.leb_nle; lia).
+      reflexivity.
+    + assert (e_start b < e_start a) by lia.
+      assert (e_start a <=? e_start b = false) as -> by (apply Nat.leb_nle; lia).
+      assert (e_start b <=? e_start a = true) as -> by (apply Nat.leb_le; lia).
+      reflexivity.
+  - (* s = x :: rest *)
+    simpl.
+    destruct (Nat.leb (e_start b) (e_start x)) eqn:Hbx;
+      destruct (Nat.leb (e_start a) (e_start x)) eqn:Hax.
+    + (* a <= x and b <= x: both insert at head; depends on a vs b *)
+      simpl. rewrite Hax, Hbx.
+      destruct (Nat.lt_ge_cases (e_start a) (e_start b)) as [Hlt | Hge].
+      * assert (e_start a <=? e_start b = true) as -> by (apply Nat.leb_le; lia).
+        assert (e_start b <=? e_start a = false) as -> by (apply Nat.leb_nle; lia).
+        reflexivity.
+      * assert (e_start b < e_start a) by lia.
+        assert (e_start a <=? e_start b = false) as -> by (apply Nat.leb_nle; lia).
+        assert (e_start b <=? e_start a = true) as -> by (apply Nat.leb_le; lia).
+        reflexivity.
+    + (* b <= x but ~a <= x *)
+      simpl.
+      apply Nat.leb_le in Hbx. apply Nat.leb_nle in Hax.
+      assert (e_start a <=? e_start b = false) as -> by (apply Nat.leb_nle; lia).
+      simpl.
+      assert (e_start b <=? e_start x = true) as -> by (apply Nat.leb_le; lia).
+      assert (e_start a <=? e_start x = false) as -> by (apply Nat.leb_nle; lia).
+      reflexivity.
+    + (* ~b <= x but a <= x *)
+      simpl.
+      apply Nat.leb_nle in Hbx. apply Nat.leb_le in Hax.
+      assert (e_start b <=? e_start a = false) as -> by (apply Nat.leb_nle; lia).
+      simpl.
+      assert (e_start a <=? e_start x = true) as -> by (apply Nat.leb_le; lia).
+      assert (e_start b <=? e_start x = false) as -> by (apply Nat.leb_nle; lia).
+      reflexivity.
+    + (* ~b <= x and ~a <= x: both recurse *)
+      simpl. rewrite Hax, Hbx. rewrite IH. reflexivity.
+Qed.
+
+(** Symmetric corollary to [sort_by_start_desc_insert_swap]. *)
+Lemma sort_by_start_asc_insert_swap :
+  forall a b es,
+    a.(e_start) <> b.(e_start) ->
+    sort_by_start_asc (a :: b :: es)
+      = sort_by_start_asc (b :: a :: es).
+Proof.
+  intros a b es Hneq.
+  cbn [sort_by_start_asc].
+  apply insert_asc_swap_distinct. exact Hneq.
+Qed.
+
+(** Symmetric to [sort_by_start_desc_perm]: sort_by_start_asc is
+    Permutation-invariant on distinct-key inputs. *)
+Lemma sort_by_start_asc_perm :
+  forall es1 es2,
+    Permutation es1 es2 ->
+    distinct_starts es1 ->
+    sort_by_start_asc es1 = sort_by_start_asc es2.
+Proof.
+  intros es1 es2 Hperm. induction Hperm as
+      [| a l1 l2 Hp IH | a b l | l1 l2 l3 Hp1 IH1 Hp2 IH2]; intros Hd.
+  - (* perm_nil *) reflexivity.
+  - (* perm_skip *)
+    cbn [sort_by_start_asc].
+    apply distinct_starts_cons_iff in Hd. destruct Hd as [Hall Hd].
+    rewrite (IH Hd). reflexivity.
+  - (* perm_swap: same direction issue as the desc proof *)
+    apply distinct_starts_cons_iff in Hd. destruct Hd as [Hall_b Hd1].
+    apply distinct_starts_cons_iff in Hd1. destruct Hd1 as [Hall_a _].
+    inversion Hall_b as [|? ? Hneq _]. subst.
+    symmetry.
+    apply (sort_by_start_asc_insert_swap a b l).
+    intros Heq. apply Hneq. symmetry. exact Heq.
+  - (* perm_trans *)
+    rewrite (IH1 Hd).
+    assert (Hd2 : distinct_starts l2)
+      by (apply (distinct_starts_perm l1 l2 Hp1 Hd)).
+    rewrite (IH2 Hd2). reflexivity.
+Qed.
+
+(** Inductive descending_sorted's mirror for ascending. *)
+Inductive ascending_sorted : list edit -> Prop :=
+  | ascending_sorted_nil : ascending_sorted []
+  | ascending_sorted_singleton : forall e, ascending_sorted [e]
+  | ascending_sorted_cons :
+      forall e1 e2 rest,
+        e1.(e_start) <= e2.(e_start) ->
+        ascending_sorted (e2 :: rest) ->
+        ascending_sorted (e1 :: e2 :: rest).
+
+(** Symmetric to [insert_desc_preserves_sorted]. *)
+Lemma insert_asc_preserves_sorted :
+  forall e es,
+    ascending_sorted es ->
+    ascending_sorted (insert_asc e es).
+Proof.
+  intros e es Hes. induction Hes as [|e0|e1 e2 rest Hle Hsorted IH].
+  - simpl. constructor.
+  - simpl. destruct (Nat.leb (e_start e) (e_start e0)) eqn:Hle0.
+    + apply Nat.leb_le in Hle0.
+      apply ascending_sorted_cons; [exact Hle0 | constructor].
+    + apply Nat.leb_nle in Hle0.
+      simpl. apply ascending_sorted_cons.
+      * lia.
+      * constructor.
+  - simpl. destruct (Nat.leb (e_start e) (e_start e1)) eqn:Hle1.
+    + apply Nat.leb_le in Hle1.
+      apply ascending_sorted_cons; [exact Hle1 |].
+      apply ascending_sorted_cons; assumption.
+    + apply Nat.leb_nle in Hle1.
+      simpl in IH. simpl.
+      destruct (Nat.leb (e_start e) (e_start e2)) eqn:Hle2.
+      * apply Nat.leb_le in Hle2.
+        apply ascending_sorted_cons; [lia |].
+        apply ascending_sorted_cons; [exact Hle2 | exact Hsorted].
+      * apply Nat.leb_nle in Hle2.
+        apply ascending_sorted_cons; [exact Hle | exact IH].
+Qed.
+
+(** Symmetric to [sort_by_start_desc_sorted]. *)
+Lemma sort_by_start_asc_sorted :
+  forall es, ascending_sorted (sort_by_start_asc es).
+Proof.
+  induction es as [|e rest IH]; simpl.
+  - constructor.
+  - apply insert_asc_preserves_sorted. exact IH.
+Qed.
+
+(** Symmetric to [sort_by_start_desc_id_when_sorted]. *)
+Lemma sort_by_start_asc_id_when_sorted :
+  forall es, ascending_sorted es -> sort_by_start_asc es = es.
+Proof.
+  intros es Hes. induction Hes as [|e0|e1 e2 rest Hle Hsorted IH].
+  - reflexivity.
+  - simpl. reflexivity.
+  - change (sort_by_start_asc (e1 :: e2 :: rest))
+      with (insert_asc e1 (sort_by_start_asc (e2 :: rest))).
+    rewrite IH.
+    cbn [insert_asc].
+    assert (Nat.leb (e_start e1) (e_start e2) = true) as Hleb.
+    { apply Nat.leb_le. exact Hle. }
+    rewrite Hleb. reflexivity.
+Qed.
+
+(** ── Cursor-universal Stage 1 zero-admit witness ──────────────────── *)
+
+Definition apply_edits_cursor_universal_stage1_zero_admits : True := I.

--- a/specs/v27/V27_APPLY_EDITS_CURSOR_UNIVERSAL_PLAN.md
+++ b/specs/v27/V27_APPLY_EDITS_CURSOR_UNIVERSAL_PLAN.md
@@ -191,9 +191,14 @@ template:
    didn't.
 4. **Verification numbers** — theorem count delta, gate state.
 
-## Acceptance criteria for the cycle (v27.0.4)
+## Acceptance criteria for the cycle (state at end of Stage 1)
 
-- [ ] All 4 Stage 1 sort-asc lemmas Qed.
+- [x] All Stage 1 sort-asc lemmas Qed (PR #325): shipped
+  `insert_asc_swap_distinct`, `sort_by_start_asc_insert_swap`,
+  `sort_by_start_asc_perm`, `insert_asc_preserves_sorted`,
+  `sort_by_start_asc_sorted`, `sort_by_start_asc_id_when_sorted`,
+  plus `ascending_sorted` Inductive (6 lemmas + 1 Inductive,
+  +2 over the original 4-lemma plan estimate).
 - [ ] Stage 2 `sort_by_start_desc_eq_rev_asc` Qed.
 - [ ] Stage 3 cursor-walk shape lemma Qed.
 - [ ] Stage 4 sequential-descending shape lemma Qed (the


### PR DESCRIPTION
## Summary

Per `specs/v27/V27_APPLY_EDITS_CURSOR_UNIVERSAL_PLAN.md` Stage 1 of 7. Symmetric ascending-sort versions of the existing Stage 4 descending-sort lemmas (PRs #319→#322 of the apply_edits_assoc cycle). These prerequisites feed the cycle's Stage 4 substantive sequential-descending shape lemma toward the headline `apply_edits_cursor_eq_parallel`.

## What Stage 1 delivers

```coq
Lemma insert_asc_swap_distinct          : Qed   (* mirror insert_desc_swap_distinct *)
Lemma sort_by_start_asc_insert_swap     : Qed
Lemma sort_by_start_asc_perm            : Qed   (* mirror sort_by_start_desc_perm *)
Inductive ascending_sorted : list edit -> Prop  (* mirror descending_sorted *)
Lemma insert_asc_preserves_sorted       : Qed
Lemma sort_by_start_asc_sorted          : Qed
Lemma sort_by_start_asc_id_when_sorted  : Qed
```

All 6 lemmas Qed-proved via the same proof structure as the descending-sort versions in PR #322 (case analysis over Nat.leb on the swap lemma; Permutation induction on the perm lemma; insertion-sort invariant on the sortedness lemmas).

## Verification

| Check | Result |
|---|---|
| `dune build` | exit 0 |
| `Print Assumptions` on all 6 new lemmas | all "Closed under the global context" |
| Admits / Axioms in `ApplyEditsAssoc.v` | 0 / 0 |
| `pre_release_check.py --skip-build` | ALL CHECKS PASSED |
| Differential test vs v27.0.3 (330 corpus files) | **PASS — 0 diffs** (proof-only) |

## Stages remaining (per V27_APPLY_EDITS_CURSOR_UNIVERSAL_PLAN.md)

- **Stage 2**: `sort_by_start_desc_eq_rev_asc` bridge lemma (relates the two sort directions on distinct-starts inputs).
- **Stage 3**: cursor-walk shape lemma (express `apply_edits_cursor_aux` as a canonical byte mapping).
- **Stage 4** (substantive): sequential-descending shape lemma (`apply_edits_concrete src (rev sorted_asc)` = same canonical mapping).
- **Stage 5**: combine into `apply_edits_cursor_eq_parallel` headline.
- **Stage 6**: wire into ADMISSIBILITY_MAP + remove "future extension" framing in MERGING_GUARANTEES.md.
- **Stage 7**: release-bump v27.0.4.

## Test plan

- [ ] proof-ci, unicode-smoke, l1-smoke, smoke-cli, rest-smoke, perf-ci, xxh-selfcheck, unit-tests, spec-drift all green
- [ ] dune build clean
- [ ] 0 admits / 0 axioms invariant maintained
- [ ] Differential 0 diffs vs v27.0.3