### PR TITLE
feat(v27 cursor-universal Stage 6): wire universal extension into docs + ADMISSIBILITY_MAP

### DIFF
--- a/docs/MERGING_GUARANTEES.md
+++ b/docs/MERGING_GUARANTEES.md
@@ -166,36 +166,48 @@ proof to the shipped binary because both algorithms compute the
 same parallel-applier semantic on every input where
 `distinct_starts` holds.
 
-The runtime-vs-Coq correspondence is **mechanised** for
-representative inputs in `proofs/ApplyEditsAssoc.v` Stage 5b:
+The runtime-vs-Coq correspondence is **mechanically certified
+universally** in `proofs/ApplyEditsAssoc.v`:
 
-- `Definition apply_edits_cursor src es :=
-   apply_edits_cursor_aux src 0 (sort_by_start_asc es)` — Coq
-  mirror of OCaml `Cst_edit.apply_all`'s ascending-sort + cursor-
-  walk algorithm.
-- 4 `Example`s prove `apply_edits_cursor src es =
-  apply_edits_parallel src es` by `reflexivity` on the documented
-  non-overlapping inputs (2-edit, 2-edit-swap, 3-edit,
-  3-edit-permuted). All `Print Assumptions` Closed under the
-  global context.
-- `apply_edits_cursor_empty` and `apply_edits_parallel_empty`
-  Qed-prove that both algorithms return the source unchanged for
-  the empty edit list.
+```coq
+Theorem apply_edits_cursor_eq_parallel :
+  forall (src : bytes) (es : list edit),
+    distinct_starts es ->
+    pairwise_non_overlapping es ->
+    (forall e, In e es -> edit_wf e) ->
+    (forall e, In e es -> e.(e_end) <= length src) ->
+    apply_edits_cursor src es = apply_edits_parallel src es.
+```
 
