### PR TITLE
fix(v27.0.13 round-2 audit): TYPO-039 trim trailing punctuation

### DIFF
--- a/latex-parse/src/test_typo_fix.ml
+++ b/latex-parse/src/test_typo_fix.ml
@@ -758,13 +758,12 @@ let () =
 
   run "TYPO-039 fix: math + wrapped + plain integration (round-1 audit)"
     (fun tag ->
-      (* All four conditions in one input: - plain URL (should wrap) - URL
-         inside \\url{} (skip) - URL inside \\href{} URL slot (skip) - URL
-         inside math (skip) Note: the URL regex is permissive on trailing
-         punctuation, so use space-delimited URLs to keep the wrap span
-         clean. *)
+      (* All four conditions in one input: plain URL (wraps), URL inside \\url{}
+         (skip), URL inside \\href{} URL slot (skip), URL inside math (skip).
+         Round-2 audit: comma after the plain URL exercises trim_trailing_punct
+         so the wrap span excludes the comma. *)
       let src =
-        "Plain http://a.io wrapped \\url{http://b.io} href \
+        "Plain http://a.io, wrapped \\url{http://b.io} href \
          \\href{http://c.io}{c} and math $http://d.io$"
       in
       let edits = fix_edits "TYPO-039" src in
@@ -772,8 +771,25 @@ let () =
       expect
         (List.length edits = 1
         && out
-           = "Plain \\url{http://a.io} wrapped \\url{http://b.io} href \
+           = "Plain \\url{http://a.io}, wrapped \\url{http://b.io} href \
               \\href{http://c.io}{c} and math $http://d.io$")
-        (tag ^ ": only plain URL wrapped"));
+        (tag ^ ": only plain URL wrapped, trailing comma trimmed"));
+
+  run "TYPO-039 fix: trims trailing punctuation (round-2 audit)" (fun tag ->
+      (* The URL regex `https?://[^ \t\n}]+` is permissive on trailing
+         punctuation. trim_trailing_punct excludes `,.;:!)` from the wrap span
+         so sentence-ending marks stay outside \\url{}. `?` is NOT trimmed
+         (commonly starts a URL query string). *)
+      let src =
+        "Site https://a.io. Also https://b.io! See (https://c.io); end."
+      in
+      let edits = fix_edits "TYPO-039" src in
+      let out = apply_all src edits in
+      expect
+        (List.length edits = 3
+        && out
+           = "Site \\url{https://a.io}. Also \\url{https://b.io}! See \
+              (\\url{https://c.io}); end.")
+        (tag ^ ": .!) trimmed from URL wrap span"));
 
   finalise "typo-fix"

--- a/latex-parse/src/validators_l0_typo.ml
+++ b/latex-parse/src/validators_l0_typo.ml
@@ -1812,10 +1812,30 @@ let r_typo_039 : rule =
         outside_math start_offset && not (already_wrapped s start_offset))
       (collect_matches s)
   in
+  (* Round-2 audit fix: the URL regex `https?://[^ \t\n}]+` is permissive on
+     trailing punctuation (period, comma, semicolon, colon, bang, right-paren),
+     so a URL followed by a sentence-ending mark would have the punctuation
+     absorbed into the wrap (e.g. `Visit https://x.com.` would become `Visit
+     \url{https://x.com.}` with the period as part of the URL). Trim trailing
+     punctuation from the fix span; `?` is intentionally NOT trimmed because it
+     commonly starts a URL query string. *)
+  let trim_trailing_punct s start_offset end_offset =
+    let punct = [ ','; '.'; ';'; ':'; '!'; ')' ] in
+    let e = ref end_offset in
+    while !e > start_offset && List.mem s.[!e - 1] punct do
+      decr e
+    done;
+    !e
+  in
   let mk_fix_edits s =
     List.map
-      (fun (start_offset, end_offset, url) ->
-        Cst_edit.replace ~start_offset ~end_offset ("\\url{" ^ url ^ "}"))
+      (fun (start_offset, end_offset, _url) ->
+        let trimmed_end = trim_trailing_punct s start_offset end_offset in
+        let trimmed_url =
+          String.sub s start_offset (trimmed_end - start_offset)
+        in
+        Cst_edit.replace ~start_offset ~end_offset:trimmed_end
+          ("\\url{" ^ trimmed_url ^ "}"))
       (unwrapped_matches s)
   in
   let run s =


### PR DESCRIPTION
## Summary
- Round-2 audit follow-up to PR #344 (squash-merge dropped this commit per `feedback_squash_merge_drops_late_commits.md` recurrence #5).
- Adds `trim_trailing_punct` to TYPO-039 fix producer: the URL regex `https?://[^ \t\n}]+` is permissive on trailing `.,;:!)`, so a URL followed by a sentence-ending mark absorbed the punctuation into the wrap (`Visit https://x.com.` → `Visit \url{https://x.com.}`). The trim helper excludes `,.;:!)` from the fix span. `?` is intentionally NOT trimmed (commonly starts a URL query string).
- Tests: integration test now uses comma-delimited URLs (verifies trim); new dedicated "trims trailing punctuation" test covers `.!)` and the closing-paren+semicolon case.

## Test plan
- [x] `dune build` clean
- [x] `dune exec latex-parse/src/test_typo_fix.exe` — 86/86 PASS
- [x] `run_differential_test.py --baseline-ref v27.0.12 --current-ref HEAD` — 0 diffs across 330 corpus files
- [ ] CI green
- [ ] Tag v27.0.13 from the merge SHA after merge