### PR TITLE
fix(ci): perf-nightly — restore source ref after gh-pages publish (post-#377)

### DIFF
--- a/.github/workflows/perf-nightly.yml
+++ b/.github/workflows/perf-nightly.yml
@@ -287,6 +287,13 @@ jobs:
           git add badges/perf.json badges/perf_spark.svg data/perf_history.json index.html
           git commit -m "chore(badge): update nightly perf badge" || true
           git push "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git" gh-pages || true
+          # Restore the source-ref working tree so the composite-action
+          # post-step (./.github/actions/setup-ocaml-env) can still find
+          # its action.yml after this step.  Otherwise the post-job
+          # cleanup fails with "Can't find 'action.yml' under
+          # '.github/actions/setup-ocaml-env'" because the gh-pages
+          # branch we left checked out doesn't contain .github/actions/.
+          git checkout -f "${GITHUB_SHA}" || true
 
       - name: Upload perf artifacts
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary

Fourth layer of perf-nightly fixes.  After PRs #374/#375/#377 finally let the workflow complete the badge-publish step (the badge actually landed on gh-pages — verified in run 25870176379 log: \`96d4628..09944e8  gh-pages -> gh-pages\`), the job still exited 1 at the very end:

\`\`\`
##[error]Can't find 'action.yml', 'action.yaml' or 'Dockerfile' under '/home/runner/work/latex_perf/latex_perf/.github/actions/setup-ocaml-env'. Did you forget to run actions/checkout before running your local action?
\`\`\`

## Root cause

The publish step does \`git checkout gh-pages\` in-place. After it finishes, HEAD is still on \`gh-pages\`, which doesn't carry \`.github/actions/setup-ocaml-env/\` (the orphan-init path explicitly \`rm -rf .github\`, and existing gh-pages branches don't carry it either). The composite-action post-step that runs at end-of-job then can't find the action source and fails.

## Fix

After the gh-pages push, \`git checkout -f "\${GITHUB_SHA}"\` to restore the source-ref working tree. The composite action's post-step finds its action.yml again and the job exits 0.

The badge itself was published correctly even on the failing run; this fix is purely about getting a green job status so the cron stops alerting.

## Test plan

- [x] Workflow YAML syntactically valid.
- [ ] Post-merge: manual \`gh workflow run perf-nightly.yml\` to verify the workflow exits 0.

Combined chain: PR #374 (build path) + PR #375 (gh-pages stash) + PR #377 (env export) + PR #378 (this) — four layers of latent bugs each unmasked by fixing the prior one.