-The fully universal theorem
-`forall src es, distinct_starts es -> pairwise_non_overlapping es ->
-   apply_edits_cursor src es = apply_edits_parallel src es`
-extends the corpus mechanisation to every valid input.  Stage-
-decomposed plan committed as
-[`specs/v27/V27_APPLY_EDITS_CURSOR_UNIVERSAL_PLAN.md`](../specs/v27/V27_APPLY_EDITS_CURSOR_UNIVERSAL_PLAN.md)
-(7 stages, target tag **v27.0.4**, ~4–6 sessions).  Stage 4 of
-that plan carries the technically substantive proof
-(induction over the sorted-ascending list, with cursor-walk and
-sequential-descending shapes both reduced to a canonical byte
-mapping); Stages 1–3 build prerequisite sort-permutation /
-sort-rev-bridge / cursor-walk-shape lemmas; Stage 5 combines;
-Stage 6 wires into ADMISSIBILITY_MAP + this doc; Stage 7
-release-bumps v27.0.4.
+Qed.  `Print Assumptions` returns "Closed under the global
+context" — the equation holds on **every** valid edit list, not
+just the four corpus-level reflexivity Examples shipped at
+v27.0.3.
+
+The proof structure (cycle PRs #325 → #330):
+
+- **`apply_edits_cursor src es := apply_edits_cursor_aux src 0
+  (sort_by_start_asc es)`** — Coq mirror of OCaml
+  `Cst_edit.apply_all`'s ascending-sort + cursor-walk algorithm
+  (defined in v27.0.3 Stage 5b).
+- **Stage 1** (PR #325): symmetric ascending-sort permutation +
+  sortedness lemmas.
+- **Stage 2** (PR #326): bridge lemma
+  `sort_by_start_desc_eq_rev_asc` connecting the two sort
+  directions on `distinct_starts` inputs.
+- **Stage 3** (PR #328): canonical form `cursor_walk_canonical` +
+  `apply_edits_cursor_aux_shape` (cursor-walk = canonical).
+- **Stage 4** (PR #329): substantive sequential-descending shape
+  lemma `apply_edits_concrete_rev_sorted_shape` (parallel applier
+  on `rev sorted_asc` = canonical).
+- **Stage 5** (PR #330): combines Stages 1–4 via
+  `pairwise_non_overlapping_perm` + sort-permutation lifts into
+  the universal headline.
+
+The four reflexivity Examples shipped at v27.0.3 Stage 5b
+(`apply_edits_cursor_matches_parallel_*`) are **superseded for
+the runtime-correspondence claim** but remain in the file as
+quick-check sanity tests.
 
 The rewrite engine surface relevant to v27.0.3:
 

--- a/proofs/ADMISSIBILITY_MAP.md
+++ b/proofs/ADMISSIBILITY_MAP.md
@@ -296,22 +296,35 @@ its premise.
    apply function defined in Coq, under the same disjointness
    precondition.
 
-### Rewrite engine — associative-reorder (`ApplyEditsAssoc.v`, DISCHARGED in v27.0.3)
+### Rewrite engine — associative-reorder (`ApplyEditsAssoc.v`, DISCHARGED in v27.0.3 + v27.0.4 universal extension)
 
-> **v27.0.3 STATUS.** `proofs/ApplyEditsAssoc.v` ships
-> `apply_edits_parallel_perm` (Theorem, Qed, Closed under the
-> global context).  Closes the v26.4 deferral originally noted as
-> `apply_edits_concrete_associative_subset` (the original form was
-> FALSE in general — sequential `apply_edits_concrete` interprets
-> each edit's `e_start` / `e_end` relative to the post-earlier-edits
-> buffer, not the original source, so reordering non-overlapping
-> edits in the SEQUENTIAL applier produces different results).
+> **v27.0.3 + v27.0.4 STATUS.** `proofs/ApplyEditsAssoc.v` ships
+> two complementary headlines:
 >
-> The substantive guarantee is permutation invariance for the
+> 1. **v27.0.3 — parallel applier permutation invariance**
+>    (`apply_edits_parallel_perm`, Theorem, Qed, Closed under the
+>    global context).  Closes the v26.4 deferral originally noted as
+>    `apply_edits_concrete_associative_subset` (the original form was
+>    FALSE in general — sequential `apply_edits_concrete` interprets
+>    each edit's `e_start` / `e_end` relative to the post-earlier-edits
+>    buffer, not the original source, so reordering non-overlapping
+>    edits in the SEQUENTIAL applier produces different results).
+>
+> 2. **v27.0.4 — universal cursor-walk = parallel-applier**
+>    (`apply_edits_cursor_eq_parallel`, Theorem, Qed, Closed under
+>    the global context).  The runtime-Coq correspondence between
+>    the OCaml `Cst_edit.apply_all` (sort ascending + cursor walk
+>    over the original source) and the parallel applier
+>    (sort descending + sequential `apply_edits_concrete`) is now
+>    mechanically certified for *every* valid edit list, not just
+>    the four corpus-level reflexivity Examples shipped at v27.0.3
+>    Stage 5b.
+>
+> The v27.0.3 guarantee is permutation invariance for the
 > *parallel* applier `apply_edits_parallel := apply_edits_concrete o
 > sort_by_start_desc`, which interprets every offset relative to the
 > original source by sorting edits descending and applying them
-> right-to-left.
+> right-to-left:
 >
 > ```coq
 > Theorem apply_edits_parallel_perm :
@@ -321,12 +334,42 @@ its premise.
 >     apply_edits_parallel src es1 = apply_edits_parallel src es2.
 > ```
 >
-> Stage breakdown: PR #319 (Stage 1 `non_overlapping`) → PR #320
-> (Stage 2 parallel applier + counter-example documentation) →
-> PR #321 (Stage 3 sort-idempotence + sorted equivalence) →
-> PR #322 (Stage 4 substantive `apply_edits_parallel_perm`) →
-> PR #323+ (Stage 5 ADMISSIBILITY_MAP wire-in / this entry, plus
-> `docs/MERGING_GUARANTEES.md`) → release-bump v27.0.3.
+> The v27.0.4 universal extension certifies that the OCaml runtime
+> applier produces the same byte stream as the parallel applier
+> for every valid input:
+>
+> ```coq
+> Theorem apply_edits_cursor_eq_parallel :
+>   forall src es,
+>     distinct_starts es ->
+>     pairwise_non_overlapping es ->
+>     (forall e, In e es -> edit_wf e) ->
+>     (forall e, In e es -> e.(e_end) <= length src) ->
+>     apply_edits_cursor src es = apply_edits_parallel src es.
+> ```
+>
+> Stage breakdown:
+> - **v27.0.3 cycle (PRs #319→#324):** PR #319 (Stage 1
+>   `non_overlapping`) → PR #320 (Stage 2 parallel applier +
+>   counter-example documentation) → PR #321 (Stage 3
+>   sort-idempotence + sorted equivalence) → PR #322 (Stage 4
+>   substantive `apply_edits_parallel_perm`) → PR #323
+>   (ADMISSIBILITY_MAP wire-in + `docs/MERGING_GUARANTEES.md` +
+>   Stage 5b cursor-walk Coq mirror with 4 corpus-level Examples)
+>   → PR #324 (release-bump v27.0.3).
+> - **v27.0.4 cycle (PRs #325→#330+):** PR #325 (Stage 1
+>   sort-asc permutation lemmas) → PR #326 (Stage 2
+>   `sort_by_start_desc_eq_rev_asc` bridge) → PR #328 (Stage 3
+>   `cursor_walk_canonical` + `apply_edits_cursor_aux_shape`) →
+>   PR #329 (Stage 4 substantive
+>   `apply_edits_concrete_rev_sorted_shape`) → PR #330 (Stage 5
+>   universal `apply_edits_cursor_eq_parallel`) → Stage 6 (this
+>   entry) → release-bump v27.0.4.
+>
+> The Stage 5b corpus-level mechanisation (4 reflexivity Examples
+> on representative inputs) shipped at v27.0.3 is **superseded by
+> the universal Theorem** for the runtime-correspondence claim;
+> the Examples remain as quick-check sanity tests.
 
 **File:** `proofs/ApplyEditsAssoc.v`.
 **Predicate:** `distinct_starts es := NoDup (map e_start es)` —

