### PR TITLE
docs: fix v26.1 README/docs-index drift surfaced by full spec audit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,9 @@ test/**/*
 /*_debug
 
 target/
+# rust/ is an internal evidence/bench workspace; its lockfile has never been
+# tracked and CI regenerates it. Ignore so local `cargo build` doesn't dirty the tree.
+rust/Cargo.lock
 public-badges/
 *.csv
 *.pkl

--- a/README.md
+++ b/README.md
@@ -55,12 +55,12 @@ dune exec latex-parse/src/validators_cli.exe -- --layer l2 paper.tex
 | `L0_PROM_ADDR` | `127.0.0.1:9109` | Prometheus TCP bind address |
 | `L0_USE_SIMD_XXH` | unset | Set to `1` for SIMD xxHash acceleration |
 
-## Current Status — v26.1 (April 2026)
+## Current Status — v27.0.67 (June 2026)
 
 All layers (L0-L4) implemented. L3 file-based validators (PNG/JPEG/PDF/font). ML v2 byte classifier trained (F1=0.9799) and formally verified:
-- **Build**: `dune build` compiles the SIMD service, benches, and the Coq proof tree (33 core + 108 generated + 1 ML) via `(coq.theory)` stanzas.
+- **Build**: `dune build` compiles the SIMD service, benches, and the Coq proof tree (55 core + 114 generated + 1 ML) via `(coq.theory)` stanzas.
 - **Proofs**: 170 Coq files, 1,400 theorems/lemmas. 644 per-rule soundness (637 faithful, 20 conservative, 3 conditional). 0 admits, 0 axioms. ML: `v2_span_extractor_sound` QED.
-- **Validators**: 638 rule IDs / 654 spec. 329 golden corpus tests, ~7,800 test cases across 89 suites. 19 L3 file-based + 12 expl3 rules.
+- **Validators**: 644 rule IDs / 660 spec. 96 fix-producing rules (Bucket A rolling cadence). 19 L3 file-based + 12 expl3 rules.
 - **Macros**: 520 production macros (441 symbols + 79 argsafe) with multi-arg support.
 - **ML Pipeline**: v2 ByteClassifier (CNN+BiLSTM, 538K params) trained on A100. F1=0.9799, precision=0.975, recall=0.985. Proved in `proofs/ML/SpanExtractorSound.v`.
 - **Performance**: Harnesses (`latex-parse/bench`, `scripts/perf_gate.sh`, `scripts/edit_window_gate.sh`) are in place. Latest runs on `perf_smoke_big` show p95 ≈ 2.73 ms (200 k iters) and ≈ 2.96 ms (1 M iters), with p99.9 ≈ 8.69 ms; the 4 KB edit-window bench lands at p95 ≈ 0.017 ms. See `core/l0_lexer/current_baseline_performance.json` and re-run after major changes.
@@ -207,7 +207,7 @@ bash scripts/latency_smoke_expand.sh 200
 
 ## Documentation
 
-- **[specs/v26/V26_REPO_EXACT_MASTER_SPEC.md](specs/v26/V26_REPO_EXACT_MASTER_SPEC.md)** — current release master spec
+- **[specs/v27/V27_REPO_EXACT_MASTER_SPEC.md](specs/v27/V27_REPO_EXACT_MASTER_SPEC.md)** — current release master spec (v26: [specs/v26/V26_REPO_EXACT_MASTER_SPEC.md](specs/v26/V26_REPO_EXACT_MASTER_SPEC.md))
 - **[specs/v26/language_contract.md](specs/v26/language_contract.md)** — LP-Core / LP-Extended / LP-Foreign tiers
 - **[docs/SUPPORT_MATRIX.yaml](docs/SUPPORT_MATRIX.yaml)** — machine-readable support contract
 - **[specs/REPO_EXACT_MISSING_ARCHITECTURE_MEMO_V26_V27.md](specs/REPO_EXACT_MISSING_ARCHITECTURE_MEMO_V26_V27.md)** — architecture memo (v26/v27 plan)
@@ -217,10 +217,10 @@ bash scripts/latency_smoke_expand.sh 200
 - **[docs/BUILD_LOG_CONTRACT.md](docs/BUILD_LOG_CONTRACT.md)** — Class C compile-log contract
 - **[docs/UNIT_TESTS.md](docs/UNIT_TESTS.md)**, **[docs/BUILD_SYSTEM_GUIDE.md](docs/BUILD_SYSTEM_GUIDE.md)**, **[docs/REST_API.md](docs/REST_API.md)**
 
-## Success Metrics (v26.1)
+## Success Metrics (v27.0.67)
 
-- 660 rules specified / 643 shipped
-- 631 formal faithful + 20 conservative + 3 conditional proofs
+- 660 rules specified / 644 shipped
+- 637 formal faithful + 20 conservative + 3 conditional proofs
 - 0 admits, 0 axioms
 - 21-language target (7 live + 14 stubbed)
 - p95 edit-window ≈ 0.017 ms (target ≤ 1.2 ms)

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,7 +18,7 @@ Comprehensive LaTeX document analysis and style validation system with 660 rules
 | Fix-producing rules | 96 (Bucket A rolling cadence, see [V27_FIX_PRODUCER_CADENCE.md](../specs/v27/V27_FIX_PRODUCER_CADENCE.md)) |
 | Soundness theorems | 644 per-rule (637 faithful, 20 conservative, 3 conditional) |
 | Total theorems/lemmas | 1,400 across 170 Coq files |
-| Performance p95 (L1 expand) | 25.22 ms (gate: 25 ms) |
+| Performance p95 (L1 expand) | ≈ 2.8 ms (gate: 20 ms, Tier A) |
 | Admits / Axioms | 0 / 0 |
 | Languages | 7 live + 14 stubbed = 21 target |
 


### PR DESCRIPTION
Follow-up to the full no-slack spec audit (the codebase itself audited 100% clean — see below). The audit surfaced **documentation drift that every automated gate misses** (`check_doc_refs` validates that referenced paths exist, not that version labels/counts are current).

## Root cause
README's H1 and the line-230 Status block are bumped every release, but two prose sections (`## Current Status`, `## Success Metrics`) and a Documentation pointer were frozen at **v26.1**, with counts that contradict both `governance/project_facts.yaml` and the README's own Status line.

Canonical numbers (project_facts.yaml @ v27.0.67): 660 specified / **644 shipped** / 16 reserved · 170 .v = **55 core + 114 generated + 1 ML** · **637 faithful** + 20 conservative + 3 conditional · 1400 theorems · **96 fix producers**.

## Changes (doc-only; no version bump, no tag)
**README.md**
- `Current Status — v26.1 (April 2026)` → `v27.0.67 (June 2026)`
- proof-tree files `33 core + 108 generated` → `55 core + 114 generated`
- `638 rule IDs / 654 spec` → `644 rule IDs / 660 spec`; dropped unverifiable golden/suite counts; added canonical `96 fix-producing rules`
- Documentation "current release master spec" pointer: `specs/v26/…` → `specs/v27/V27_REPO_EXACT_MASTER_SPEC.md` (v26 kept as prior)
- `Success Metrics (v26.1)` → `(v27.0.67)`; `643 shipped` → `644`; `631 faithful` → `637` (resolves the README's internal 643/631-vs-644/637 contradiction)

**docs/index.md**
- perf cell `25.22 ms (gate: 25 ms)` (value exceeded its own gate; stale) → `≈ 2.8 ms (gate: 20 ms, Tier A)` matching the real Week-5 perf gate and `validators.ml`'s documented current p95

**.gitignore**
- ignore `rust/Cargo.lock` (never tracked; CI regenerates) so local `cargo build` doesn't dirty the tree

## Audit result (codebase — all PASS, no changes needed)
- **Registry**: 4-way producer consistency 96/96/96/96 (empty symmetric diff); contracts.yaml↔json byte-identical rule sets; tri-state 96/92/472; rules_v3.yaml catalog ↔ README snapshot all match.
- **Proofs**: 170 .v / 1400 theorems / **0 Admitted / 0 admit-tactic / 0 Axiom** (8 `Hypothesis` all Section-local).
- **Tests**: 96/96 fix producers have test coverage; 135/135 dune test stanzas wired (no dead tests).
- **v27 plan docs**: every acceptance box matches reality (CADENCE 3/6; CURSOR_UNIVERSAL/WS8/T5/ASSOC shipped; FAITHFUL/L3 open).
- **CI on main `3422983`**: 25 runs, **zero non-success** (Unit Tests ✓, Perf Gate CI ✓, Week-5 p95<20ms ✓). The local `cst-perf p95=1089ms>900ms` is the documented environmental flake (loaded machine; CI runs the identical test green on the same commit).

`check_doc_refs.py` passes (76 docs) after the edits.