### PR TITLE
docs(v27.0.67.1): refresh specs/README.md + specs/rules/README.md

### DIFF
--- a/specs/README.md
+++ b/specs/README.md
@@ -4,8 +4,8 @@
 
 | Directory / file | Contents |
 |------------------|----------|
-| `v26/` | **Current release** (v26.2): master spec (`V26_REPO_EXACT_MASTER_SPEC.{md,yaml}`), `language_contract.{md,yaml}`, `compilation_guarantee_stack.md`, `compilation_profiles.yaml`, `partial_document_semantics.{md,yaml}`, `V26_2_PLAN.md` |
-| `v27/` | Forward spec: platform / editorial / collaboration roadmap (`V27_REPO_EXACT_MASTER_SPEC.{md,yaml}`) |
+| `v27/` | **Current release** (v27.0.x — currently shipping the Bucket A fix-producer cadence; latest tag `v27.0.67`): master spec (`V27_REPO_EXACT_MASTER_SPEC.{md,yaml}`), cadence + ledger (`V27_FIX_PRODUCER_CADENCE.md`, `FIX_PRODUCER_LEDGER.md`), faithful-semantics / L3-AST / apply-edits / T5 / WS8 plan docs |
+| `v26/` | Prior release (v26.2): master spec (`V26_REPO_EXACT_MASTER_SPEC.{md,yaml}`), `language_contract.{md,yaml}`, `compilation_guarantee_stack.md`, `compilation_profiles.yaml`, `partial_document_semantics.{md,yaml}`, `V26_2_PLAN.md` |
 | `REPO_EXACT_MISSING_ARCHITECTURE_MEMO_V26_V27.md` | Authoritative architecture memo (11 pieces, v26/v27 plan) |
 | `rules/` | `rules_v3.yaml` (660 rules, 644 non-reserved, 16 reserved), `rule_contracts.yaml` / `.json` (per-rule metadata), golden YAML test fixtures |
 | `macro_expander_L1/` | Macro catalogue spec + loader/checker tools |

--- a/specs/rules/README.md
+++ b/specs/rules/README.md
@@ -1,4 +1,4 @@
-# LaTeX Perfectionist v26.2 — Rules Directory
+# LaTeX Perfectionist v27.0.x — Rules Directory
 
 ## Files
 
@@ -18,20 +18,30 @@
 
 ## Catalog Snapshot (rules_v3.yaml)
 
-- Total rules: 654
+> Counts mirror `rules_v3.yaml` (the unified ruleset).  Regenerate via
+> `python3 scripts/tools/generate_project_facts.py` if `rules_v3.yaml` grows
+> or shrinks; the canonical `total_specified` lives in
+> `governance/project_facts.yaml`.
+
+- Total rules: 660
 - By layer (exact):
-  - L0_Lexer: 187
-  - L1_Expanded: 158
-  - L2_Ast: 99 (v26.1: +3 for LAY-025/026/027 compile-log rules)
-  - L3_Semantics: 112
+  - L0_Lexer: 192
+  - L1_Expanded: 180
+  - L2_Ast: 102
+  - L3_Semantics: 116
   - L4_Style: 70
 - By default severity:
-  - Error: 46
-  - Warning: 206
-  - Info: 371
+  - Error: 49
+  - Warning: 231
+  - Info: 380
 - Maturity:
-  - Draft: 607
+  - Draft: 619
+  - Implemented: 19
+  - Impl: 6
   - Reserved: 16 (future families; do not implement yet)
+- Fix producers (`produces_fix: true` in `rule_contracts.yaml`): 96 as of
+  v27.0.67.  See `../v27/V27_FIX_PRODUCER_CADENCE.md` for cadence and
+  `../v27/FIX_PRODUCER_LEDGER.md` for the per-rule shipping ledger.
 
 ## Implementation Guidance (When to Start)
 


### PR DESCRIPTION
## Summary
Hygiene PR (no version bump, no tag) found during the 2026-06-06 triple-check audit. Two spec READMEs had drifted across many releases and aren't in the per-release bump list, so the drift accumulated silently.

- **`specs/README.md`**: "Current release" row promoted from `v26/` to `v27/` (we're on v27.0.67; `v26/` correctly demoted to "Prior release").
- **`specs/rules/README.md`**:
  - H1 v26.2 → v27.0.x
  - "Catalog Snapshot" regenerated from `rules_v3.yaml`:
    - Total: **654 → 660**, L0_Lexer **187 → 192**, L1_Expanded **158 → 180**, L2_Ast **99 → 102** (drops stale v26.1 annotation), L3_Semantics **112 → 116**, L4_Style 70 unchanged
    - Severity: Error **46 → 49**, Warning **206 → 231**, Info **371 → 380**
    - Maturity: Draft **607 → 619**, Reserved 16, added Implemented (19) and Impl (6) which were missing
  - Added regen-instruction note + a "Fix producers" line pointing at the v27 cadence + ledger.

## Why `check_repo_facts.py` didn't catch this earlier
The gate looks for canonical values appearing **anywhere** in each file (EXISTS check, not EXCLUSIVITY). Line 5 of `specs/rules/README.md` has the correct `"660 rules, 644 non-reserved, 16 reserved"`, so the gate is satisfied even though line 21 said "Total rules: 654".

## Test plan
- [x] `pre_release_check.py` — all 18 substantive gates + full build + proofs build + unit tests — green ("safe to tag")
- [x] `check_repo_facts.py` — Project facts check passed
- [x] `check_doc_refs.py` — 76 docs, all references resolve
- [ ] CI green on PR head