--- a/proofs/ADMISSIBILITY_MAP.md
+++ b/proofs/ADMISSIBILITY_MAP.md
@@ -357,14 +357,17 @@ its premise.
 >   (ADMISSIBILITY_MAP wire-in + `docs/MERGING_GUARANTEES.md` +
 >   Stage 5b cursor-walk Coq mirror with 4 corpus-level Examples)
 >   → PR #324 (release-bump v27.0.3).
-> - **v27.0.4 cycle (PRs #325→#330+):** PR #325 (Stage 1
+> - **v27.0.4 cycle (PRs #325, #326, #328, #329, #330, #332,
+>   + Stage 7 release-bump pending):** PR #325 (Stage 1
 >   sort-asc permutation lemmas) → PR #326 (Stage 2
 >   `sort_by_start_desc_eq_rev_asc` bridge) → PR #328 (Stage 3
 >   `cursor_walk_canonical` + `apply_edits_cursor_aux_shape`) →
 >   PR #329 (Stage 4 substantive
 >   `apply_edits_concrete_rev_sorted_shape`) → PR #330 (Stage 5
->   universal `apply_edits_cursor_eq_parallel`) → Stage 6 (this
->   entry) → release-bump v27.0.4.
+>   universal `apply_edits_cursor_eq_parallel`) → PR #332
+>   (Stage 6 — this entry, plus
+>   `docs/MERGING_GUARANTEES.md` + `proofs/ApplyEditsAssoc.v` file
+>   header) → Stage 7 release-bump v27.0.4 (pending).
 >
 > The Stage 5b corpus-level mechanisation (4 reflexivity Examples
 > on representative inputs) shipped at v27.0.3 is **superseded by

