### PR TITLE
docs(v27.0.68.1): specs README currency (97 / v27.0.68) — re-apply squash-dropped audit fixes

### DIFF
--- a/specs/README.md
+++ b/specs/README.md
@@ -4,7 +4,7 @@
 
 | Directory / file | Contents |
 |------------------|----------|
-| `v27/` | **Current release** (v27.0.x — currently shipping the Bucket A fix-producer cadence; latest tag `v27.0.67`): master spec (`V27_REPO_EXACT_MASTER_SPEC.{md,yaml}`), cadence + ledger (`V27_FIX_PRODUCER_CADENCE.md`, `FIX_PRODUCER_LEDGER.md`), faithful-semantics / L3-AST / apply-edits / T5 / WS8 plan docs |
+| `v27/` | **Current release** (v27.0.x — currently shipping the Bucket A fix-producer cadence; latest tag `v27.0.68`): master spec (`V27_REPO_EXACT_MASTER_SPEC.{md,yaml}`), cadence + ledger (`V27_FIX_PRODUCER_CADENCE.md`, `FIX_PRODUCER_LEDGER.md`), faithful-semantics / L3-AST / apply-edits / T5 / WS8 plan docs |
 | `v26/` | Prior release (v26.2): master spec (`V26_REPO_EXACT_MASTER_SPEC.{md,yaml}`), `language_contract.{md,yaml}`, `compilation_guarantee_stack.md`, `compilation_profiles.yaml`, `partial_document_semantics.{md,yaml}`, `V26_2_PLAN.md` |
 | `REPO_EXACT_MISSING_ARCHITECTURE_MEMO_V26_V27.md` | Authoritative architecture memo (11 pieces, v26/v27 plan) |
 | `rules/` | `rules_v3.yaml` (660 rules, 644 non-reserved, 16 reserved), `rule_contracts.yaml` / `.json` (per-rule metadata), golden YAML test fixtures |

--- a/specs/rules/README.md
+++ b/specs/rules/README.md
@@ -39,8 +39,8 @@
   - Implemented: 19
   - Impl: 6
   - Reserved: 16 (future families; do not implement yet)
-- Fix producers (`produces_fix: true` in `rule_contracts.yaml`): 96 as of
-  v27.0.67.  See `../v27/V27_FIX_PRODUCER_CADENCE.md` for cadence and
+- Fix producers (`produces_fix: true` in `rule_contracts.yaml`): 97 as of
+  v27.0.68.  See `../v27/V27_FIX_PRODUCER_CADENCE.md` for cadence and
   `../v27/FIX_PRODUCER_LEDGER.md` for the per-rule shipping ledger.
 
 ## Implementation Guidance (When to Start)


### PR DESCRIPTION
Re-applies two doc-currency fixes from the post-v27.0.68 audit that were **dropped when #409 was squash-merged**. #409's squash captured the branch at `bed8ce5`, before the commit carrying these fixes (`152b8ce`) — the documented squash-drops-late-commits failure mode (a commit pushed after the PR head was captured is lost on squash).

As a result, `main` (313271e) still has the stale values:
- `specs/rules/README.md` — "Fix producers: **96** as of **v27.0.67**" → **97 as of v27.0.68**
- `specs/README.md` — v27 "latest tag **v27.0.67**" → **v27.0.68**

The rest of v27.0.68 (SPC-027 + all other version/count bumps) **is** correctly on main; only these two `specs/` READMEs were lost.

`check_doc_refs` and `check_repo_facts` pass. Doc-only, no version bump, no tag.

> To avoid a repeat: please merge this as-is and don't push further commits to the branch once you start the merge.