### PR TITLE
docs+gate(v27.0.68.2): fix 3 stale version labels + add check_version_labels gate to end the recurrence

### DIFF
--- a/.github/workflows/spec-drift.yml
+++ b/.github/workflows/spec-drift.yml
@@ -100,6 +100,13 @@ jobs:
         # docs/ and specs/ must resolve to an existing file.
         run: python3 scripts/tools/check_doc_refs.py --repo .
 
+      - name: Doc version-label currency (v27.0.68.2)
+        # Headings/stamps that name a version or fix-producer count
+        # ("Current State (vN)", "latest tag vN", "N as of vN", ...) must
+        # match dune-project / rule_contracts.yaml. Catches the label drift
+        # that check_doc_refs cannot (it only checks path existence).
+        run: python3 scripts/tools/check_version_labels.py --repo .
+
       - name: Release integrity (PR #245 p1.11)
         # CHANGELOG↔governance version coherence, generated-file
         # authenticity (regen+diff), orphan consumes capabilities.

--- a/docs/L3_ROADMAP.md
+++ b/docs/L3_ROADMAP.md
@@ -3,7 +3,7 @@
 > Written in response to memo §15.5:
 > > "Document honestly that current L3 is partly source-regex-derived, then plan migration toward AST/project semantics."
 
-## Current state (v26.1)
+## Current state (L3 unchanged since v26.1; AST migration pending — see [../specs/v27/V27_L3_AST_PLAN.md](../specs/v27/V27_L3_AST_PLAN.md))
 
 The L3 layer — `latex-parse/src/validators_l3_file.ml` + `latex-parse/src/semantic_state.ml` + `latex-parse/src/validators_project.ml` — has two kinds of rules:
 

--- a/docs/PROOF_GUIDE.md
+++ b/docs/PROOF_GUIDE.md
@@ -141,7 +141,7 @@ Runs on every push and PR. Cannot be bypassed.
 
 ---
 
-## Current State (v26.2)
+## Current State (v27.0.68)
 
 - **1,400 theorems/lemmas** across 170 files
 - **637 faithful proofs** (VPD-pattern match, exact Coq model)

--- a/scripts/tools/check_gates_meta.py
+++ b/scripts/tools/check_gates_meta.py
@@ -44,6 +44,7 @@ GATE_SCRIPTS = [
     ("scripts/tools/check_unused_hypotheses.py", ["--repo", "."]),
     # PR #245 (p1.11) additions
     ("scripts/tools/check_doc_refs.py", ["--repo", "."]),
+    ("scripts/tools/check_version_labels.py", ["--repo", "."]),
     ("scripts/tools/check_release_integrity.py",
      ["--repo", ".", "--skip-generated"]),
     # PR #246 (p1.12) addition — skip-exec used for meta-check (gate

--- a/scripts/tools/check_version_labels.py
+++ b/scripts/tools/check_version_labels.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+"""check_version_labels.py — fail if a maintained doc carries a stale version/count LABEL.
+
+Catches the recurring drift class where a heading or stamp names an OLD version (or an
+OLD fix-producer count) while the content underneath is already current. `check_doc_refs`
+validates that referenced paths exist and `check_repo_facts` validates the generated fact
+files, but neither checks doc *label currency* — so this class recurred across three
+release audits (v27.0.67 / v27.0.68): "## Current Status — v26.1", "latest tag v27.0.67",
+"96 as of v27.0.67", "## Current State (v26.2)", "the current 32 fix-producing rules", and
+a "current release master spec" pointer left aimed at the v26 spec.
+
+Canonical sources:
+  - version:        dune-project  `(version X.Y.Z)`
+  - producer count: number of `produces_fix: true` lines in specs/rules/rule_contracts.yaml
+
+Patterns (deliberately high-precision — calibrated against the live corpus so legitimate
+historical references do NOT trip the gate, e.g. CHANGELOG entries, "shipped in vN"
+provenance, and "annotation ... as of v27.0.42" stamps):
+
+  A  '## Current State/Status (vX)'  or  '— vX'  heading label      vX must be current version
+  B  'latest tag vX'                                                vX must be current version
+  C  '[..](specs/vN/..) — current release master spec'             N must be current major
+  D  'Fix producers ...: N as of vX'                               N == producer count, vX current
+  E  'the current N fix-producing rules'                           N == producer count
+  F  'N/M (~P%) shipped as of vX'                                  N == producer count, vX current
+
+A version token in a doc passes if its components are a prefix of the canonical version
+(so "v27", "v27.0", "v27.0.68" all pass when canonical is 27.0.68; "v27.0.67" / "v26.1" fail).
+
+Scope: tracked *.md files, excluding CHANGELOG.md and anything under archive/, .claude/,
+_build/, node_modules/, ml/ (historical / generated / experiment outputs).
+
+Exit 0 if every label is current; exit 1 (listing each violation) otherwise.
+"""
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+EXCLUDE_SEGMENTS = ("/archive/", "/.claude/", "/_build/", "/node_modules/")
+EXCLUDE_PREFIXES = ("archive/", "docs/archive/", ".claude/", "_build/", "node_modules/", "ml/")
+EXCLUDE_BASENAMES = ("CHANGELOG.md",)
+
+# Escape hatch: a violation whose offending text contains any allowlisted substring is
+# skipped. Keep empty unless a genuinely-legitimate exception appears; document why.
+ALLOWLIST: tuple[str, ...] = ()
+
+
+def canonical_version(repo: Path) -> tuple[int, ...]:
+    m = re.search(r"\(version\s+([0-9][0-9.]*)\)", (repo / "dune-project").read_text())
+    if not m:
+        raise SystemExit("[version-labels] ERROR: could not read version from dune-project")
+    return tuple(int(p) for p in m.group(1).split("."))
+
+
+def producer_count(repo: Path) -> int:
+    text = (repo / "specs/rules/rule_contracts.yaml").read_text()
+    return len(re.findall(r"^\s*produces_fix:\s*true\b", text, re.M))
+
+
+def ver_components(token: str) -> tuple[int, ...]:
+    """'v27.0.68' / '27.0' -> (27,0,68) / (27,0); stops at the first non-numeric part."""
+    out: list[int] = []
+    for p in token.lstrip("vV").split("."):
+        if p.isdigit():
+            out.append(int(p))
+        else:
+            break
+    return tuple(out)
+
+
+def version_is_current(token: str, canon: tuple[int, ...]) -> bool:
+    doc = ver_components(token)
+    return len(doc) > 0 and canon[: len(doc)] == doc
+
+
+def tracked_md_files(repo: Path) -> list[Path]:
+    try:
+        out = subprocess.run(
+            ["git", "ls-files", "*.md"], cwd=repo, capture_output=True, text=True, check=True
+        ).stdout
+        rels = [r for r in out.splitlines() if r]
+    except Exception:
+        rels = [str(p.relative_to(repo)) for p in repo.rglob("*.md")]
+    keep = []
+    for rel in rels:
+        if any(seg in f"/{rel}" for seg in EXCLUDE_SEGMENTS):
+            continue
+        if rel.startswith(EXCLUDE_PREFIXES):
+            continue
+        if Path(rel).name in EXCLUDE_BASENAMES:
+            continue
+        keep.append(repo / rel)
+    return keep
+
+
+# Pattern A — "Current State/Status" heading whose label is a version (sep = ( — – - :)
+RE_CURSTATE = re.compile(
+    r"^#{1,6}[^\n]*?Current\s+Stat(?:e|us)\s*[\(\-—–:]\s*v?(\d+(?:\.\d+)+)",
+    re.M | re.I,
+)
+RE_LATEST_TAG = re.compile(r"latest\s+tag\s*[`'\"]?\s*v?(\d+(?:\.\d+)+)", re.I)
+RE_MASTER_SPEC = re.compile(
+    r"specs/v(\d+)/[^\s)]+\)\**\s*[—–\-]\s*current release master spec", re.I
+)
+# Non-greedy [^\n]*? (not [^:\n]*) so an inline `produces_fix: true` colon inside the
+# label text does not block the match; the count/version may wrap across one newline.
+RE_FIX_PROD_ASOF = re.compile(
+    r"[Ff]ix[- ]produc\w*[^\n]*?:\s*(\d+)\s+as of\s+v?(\d+(?:\.\d+)+)", re.I
+)
+RE_CURRENT_N_PROD = re.compile(r"current\s+(\d+)\s+fix[- ]?produc\w*\s+rules", re.I)
+RE_SHIPPED_ASOF = re.compile(
+    r"(\d+)\s*/\s*\d+\s*\([^)]*%\)\s*shipped\s+as of\s+v?(\d+(?:\.\d+)+)", re.I
+)
+
+
+def line_of(text: str, pos: int) -> int:
+    return text.count("\n", 0, pos) + 1
+
+
+def check_file(path: Path, rel: str, canon, prod, violations: list):
+    text = path.read_text(encoding="utf-8", errors="ignore")
+
+    def add(pos: int, msg: str):
+        snippet = text[pos : text.find("\n", pos) if text.find("\n", pos) != -1 else len(text)]
+        if any(a in snippet for a in ALLOWLIST):
+            return
+        violations.append(f"{rel}:{line_of(text, pos)}: {msg}")
+
+    for m in RE_CURSTATE.finditer(text):
+        if not version_is_current(m.group(1), canon):
+            add(m.start(), f"'Current State/Status' label says v{m.group(1)} (current is "
+                           f"v{'.'.join(map(str, canon))})")
+    for m in RE_LATEST_TAG.finditer(text):
+        if not version_is_current(m.group(1), canon):
+            add(m.start(), f"'latest tag v{m.group(1)}' is stale (current is "
+                           f"v{'.'.join(map(str, canon))})")
+    for m in RE_MASTER_SPEC.finditer(text):
+        if int(m.group(1)) != canon[0]:
+            add(m.start(), f"'current release master spec' points at specs/v{m.group(1)}/ "
+                           f"(current major is v{canon[0]})")
+    for m in RE_FIX_PROD_ASOF.finditer(text):
+        n, v = int(m.group(1)), m.group(2)
+        if n != prod or not version_is_current(v, canon):
+            add(m.start(), f"'Fix producers: {n} as of v{v}' stale (current is "
+                           f"{prod} as of v{'.'.join(map(str, canon))})")
+    for m in RE_CURRENT_N_PROD.finditer(text):
+        if int(m.group(1)) != prod:
+            add(m.start(), f"'current {m.group(1)} fix-producing rules' stale (current is {prod})")
+    for m in RE_SHIPPED_ASOF.finditer(text):
+        n, v = int(m.group(1)), m.group(2)
+        if n != prod or not version_is_current(v, canon):
+            add(m.start(), f"'{n}/... shipped as of v{v}' stale (current is "
+                           f"{prod} as of v{'.'.join(map(str, canon))})")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--repo", default=".", help="repo root (default: .)")
+    ns = ap.parse_args()
+    repo = Path(ns.repo).resolve()
+
+    canon = canonical_version(repo)
+    prod = producer_count(repo)
+    files = tracked_md_files(repo)
+
+    violations: list[str] = []
+    for path in files:
+        rel = str(path.relative_to(repo))
+        try:
+            check_file(path, rel, canon, prod, violations)
+        except Exception as e:  # never let one unreadable file mask the gate
+            violations.append(f"{rel}: ERROR reading/checking ({e})")
+
+    if violations:
+        print(f"[version-labels] FAIL: {len(violations)} stale label(s) "
+              f"(canonical v{'.'.join(map(str, canon))} / {prod} producers):", file=sys.stderr)
+        for v in violations:
+            print(f"  {v}", file=sys.stderr)
+        print("  Bump the label(s) to the current version/count, or add a documented "
+              "ALLOWLIST entry if genuinely historical.", file=sys.stderr)
+        return 1
+
+    print(f"[version-labels] PASS: all version/count labels current across {len(files)} docs "
+          f"(v{'.'.join(map(str, canon))} / {prod} producers).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tools/pre_release_check.py
+++ b/scripts/tools/pre_release_check.py
@@ -37,6 +37,7 @@ GATES = [
     ("python3", "scripts/tools/check_code_quality.py", "--repo", "."),
     ("python3", "scripts/tools/check_unused_hypotheses.py", "--repo", "."),
     ("python3", "scripts/tools/check_doc_refs.py", "--repo", "."),
+    ("python3", "scripts/tools/check_version_labels.py", "--repo", "."),
     ("python3", "scripts/tools/check_release_integrity.py", "--repo", "."),
     ("python3", "scripts/tools/check_gates_meta.py", "--repo", "."),
     ("python3", "scripts/tools/check_perf_ratchet.py", "--repo", "."),

--- a/specs/v27/V27_FIX_PRODUCER_CADENCE.md
+++ b/specs/v27/V27_FIX_PRODUCER_CADENCE.md
@@ -1,7 +1,8 @@
 # V27_FIX_PRODUCER_CADENCE — Rolling fix-producer extension to full coverage
 
-**Goal:** Bring the catalogue of 660 lint rules from the current 32
-fix-producing rules to full coverage where mechanically safe, with
+**Goal:** Bring the catalogue of 660 lint rules from the 32 fix-producing
+rules at plan authoring (97 shipped as of v27.0.68) to full coverage where
+mechanically safe, with
 explicit deferral of NLP-required and unsafe-without-context rules.
 
 **Tag targets:** rolling — v27.0.x patches, then v27.2.x cycles.


### PR DESCRIPTION
Two parts: **fix** the stale labels the third audit found, and **add a gate** so this drift class can't recur.

## Part 1 — fix 3 stale version *labels* (content already current)
The third full audit found the substantive state 100% consistent (registry 4-way 97, proofs 170/1400/0/0, 97/97 test coverage, catalog/CHANGELOG/6 cross-doc sources all agree). The only findings were version-label lags:
- `docs/PROOF_GUIDE.md` — `## Current State (v26.2)` → `(v27.0.68)` (body 1,400/170/637-20-3/0-0 already current)
- `docs/L3_ROADMAP.md` — `## Current state (v26.1)` → clarifies L3 unchanged since v26.1, AST migration pending (links `V27_L3_AST_PLAN.md`)
- `specs/v27/V27_FIX_PRODUCER_CADENCE.md` — "the **current** 32 fix-producing rules" → "32 at plan authoring (**97 shipped as of v27.0.68**)"

## Part 2 — `scripts/tools/check_version_labels.py` (prevention)
**Three consecutive release audits each found the same class of issue** — a heading/stamp naming an old version/count while the content is current. `check_doc_refs` checks path existence and `check_repo_facts` checks generated facts, but **neither checks doc label currency**. This gate closes that gap.

6 high-precision patterns, validated against `dune-project` (version) + `rule_contracts.yaml` (producer count):

| | Pattern | Asserts |
|---|---|---|
| A | `## Current State/Status (vN)` heading | vN = current version |
| B | `latest tag vN` | vN = current version |
| C | `… (specs/vN/…) — current release master spec` | N = current major |
| D | `Fix producers …: N as of vN` | N = count, vN current |
| E | `the current N fix-producing rules` | N = count |
| F | `N/M (~P%) shipped as of vN` | N = count, vN current |

**Calibrated for zero false positives** against the live corpus — legitimate historical refs (CHANGELOG, "shipped in vN" provenance, "annotation … as of v27.0.42", `archive/`) do not trip it. Empty `ALLOWLIST` escape hatch for documented future exceptions.

**Verified both directions:** PASSES on current main (105 docs); and when run against the *pre-fix* versions of the files from all three audits, it FAILS and lists every real drift item (the `Current Status — v26.1`, `latest tag v27.0.67`, `96 as of v27.0.67`, `Current State (v26.2)`, `current 32 fix-producing rules`, and v26 master-spec pointer).

Wired into `pre_release_check.py`, `spec-drift.yml` CI (mirroring `check_doc_refs`), and `check_gates_meta.py` (now 14 gate scripts).

Context: v27.0.68 is tagged (`v27.0.68` → `2ebff28`); this is post-tag hygiene + tooling. Doc/tooling only, no version bump.