### PR TITLE
fix: resolve CJK-001/002 ⇄ CJK-010 apply-fixes oscillation at source (P0b-CJK)

### DIFF
--- a/latex-parse/src/test_typo_fix.ml
+++ b/latex-parse/src/test_typo_fix.ml
@@ -3010,6 +3010,51 @@ let () =
         (does_not_fire "CJK-002" "End of sentence. New begins.")
         (tag ^ ": no U+FF0E → no fire"));
 
+  (* P0b-CJK: Han-adjacency delegation. When a fullwidth comma/period sits in an
+     ASCII-MAJORITY ±32-byte window (is_ascii_context true) but is immediately
+     adjacent to a Han ideograph (lead byte 0xE4–0xE9 at i-3 or i+3),
+     CJK-001/002 now WITHHOLD the fix and delegate to CJK-010 (fullwidth is
+     correct next to CJK). Count is still emitted (0-diff lint). This is what
+     stops the CJK-001/002 ⇄ CJK-010 oscillation: the fullwidth form next to a
+     Han glyph is never flipped back to ASCII, so the context window can't
+     flip-flop. The "Hello world…" / "End of sentence…" cases above (ASCII
+     neighbours, not Han) still fix — so this is a strict refinement, not a
+     regression. *)
+  run "CJK-001 delegate: Han-preceding fullwidth comma in ASCII window → NO fix"
+    (fun tag ->
+      (* 中 (U+4E2D = E4 B8 AD) immediately before U+FF0C; 20 ASCII bytes around
+         it make is_ascii_context true, yet i-3 is a Han lead byte →
+         delegated. *)
+      let src = "abcdefghij\xe4\xb8\xad\xef\xbc\x8cabcdefghij" in
+      expect
+        (fires "CJK-001" src && fix_edits "CJK-001" src = [])
+        (tag ^ ": fires (count) but no fix — delegated to CJK-010"));
+
+  run "CJK-001 delegate: Han-following fullwidth comma in ASCII window → NO fix"
+    (fun tag ->
+      (* U+FF0C immediately followed by 中 → i+3 is a Han lead byte →
+         delegated. *)
+      let src = "abcdefghij\xef\xbc\x8c\xe4\xb8\xadabcdefghij" in
+      expect
+        (fires "CJK-001" src && fix_edits "CJK-001" src = [])
+        (tag ^ ": i+3 Han lead byte fires but no fix"));
+
+  run "CJK-002 delegate: Han-adjacent fullwidth period in ASCII window → NO fix"
+    (fun tag ->
+      let src = "abcdefghij\xe4\xb8\xad\xef\xbc\x8eabcdefghij" in
+      expect
+        (fires "CJK-002" src && fix_edits "CJK-002" src = [])
+        (tag ^ ": fires (count) but no fix — delegated to CJK-010"));
+
+  run "CJK-001 still fixes ASCII-neighbour fullwidth comma (not delegated)"
+    (fun tag ->
+      (* No Han neighbour: ordinary ASCII context → fix still emitted. *)
+      let src = "abc\xef\xbc\x8cdef" in
+      let edits = fix_edits "CJK-001" src in
+      expect
+        (List.length edits = 1 && apply_all src edits = "abc,def")
+        (tag ^ ": ASCII-only neighbours still get the fix"));
+
   (* v27.0.62: CJK-010 (ASCII punct adjacent to CJK → fullwidth, INVERSE
      direction) and CJK-014 (U+30FB outside CJK → ASCII `.`). CJK-010 reuses the
      new `is_extended_context` helper; CJK-014 reuses `is_ascii_context` from

--- a/latex-parse/src/validators_l0.ml
+++ b/latex-parse/src/validators_l0.ml
@@ -3745,6 +3745,23 @@ let rules_verb : rule list =
    where U+FF0C is the intended typography. Cross-rule: CHAR-016 also fires on
    U+FF0C with no fix-set, so the two emit independent diagnostics and only
    CJK-001's fix lands at the offset (no overlap conflict). *)
+(* P0b-CJK: a 3-byte fullwidth punctuation at offset [i] is "adjacent to CJK" if
+   a Han-ideograph lead byte (0xE4–0xE9, the SAME range CJK-010 uses for its
+   [is_cjk_byte0]) immediately precedes it (its lead byte sits at [i-3]) or
+   follows it (the next char's lead byte sits at [i+3]). CJK-001/002 use this to
+   DELEGATE their fix: a fullwidth comma/period next to a CJK ideograph is the
+   correct fullwidth form — that position is CJK-010's domain (ASCII→fullwidth),
+   so converting it back to ASCII would fight CJK-010 and oscillate under
+   repeated [--apply-fixes] (the ±32-byte majority window flips when multi-punct
+   conversions shift the byte balance). The diagnostic count is unchanged — only
+   the fix is withheld at adjacent positions (0-diff lint). Mirrors the
+   TYPO-002⇄TYPO-026 numeric-range delegation. *)
+let fullwidth_punct_adjacent_to_cjk s i =
+  let n = String.length s in
+  let cjk b = b >= 0xE4 && b <= 0xE9 in
+  (i >= 3 && cjk (Char.code s.[i - 3]))
+  || (i + 3 < n && cjk (Char.code s.[i + 3]))
+
 let r_cjk_001 : rule =
   let run s =
     (* U+FF0C = EF BC 8C *)
@@ -3761,7 +3778,9 @@ let r_cjk_001 : rule =
       then (
         incr cnt;
         if
-          (not (is_in_math_range (Lazy.force math) !i)) && is_ascii_context s !i
+          (not (is_in_math_range (Lazy.force math) !i))
+          && is_ascii_context s !i
+          && not (fullwidth_punct_adjacent_to_cjk s !i)
         then
           fix_edits :=
             Cst_edit.replace ~start_offset:!i ~end_offset:(!i + 3) ","
@@ -3803,7 +3822,9 @@ let r_cjk_002 : rule =
       then (
         incr cnt;
         if
-          (not (is_in_math_range (Lazy.force math) !i)) && is_ascii_context s !i
+          (not (is_in_math_range (Lazy.force math) !i))
+          && is_ascii_context s !i
+          && not (fullwidth_punct_adjacent_to_cjk s !i)
         then
           fix_edits :=
             Cst_edit.replace ~start_offset:!i ~end_offset:(!i + 3) "."

--- a/scripts/tools/check_apply_fixes_safety.py
+++ b/scripts/tools/check_apply_fixes_safety.py
@@ -30,9 +30,10 @@ those naive scanners is tracked separately.
 Runs in pilot mode (L0_VALIDATORS=pilot) so pilot-gated TYPO fixes are exercised.
 
 Exit 0 if every corpus file converges to valid output. Exit 1 (listing each hard
-violation) otherwise. KNOWN_UNSTABLE allowlists the two tracked contradictory
-producer pairs (dash + CJK) so the gate is CI-wireable while they are reconciled;
-any NEW non-convergence fails.
+violation) otherwise. Both originally-tracked contradictory producer pairs have
+now been reconciled at the source (TYPO-002⇄TYPO-026 numeric-range delegation;
+CJK-001/002⇄CJK-010 Han-adjacency delegation), so KNOWN_UNSTABLE_SUBSTR is empty
+and EVERY corpus file must converge — any non-convergence fails the gate.
 """
 
 from __future__ import annotations
@@ -47,15 +48,15 @@ import tempfile
 MAX_PASSES = 8
 
 # Tracked non-convergent files pending reconciliation (do NOT fail the gate on
-# these; DO fail on any NEW non-convergence). TODO(P0b): resolve and shrink.
-#   - CJK: CJK-001/002 (`fullwidth→ASCII`) vs CJK-010 (`ASCII→fullwidth`)
-#          oscillate in mixed-script paragraphs (context gate flips under the
-#          conversion). Still open.
-#   - dash: TYPO-002 (`--`→`–`) vs TYPO-026 (`–`→`--`) — RESOLVED at the source
-#           (TYPO-002 now delegates numeric ranges), so no longer allowlisted.
-KNOWN_UNSTABLE_SUBSTR: tuple[str, ...] = (
-    "i18n_qa_mixed",
-)
+# these; DO fail on any NEW non-convergence). Both originally-tracked oscillating
+# producer pairs are now RESOLVED at the source, so this is empty:
+#   - dash: TYPO-002 (`--`→`–`) vs TYPO-026 (`–`→`--`) — TYPO-002 now delegates
+#           numeric ranges (digit`--`digit) to TYPO-026.
+#   - CJK:  CJK-001/002 (`fullwidth→ASCII`) vs CJK-010 (`ASCII→fullwidth`) —
+#           CJK-001/002 now delegate Han-adjacent fullwidth punctuation to
+#           CJK-010 (fullwidth_punct_adjacent_to_cjk), so the ±32-byte context
+#           window no longer flips under the conversion.
+KNOWN_UNSTABLE_SUBSTR: tuple[str, ...] = ()
 
 
 def cli(repo: str) -> str:


### PR DESCRIPTION
## What

Resolves the last `--apply-fixes` oscillation — the **CJK-001/002 ⇄ CJK-010** flip-flop in mixed-script paragraphs — at the source, and empties the safety gate's allowlist.

## Why

The corpus apply-fixes safety gate added in #417 flagged the `i18n_qa_mixed` CJK files as non-convergent (it allowlisted them as `KNOWN_UNSTABLE`):

- **CJK-001/002** convert fullwidth comma/period `，．` → ASCII `,.` when the ±32-byte window is ASCII-majority (`is_ascii_context`).
- **CJK-010** converts ASCII `,.:;` → fullwidth when the window is extended-majority (`is_extended_context`) and adjacent to CJK.

In mixed paragraphs the two **majority windows flip** as multi-punct conversions shift the byte balance, so each pass toggles the gate and the file never reaches a fixpoint.

## Fix — fix-set delegation (same shape as the dash pair)

Mirrors the TYPO-002⇄TYPO-026 numeric-range delegation already shipped in #417. CJK-001/002 now **withhold their fix** when the fullwidth punctuation is immediately adjacent to a Han ideograph (new helper `fullwidth_punct_adjacent_to_cjk` — a Han lead byte `0xE4–0xE9` at `i-3` or `i+3`, the **same** range CJK-010's `is_cjk_byte0` already uses). Fullwidth punctuation next to a CJK glyph is the correct form (CJK-010's domain), so it is never converted back to ASCII and the window can no longer flip-flop.

The adjacency test is **local and deterministic**, unlike the flippy ±32-byte majority window.

## Safety

- Diagnostic **count is unchanged** (every fullwidth punct still tallied) → **0-diff lint**; only the fix is delegated.
- `KNOWN_UNSTABLE_SUBSTR` in `check_apply_fixes_safety.py` is now **empty** — every corpus file must converge.

## Verification

- ✅ All **330** lint-corpus files converge to valid output (≤8 passes, empty allowlist)
- ✅ Differential: **0 diffs** vs `v27.0.72`
- ✅ `test_typo_fix`: **412** cases (+4: Han-adjacent comma/period delegation `i-3` & `i+3`, plus a regression guard that ASCII-neighbour fullwidth punct still fixes)
- ✅ Full `pre_release_check.py` green (19 gates + build + proofs + runtest + apply-fixes safety)

No version bump (behaviour change is fix-only, 0-diff lint; no new producer) — same release-neutral class as #417.