### PR TITLE
fix(ci): perf-nightly build path — broken since 2026-04-23 (28+ failures)

### DIFF
--- a/.github/workflows/perf-nightly.yml
+++ b/.github/workflows/perf-nightly.yml
@@ -24,14 +24,15 @@ jobs:
       - uses: ./.github/actions/setup-ocaml-env
 
       - name: Build project
+        # Build from repo root so the bench binaries land at
+        # _build/default/latex-parse/bench/*.exe where perf_gate.sh,
+        # edit_window_gate.sh, and perf_summary.sh look for them.
+        # The previous version did `pushd latex-parse && dune build
+        # @install` which built into latex-parse/_build/ instead, and
+        # all three perf scripts failed with "No such file or
+        # directory" (perf-nightly broken since 2026-04-23).
         run: |
-          pushd latex-parse >/dev/null
-          opam exec -- dune build @install
-          opam exec -- dune install latex_parse --prefix "$OPAM_SWITCH_PREFIX" --profile release
-          popd >/dev/null
-          pushd core >/dev/null
           opam exec -- dune build @all
-          popd >/dev/null
 
       - name: Run perf gates (capture status)
         id: gates


### PR DESCRIPTION
## Summary

**perf-nightly** workflow has been failing nightly for 28+ consecutive runs (since 2026-04-23). Root cause is a build-path mismatch.

## Root cause

The build step did:
\`\`\`yaml
pushd latex-parse
opam exec -- dune build @install     # builds into latex-parse/_build/
opam exec -- dune install latex_parse ...
popd
pushd core
opam exec -- dune build @all          # builds parent project (no latex-parse since it's a separate sub-project)
popd
\`\`\`

But the perf scripts hardcode binaries at the **parent project's** _build path:
- \`scripts/perf_gate.sh\` line 7: \`BIN="_build/default/latex-parse/bench/ab_microbench.exe"\`
- \`scripts/edit_window_gate.sh\` line 9: \`_build/default/latex-parse/bench/edit_window_bench.exe\`
- \`scripts/perf_summary.sh\`: \`./_build/default/latex-parse/bench/ab_microbench.exe\`

Failure log from yesterday's run:
\`\`\`
scripts/perf_gate.sh: line 16: _build/default/latex-parse/bench/ab_microbench.exe: No such file or directory
scripts/edit_window_gate.sh: line 9: _build/default/latex-parse/bench/edit_window_bench.exe: No such file or directory
[ERROR] Command not found './_build/default/latex-parse/bench/ab_microbench.exe'
\`\`\`

\`first_token_gate.sh\` passes because it builds its own binary inline.

PR #335 (v27.0.5) fixed an earlier OPAMSWITCH issue but didn't touch this path.

## Fix

Drop the pushd-into-subdir builds; just \`dune build @all\` from repo root. The parent dune-project treats \`latex-parse/\` as a nested sub-project; dune builds its bench binaries to \`_build/default/latex-parse/bench/*.exe\` at repo root — exactly where the scripts look.

## Test plan

- [x] Verified locally: \`_build/default/latex-parse/bench/ab_microbench.exe\` is the path that exists after \`dune build\` from repo root.
- [ ] Post-merge: manual \`gh workflow run perf-nightly.yml\` to confirm fix.