### PR TITLE
fix(ci): perf-nightly OPAMSWITCH=l0-testing override breaks GitHub Actions

### DIFF
--- a/scripts/perf_summary.sh
+++ b/scripts/perf_summary.sh
@@ -3,6 +3,13 @@ set -euo pipefail
 
 # Produce a local perf summary CSV by running ab_microbench (10K) and
 # edit_window_bench (5K) and merging results.
+#
+# OPAMSWITCH handling: respect the caller's OPAMSWITCH if explicitly set
+# (e.g. local development with a `l0-testing` switch), otherwise fall
+# through to the ambient opam switch (CI runners use a switch named
+# after the OCaml version, NOT `l0-testing`).  Hardcoding `l0-testing`
+# as a default broke perf-nightly on GitHub Actions because that switch
+# does not exist there — see commit message for context.
 
 FILE=${1:-corpora/perf/perf_smoke_big.tex}
 AB_CSV=/tmp/ab_microbench_10k.csv
@@ -10,12 +17,12 @@ EDIT_CSV=/tmp/edit_window_bench_5k.csv
 OUT=${2:-/tmp/perf_summary.csv}
 
 echo "[perf-summary] running ab_microbench 10k on $FILE"
-OPAMSWITCH=${OPAMSWITCH:-l0-testing} opam exec -- \
+opam exec -- \
   ./_build/default/latex-parse/bench/ab_microbench.exe \
   "$FILE" 10000 --csv "$AB_CSV"
 
 echo "[perf-summary] running edit_window_bench 5k"
-OPAMSWITCH=${OPAMSWITCH:-l0-testing} opam exec -- \
+opam exec -- \
   ./_build/default/latex-parse/bench/edit_window_bench.exe \
   corpora/perf/edit_window_4kb.tex 5000 --csv "$EDIT_CSV" --window 4096
 


### PR DESCRIPTION
## Summary

`scripts/perf_summary.sh` forced `OPAMSWITCH=l0-testing` if unset. GitHub Actions runners (via `.github/actions/setup-ocaml-env` / `setup-ocaml@v2`) create a switch named after the OCaml version, NOT `l0-testing`, so the override picked a non-existent switch and `opam exec` errored:

```
[ERROR] The selected switch l0-testing is not installed.
```

This has been failing every nightly run for at least 5 consecutive days (April 28 → May 2). The perf-nightly workflow's preceding steps (perf-gate, edit-window-gate, first-token-gate) all PASSED — the failure was isolated to `perf_summary.sh`'s OPAMSWITCH override.

### Fix

Drop the override. When `OPAMSWITCH` is explicitly set by a local caller, `opam exec` already respects it via the environment; when unset (CI default), `opam exec` uses the ambient switch. No need to inject a hardcoded fallback name.

Documented the OPAMSWITCH handling decision inline so future readers don't re-introduce the override.

### Scope

Other scripts with the same pattern (`smoke_rules_pilot_cli.sh`, `build_simd.sh`, `run_all_gates.sh`, `hash_gate.sh`, `pilot_fp_scan.sh`, `pre-commit-hook`) are not affected because they're not invoked from CI workflows that hit this code path. Left alone to limit blast radius.

## Test plan
- [x] No code changed in proofs/runtime
- [ ] CI green on PR
- [ ] Next perf-nightly run (next scheduled: 2026-05-03 04:00 UTC) passes