--- a/proofs/ApplyEditsAssoc.v
+++ b/proofs/ApplyEditsAssoc.v
@@ -1,15 +1,27 @@
-(** * ApplyEditsAssoc — apply_edits associative-reorder theorem.
+(** * ApplyEditsAssoc — apply_edits associative-reorder + universal
+    cursor-walk = parallel-applier theorems.
 
-    Per `specs/v27/V27_APPLY_EDITS_ASSOC_PLAN.md` (REVISED): prove
-    that the parallel applier [apply_edits_parallel] (defined as
-    [apply_edits_concrete o sort_by_start_desc]) is invariant under
-    reordering of edits with distinct start positions.  The original
-    draft form against the SEQUENTIAL applier is FALSE in general —
-    sequential interprets offsets relative to the current buffer,
-    not the original source (counter-example in the Stage 2 block
-    of this file).
+    Two complementary headlines, shipped across two release cycles:
 
-    Multi-stage progression:
+    1. **v27.0.3 — parallel applier permutation invariance.**  Per
+       `specs/v27/V27_APPLY_EDITS_ASSOC_PLAN.md` (REVISED): the
+       parallel applier [apply_edits_parallel] (defined as
+       [apply_edits_concrete o sort_by_start_desc]) is invariant
+       under reordering of edits with distinct start positions.
+       The original draft form against the SEQUENTIAL applier is
+       FALSE in general — sequential interprets offsets relative
+       to the current buffer, not the original source
+       (counter-example in the Stage 2 block of this file).
+
+    2. **v27.0.4 — universal runtime correspondence.**  Per
+       `specs/v27/V27_APPLY_EDITS_CURSOR_UNIVERSAL_PLAN.md`: the
+       OCaml [Cst_edit.apply_all] (sort ascending + cursor walk)
+       and the parallel applier produce the same byte stream for
+       every valid edit list, not just the four corpus-level
+       reflexivity Examples shipped at v27.0.3 Stage 5b.  Headline:
+       [apply_edits_cursor_eq_parallel].
+
+    apply_edits_assoc cycle (v27.0.3) — multi-stage progression:
     - Stage 1 (PR #319): [non_overlapping] predicate + sanity
       lemmas (decidability, symmetry, consistency with the existing
       [RewritePreservesCST.edits_conflict] predicate).
@@ -25,8 +37,44 @@
       (originally noted as
       [apply_edits_concrete_associative_subset], FALSE shape).
     - Stage 5 (PR #323): wire into [proofs/ADMISSIBILITY_MAP.md] +
-      create [docs/MERGING_GUARANTEES.md].
-    - Stage 6: release-bump v27.0.3.
+      create [docs/MERGING_GUARANTEES.md] + Stage 5b cursor-walk
+      Coq mirror of OCaml [Cst_edit.apply_all] with 4 reflexivity
+      Examples on representative inputs (corpus-level
+      mechanisation of the runtime correspondence).
+    - Stage 6 (PR #324): release-bump v27.0.3.
+
+    cursor-universal cycle (v27.0.4) — universal extension:
+    - Stage 1 (PR #325): symmetric ascending-sort permutation
+      lemmas ([insert_asc_swap_distinct],
+      [sort_by_start_asc_perm], [insert_asc_preserves_sorted],
+      [sort_by_start_asc_sorted],
+      [sort_by_start_asc_id_when_sorted], + [ascending_sorted]
+      Inductive).
+    - Stage 2 (PR #326): bridge lemma
+      [sort_by_start_desc_eq_rev_asc] connecting the two sort
+      directions on [distinct_starts] inputs.
+    - Stage 3 (PR #328): canonical form [cursor_walk_canonical]
+      Fixpoint + [apply_edits_cursor_aux_shape] (cursor-walk =
+      canonical, unconditional) +
+      [apply_edits_cursor_aux_shape_with_preconds] (plan-signature
+      variant).
+    - Stage 4 (PR #329, SUBSTANTIVE):
+      [apply_edits_concrete_rev_sorted_shape] — for sorted-
+      ascending non-overlapping in-bounds distinct-starts
+      well-formed edits, [apply_edits_concrete src (rev sorted_asc)
+      = cursor_walk_canonical src 0 sorted_asc].  The technically
+      interesting cycle stage: takes 14 supporting lemmas covering
+      take/drop ↔ firstn/skipn bridges, predicate cons-inversions,
+      and two cursor_walk_canonical manipulation lemmas
+      (skipn-advance, firstn-prefix).
+    - Stage 5 (PR #330, UNIVERSAL HEADLINE):
+      [apply_edits_cursor_eq_parallel] combines Stages 1–4 via
+      [pairwise_non_overlapping_perm] + four sort-permutation
+      precondition lifts into the universal Theorem.
+    - Stage 6 (this PR): wire universal extension into
+      [proofs/ADMISSIBILITY_MAP.md] + [docs/MERGING_GUARANTEES.md]
+      + this header.
+    - Stage 7: release-bump v27.0.4.
 
     Zero admits, zero axioms. *)
 
@@ -575,13 +623,12 @@ Definition apply_edits_assoc_stage4_zero_admits : True := I.
     This block introduces a Coq mirror of the OCaml algorithm
     ([apply_edits_cursor]) and proves it equal to
     [apply_edits_parallel] on byte-by-byte test cases via
-    reflexivity (4 Examples on representative inputs).  The fully
-    universal theorem
-    [apply_edits_cursor_eq_parallel : forall src es valid_inputs ->
-      apply_edits_cursor src es = apply_edits_parallel src es]
-    extends this to every valid input; stage-decomposed plan
-    committed as [specs/v27/V27_APPLY_EDITS_CURSOR_UNIVERSAL_PLAN.md]
-    (7 stages, target tag v27.0.4). *)
+    reflexivity (4 Examples on representative inputs).  These
+    Examples are now superseded by the universal Theorem
+    [apply_edits_cursor_eq_parallel] (shipped at v27.0.4 in the
+    "v27 cursor-universal STAGE 5" block of this file) for the
+    runtime-correspondence claim, but remain as quick-check
+    sanity tests. *)
 
 (** Insertion sort ASCENDING by [e_start] — symmetric to
     [insert_desc] / [sort_by_start_desc]. *)

--- a/proofs/ApplyEditsAssoc.v
+++ b/proofs/ApplyEditsAssoc.v
@@ -71,7 +71,7 @@
       [apply_edits_cursor_eq_parallel] combines Stages 1–4 via
       [pairwise_non_overlapping_perm] + four sort-permutation
       precondition lifts into the universal Theorem.
-    - Stage 6 (this PR): wire universal extension into
+    - Stage 6 (PR #332): wire universal extension into
       [proofs/ADMISSIBILITY_MAP.md] + [docs/MERGING_GUARANTEES.md]
       + this header.
     - Stage 7: release-bump v27.0.4.

--- a/proofs/ApplyEditsAssoc.v
+++ b/proofs/ApplyEditsAssoc.v
@@ -1309,13 +1309,11 @@ Proof.
   - apply IH.
 Qed.
 
-(** Singleton case: [apply_edits_concrete src [e] = apply_one_edit src e]. *)
-Lemma apply_edits_concrete_singleton :
-  forall src e,
-    apply_edits_concrete src [e] = apply_one_edit src e.
-Proof.
-  intros src e. simpl. reflexivity.
-Qed.
+(** [apply_edits_concrete_singleton] is reused from
+    [proofs/RewritePreservesCST.v:290] (already in scope via the
+    [From LaTeXPerfectionist Require Import ... RewritePreservesCST]
+    line at the top of this file).  Round-6 audit removed an
+    accidental local re-definition shipped by Stage 4 PR #329. *)
 
 (** Stage 4 helpers — pairwise-non-overlapping inversion.
     From [pairwise_non_overlapping (e :: rest)] derive both:


### PR DESCRIPTION
## Summary

Stage 6 of [V27_APPLY_EDITS_CURSOR_UNIVERSAL_PLAN](specs/v27/V27_APPLY_EDITS_CURSOR_UNIVERSAL_PLAN.md). Three docs updates acknowledging the v27.0.4 universal cursor-walk = parallel-applier theorem now mechanically certifies the runtime correspondence universally.

### 1. `proofs/ADMISSIBILITY_MAP.md` "Rewrite engine — associative-reorder" entry

- Extended title to "(DISCHARGED in v27.0.3 + v27.0.4 universal extension)"
- Added the universal Theorem signature alongside `apply_edits_parallel_perm`
- Added v27.0.4 PR breakdown (#325→#330+) alongside the v27.0.3 PRs (#319→#324)
- Marked v27.0.3 Stage 5b corpus mechanisation as superseded for the runtime-correspondence claim (Examples remain as sanity tests)

### 2. `docs/MERGING_GUARANTEES.md` "Runtime correspondence" section

- Replaced "achievable via induction; multi-session future extension" framing with citation of the shipped `apply_edits_cursor_eq_parallel` Theorem (Qed, Closed)
- Added the proof-structure breakdown across cycle PRs #325→#330
- Marked the four reflexivity Examples as sanity tests, not the substantive correspondence

### 3. `proofs/ApplyEditsAssoc.v` file header

- Extended to two complementary headlines (v27.0.3 parallel applier permutation invariance and v27.0.4 universal runtime correspondence)
- Added cursor-universal cycle stage breakdown (Stages 1–7)
- Updated the Stage 5b block header to mark its 4 reflexivity Examples as superseded by the universal Theorem for the runtime-correspondence claim

## Verification

- `dune build proofs`: clean
- `pre_release_check.py --skip-build`: ALL CHECKS PASSED (15/15)
- `run_differential_test vs v27.0.3`: 330 files, 0 diffs
- No "queued / multi-session / future extension" framing remains for this work (verified via grep across `docs/` and `proofs/`)

## Stage progression

- Stages 1–5 (PRs #325, #326, #328, #329, #330): all merged
- Stage 5b corpus mechanisation (v27.0.3): superseded by Stage 5 universal Theorem
- **Stage 6 (this PR)**: docs wire-in
- Stage 7 (next): release-bump v27.0.4

## Test plan
- [x] dune build proofs clean
- [x] pre_release_check 15/15 PASSED
- [x] differential test 0 diffs vs v27.0.3
- [x] No stale "future extension" framing remains
- [ ] CI green on PR