### PR TITLE
docs(v27): spec hygiene — tick Stage 6 v27.0.3 + cursor-universal Stage 1+2 acceptance

### DIFF
--- a/specs/v27/V27_APPLY_EDITS_ASSOC_PLAN.md
+++ b/specs/v27/V27_APPLY_EDITS_ASSOC_PLAN.md
@@ -206,4 +206,5 @@ Target tag: v27.0.4.
 - [x] `docs/MERGING_GUARANTEES.md` describing the parallel-applier
   semantics + original-source-offset interpretation +
   counter-example + runtime correspondence (Stage 5, PR #323).
-- [ ] CHANGELOG `[v27.0.3]` entry (Stage 6 release-bump).
+- [x] CHANGELOG `[v27.0.3]` entry + tag on main (Stage 6
+  release-bump, PR #324, tag `v27.0.3` @ commit `f3437c1`).

--- a/specs/v27/V27_APPLY_EDITS_CURSOR_UNIVERSAL_PLAN.md
+++ b/specs/v27/V27_APPLY_EDITS_CURSOR_UNIVERSAL_PLAN.md
@@ -204,7 +204,10 @@ template:
   `sort_by_start_asc_sorted`, `sort_by_start_asc_id_when_sorted`,
   plus `ascending_sorted` Inductive (6 lemmas + 1 Inductive,
   +2 over the original 4-lemma plan estimate).
-- [ ] Stage 2 `sort_by_start_desc_eq_rev_asc` Qed.
+- [x] Stage 2 `sort_by_start_desc_eq_rev_asc` Qed (PR #326,
+  merged 2026-04-30 @ commit `0b87a44`).  Plus 9 supporting
+  lemmas + 4 reflexivity Examples; all Closed under the global
+  context.
 - [ ] Stage 3 cursor-walk shape lemma Qed.
 - [ ] Stage 4 sequential-descending shape lemma Qed (the
   technically substantive piece).

--- a/specs/v27/V27_APPLY_EDITS_CURSOR_UNIVERSAL_PLAN.md
+++ b/specs/v27/V27_APPLY_EDITS_CURSOR_UNIVERSAL_PLAN.md
@@ -45,12 +45,17 @@ Symmetric versions of the existing Stage 4 sort-desc lemmas:
   `insert_desc_swap_distinct`
 - `Lemma sort_by_start_asc_perm` (Qed) — symmetric to
   `sort_by_start_desc_perm`
-- `Lemma sort_by_start_asc_sorted_ascending` (Qed) — sort produces
-  ascending order
+- `Lemma sort_by_start_asc_sorted` (Qed) — sort produces ascending
+  order.  (Originally named `_sorted_ascending` in this plan; renamed
+  during PR #325 to mirror the existing `sort_by_start_desc_sorted`
+  symbol.)
 - `Lemma sort_by_start_asc_id_when_sorted` (Qed) — identity on
   already-sorted-ascending input
 
-**Acceptance:** all 4 Qed; all `Print Assumptions` Closed.
+**Acceptance:** all 4 Qed; all `Print Assumptions` Closed.  (PR
+#325 actually shipped 6 lemmas + 1 Inductive `ascending_sorted`;
+see the cycle-acceptance checklist at the end of this file for the
+full list.)
 
 ### Stage 2 — sort_asc/sort_desc are reverses on distinct-starts inputs
 **Branch:** `v27.0/cursor-univ-stage2-rev-bridge`


### PR DESCRIPTION
## Summary

Spec-hygiene PR found during a "100% spec compliance" audit before continuing the cursor-universal cycle past Stage 2. Three small docs fixes:

1. `specs/v27/V27_APPLY_EDITS_ASSOC_PLAN.md` — Stage 6 CHANGELOG `[v27.0.3]` line was `[ ]` though v27.0.3 is RELEASED (PR #324, tag `v27.0.3` @ commit `f3437c1`). Ticked → `[x]` with refs.
2. `specs/v27/V27_APPLY_EDITS_CURSOR_UNIVERSAL_PLAN.md` Stage 1 body — referenced lemma name `sort_by_start_asc_sorted_ascending` but PR #325 shipped `sort_by_start_asc_sorted` (renamed to mirror `sort_by_start_desc_sorted`). Updated body name + added a parenthetical so future readers don't grep for the original name. Stage 1 acceptance line "all 4 Qed" pointed to the cycle-acceptance section (PR #325 actually shipped 6 lemmas + 1 Inductive).
3. `specs/v27/V27_APPLY_EDITS_CURSOR_UNIVERSAL_PLAN.md` cycle-acceptance — Stage 2 line `[ ] Stage 2 sort_by_start_desc_eq_rev_asc Qed` ticked to `[x]` with PR #326 merge / commit refs.

All pure docs/plan hygiene — no code change.

## Test plan
- [x] No code changed
- [ ] CI green