### PR TITLE
fix(ci): perf-nightly — stash artifacts before gh-pages checkout (post-#374 follow-up)

### DIFF
--- a/.github/workflows/perf-nightly.yml
+++ b/.github/workflows/perf-nightly.yml
@@ -176,11 +176,24 @@ jobs:
           REPO: ${{ github.repository }}
         run: |
           set -e
+          # Stash artifacts to /tmp BEFORE switching branches.  The previous
+          # version expected them at `../foo` (parent-dir layout from an
+          # older worktree-based setup) and silently lost the badge JSON.
+          # gh-pages already carries a badges/perf.json from prior runs;
+          # without the stash, the checkout would either refuse the switch
+          # (untracked-vs-tracked conflict) or leave the workspace with the
+          # stale on-branch content instead of today's fresh measurement.
+          mkdir -p /tmp/perf_stash
+          cp -f badges/perf.json /tmp/perf_stash/perf.json
+          cp -f perf_summary.csv /tmp/perf_stash/perf_summary.csv 2>/dev/null || true
+          cp -f hash_throughput.csv /tmp/perf_stash/hash_throughput.csv 2>/dev/null || true
+          cp -f perf_gate.out /tmp/perf_stash/perf_gate.out 2>/dev/null || true
+          cp -f /tmp/first_token_latency.csv /tmp/perf_stash/first_token_latency.csv 2>/dev/null || true
           git config user.email "actions@github.com"
           git config user.name  "github-actions[bot]"
           git fetch origin gh-pages || true
           if git show-ref --quiet refs/remotes/origin/gh-pages; then
-            git checkout gh-pages
+            git checkout -f gh-pages
             git pull origin gh-pages || true
           else
             git checkout --orphan gh-pages
@@ -188,14 +201,17 @@ jobs:
             mkdir -p badges
           fi
           mkdir -p badges data
-          cp -f ../badges/perf.json badges/perf.json || cp -f badges/perf.json badges/perf.json
-          # Rolling perf history (append)
+          # Restore today's freshly-generated badge (overwriting any stale
+          # version that lived on gh-pages).
+          cp -f /tmp/perf_stash/perf.json badges/perf.json
+          # Rolling perf history (append).  Read the artifacts from the
+          # /tmp stash so we are not dependent on the branch state.
           TS=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-          ABP95=$(awk -F, '$1=="ab10k"{print $4}' ../perf_summary.csv 2>/dev/null | tail -1)
-          EWP95=$(awk -F, '$1=="edit4k5k"{print $4}' ../perf_summary.csv 2>/dev/null | tail -1)
-          FTP95=$(awk -F, 'NR==2{print $4}' /tmp/first_token_latency.csv 2>/dev/null || true)
-          XXH=$(awk -F, '$1=="xxh64"{print $2}' ../hash_throughput.csv 2>/dev/null | tail -1)
-          MED=$(grep -E "\[gate\] median-of-100 p95 =" ../perf_gate.out | tail -1 | awk '{print $6}')
+          ABP95=$(awk -F, '$1=="ab10k"{print $4}' /tmp/perf_stash/perf_summary.csv 2>/dev/null | tail -1)
+          EWP95=$(awk -F, '$1=="edit4k5k"{print $4}' /tmp/perf_stash/perf_summary.csv 2>/dev/null | tail -1)
+          FTP95=$(awk -F, 'NR==2{print $4}' /tmp/perf_stash/first_token_latency.csv 2>/dev/null || true)
+          XXH=$(awk -F, '$1=="xxh64"{print $2}' /tmp/perf_stash/hash_throughput.csv 2>/dev/null | tail -1)
+          MED=$(grep -E "\[gate\] median-of-100 p95 =" /tmp/perf_stash/perf_gate.out 2>/dev/null | tail -1 | awk '{print $6}')
           python3 -c "
           import json, sys, os
           entry = {'ts': os.environ['TS'], 'full_doc_p95_med100_ms': os.environ.get('MED',''),


### PR DESCRIPTION
## Summary

After PR #374 fixed the build-path mismatch the workflow advanced to the badge-publish step and immediately failed there. Manual workflow_dispatch verified this is a separate bug.

## Root cause

Two issues in the "Publish badge to gh-pages" step:

1. **Stale `../` paths.** Five lines (\`cp -f ../badges/perf.json …\`, plus the \`awk\` reads of \`../perf_summary.csv\`, \`../hash_throughput.csv\`, \`../perf_gate.out\`) assumed an older worktree-based layout. The current setup does an in-place \`git checkout gh-pages\`, so the parent-dir references resolve to whatever is one level above the workspace (i.e. nothing relevant).

2. **gh-pages may carry a stale \`badges/perf.json\`** from earlier runs. Even without (1), the in-place checkout would either refuse to switch (untracked-vs-tracked conflict) or overwrite the freshly generated badge with the stale on-branch copy.

Failure log from yesterday's manual trigger (run 25814279596):

\`\`\`
cp: cannot stat '../badges/perf.json': No such file or directory
cp: 'badges/perf.json' and 'badges/perf.json' are the same file
##[error]Process completed with exit code 1.
\`\`\`

## Fix

Stash the badge JSON + perf CSVs/log to \`/tmp/perf_stash\` **before** the checkout, then restore them after. Use \`git checkout -f\` so the switch is unambiguous, then \`cp /tmp/perf_stash/perf.json badges/perf.json\` to overwrite the stale badge with today's value. All subsequent awk lookups read from \`/tmp/perf_stash/…\` so the branch state is irrelevant.

## Test plan

- [x] Workflow file lints (yaml-checked).
- [ ] Post-merge: manual \`gh workflow run perf-nightly.yml\` to verify the publish step succeeds.

Combined with PR #374, perf-nightly should now run end-to-end.