### PR TITLE
feat: make --apply-fixes iterate to a fixpoint (P1a)

### DIFF
--- a/latex-parse/src/test_apply_fixes_cli.ml
+++ b/latex-parse/src/test_apply_fixes_cli.ml
@@ -246,4 +246,48 @@ let () =
             (tag ^ ": Error (`Overlap (e1, e2)) — CLI's exit-2 path source")
       | Ok _ -> expect false (tag ^ ": expected Error, got Ok"));
 
+  (* P1a: --apply-fixes iterates to a fixpoint, so a CROSS-RULE cascade resolves
+     in a single invocation. ENC-004 rewrites the CP-1252 ellipsis byte 0x85 (an
+     invalid standalone UTF-8 byte) to U+2026; only on the NEXT pass can SPC-025
+     see — and delete — the space before that freshly-created ellipsis. A single
+     pass would stop at "word <U+2026>"; convergence yields "word<U+2026>". All
+     three rules (STRUCT-001 docclass insert, ENC-004, SPC-025) are in the
+     default set, so no pilot env is needed. *)
+  let contains s sub =
+    let nlen = String.length sub and slen = String.length s in
+    let rec find i =
+      if i + nlen > slen then false
+      else if String.sub s i nlen = sub then true
+      else find (i + 1)
+    in
+    find 0
+  in
+  run "CLI --apply-fixes converges a cross-rule cascade (ENC-004 → SPC-025)"
+    (fun tag ->
+      let path = write_temp_tex "word \x85\n" in
+      let out, code = run_cli [ "--apply-fixes"; path ] in
+      Sys.remove path;
+      let body = strip_comments out in
+      expect (code = 0) (tag ^ ": exit code 0");
+      expect
+        (contains body "word\xe2\x80\xa6")
+        (tag ^ ": ellipsis produced AND its leading space deleted (cascade)");
+      expect
+        (not (contains body "word \xe2\x80\xa6"))
+        (tag ^ ": no half-fixed 'word <space> U+2026' left behind"));
+
+  (* P1a: the converged output is a fixpoint — re-running --apply-fixes on it is
+     a no-op (idempotence), the defining property of convergence. *)
+  run "CLI --apply-fixes output is idempotent" (fun tag ->
+      let path = write_temp_tex "word \x85\n" in
+      let out1, c1 = run_cli [ "--apply-fixes"; path ] in
+      Sys.remove path;
+      let body1 = strip_comments out1 in
+      let path2 = write_temp_tex body1 in
+      let out2, c2 = run_cli [ "--apply-fixes"; path2 ] in
+      Sys.remove path2;
+      let body2 = strip_comments out2 in
+      expect (c1 = 0 && c2 = 0) (tag ^ ": exit code 0 both runs");
+      expect (body1 = body2) (tag ^ ": second pass changes nothing (fixpoint)"));
+
   finalise "apply-fixes-cli"

--- a/latex-parse/src/validators_cli.ml
+++ b/latex-parse/src/validators_cli.ml
@@ -161,42 +161,110 @@ let env_flag_on name =
     stdout, with the skipped subset reported on stderr. Exit code 0 in that case
     (the partial-fix output is the contract). When [false] (default), behaviour
     is unchanged: any overlap returns exit 2 with no stdout. *)
-let run_apply_fixes ?filter_id ?(best_effort = false) ~path ~src () =
+let overlap_error a b =
+  eprintf
+    "E.apply-fixes.overlap: two rule fixes affect overlapping source ranges; \
+     refusing to apply.\n\
+     # first edit:  %s\n\
+     # second edit: %s\n\
+     # hint: re-run with --apply-fixes-best-effort to apply the maximal \
+     non-conflicting subset.\n"
+    (Latex_parse_lib.Cst_edit.to_string a)
+    (Latex_parse_lib.Cst_edit.to_string b);
+  2
+
+(* P1a: maximum passes for the converging [--apply-fixes] loop. The corpus
+   safety gate proves every file reaches a fixpoint in ≤8 passes; this cap is a
+   generous backstop for arbitrary user documents and a hard stop should a
+   future producer regress into a non-terminating cascade. *)
+let apply_fixes_cap = 64
+
+(* P1a: iterate [--apply-fixes] to a fixpoint. Each pass refreshes the
+   src-dependent contexts (language profile, command spans, user macros, file
+   context) for the evolving text, exactly as a fresh [--apply-fixes] subprocess
+   would — so the in-process fixpoint is byte-identical to iterating the CLI
+   externally, which is the behaviour [check_apply_fixes_safety.py] validates
+   across the whole corpus. Benign cross-rule cascades (e.g. ENC-004 producing
+   U+2026, then SPC-025 deleting the space before it) now resolve in a single
+   invocation instead of needing repeated runs.
+
+   Cycle-safe: a seen-set of per-pass digests detects oscillation and the cap
+   bounds runaway cascades. Both known oscillating producer pairs were
+   reconciled at source (no file oscillates today), but if a future pair
+   regresses the loop emits the last stable state ([cur], the text whose
+   application re-enters the cycle) and warns rather than hanging. Emitting
+   [cur] — not the repeated state — keeps the safety gate able to flag the
+   regression: [--apply-fixes] of the two cycle states still map to each other,
+   so the gate's external loop sees the cycle. *)
+let run_apply_fixes_converge ?filter_id ~path ~src () =
+  let seen = Hashtbl.create 16 in
+  Hashtbl.replace seen (Digest.string src) ();
+  let rec loop cur passes =
+    ignore (resolve_profile ~requested:`Auto ~src:cur);
+    ignore (setup_all ~path ~src:cur ~log_path:None);
+    let results = Latex_parse_lib.Validators.run_all cur in
+    let edits = collect_fix_edits ?filter_id results in
+    if edits = [] then Ok cur
+    else
+      match Latex_parse_lib.Rewrite_engine.apply ~source:cur ~edits with
+      | Error _ as e -> if passes = 0 then e else Ok cur
+      | Ok nxt ->
+          if String.equal nxt cur then Ok cur
+          else
+            let dn = Digest.string nxt in
+            if Hashtbl.mem seen dn then (
+              eprintf
+                "# apply-fixes: fix cycle detected after %d pass(es); emitting \
+                 last stable state (contradictory producers)\n"
+                (passes + 1);
+              Ok cur)
+            else if passes + 1 >= apply_fixes_cap then (
+              eprintf
+                "# apply-fixes: reached the %d-pass cap without a fixpoint; \
+                 emitting latest state\n"
+                apply_fixes_cap;
+              Ok nxt)
+            else (
+              Hashtbl.replace seen dn ();
+              loop nxt (passes + 1))
+  in
+  match loop src 0 with
+  | Ok out ->
+      print_string out;
+      0
+  | Error (`Overlap (a, b)) -> overlap_error a b
+
+let run_apply_fixes ?filter_id ?(best_effort = false) ?(converge = false) ~path
+    ~src () =
   let _tier, features = resolve_profile ~requested:`Auto ~src in
   print_profile_banner _tier features;
-  let _bp = setup_all ~path ~src ~log_path:None in
   Fun.protect ~finally:cleanup (fun () ->
-      let results = Latex_parse_lib.Validators.run_all src in
-      let edits = collect_fix_edits ?filter_id results in
-      if best_effort then (
-        let out, applied, skipped =
-          Latex_parse_lib.Cst_edit.apply_best_effort src edits
-        in
-        print_string out;
-        if skipped <> [] then (
-          eprintf "# apply-fixes-best-effort: %d edit(s) applied, %d skipped\n"
-            (List.length applied) (List.length skipped);
-          List.iter
-            (fun e ->
-              eprintf "# skipped: %s\n" (Latex_parse_lib.Cst_edit.to_string e))
-            skipped);
-        0)
+      if converge && not best_effort then
+        run_apply_fixes_converge ?filter_id ~path ~src ()
       else
-        match Latex_parse_lib.Rewrite_engine.apply ~source:src ~edits with
-        | Ok out ->
-            print_string out;
-            0
-        | Error (`Overlap (a, b)) ->
+        let _bp = setup_all ~path ~src ~log_path:None in
+        let results = Latex_parse_lib.Validators.run_all src in
+        let edits = collect_fix_edits ?filter_id results in
+        if best_effort then (
+          let out, applied, skipped =
+            Latex_parse_lib.Cst_edit.apply_best_effort src edits
+          in
+          print_string out;
+          if skipped <> [] then (
             eprintf
-              "E.apply-fixes.overlap: two rule fixes affect overlapping source \
-               ranges; refusing to apply.\n\
-               # first edit:  %s\n\
-               # second edit: %s\n\
-               # hint: re-run with --apply-fixes-best-effort to apply the \
-               maximal non-conflicting subset.\n"
-              (Latex_parse_lib.Cst_edit.to_string a)
-              (Latex_parse_lib.Cst_edit.to_string b);
-            2)
+              "# apply-fixes-best-effort: %d edit(s) applied, %d skipped\n"
+              (List.length applied) (List.length skipped);
+            List.iter
+              (fun e ->
+                eprintf "# skipped: %s\n" (Latex_parse_lib.Cst_edit.to_string e))
+              skipped);
+          0)
+        else
+          match Latex_parse_lib.Rewrite_engine.apply ~source:src ~edits with
+          | Ok out ->
+              print_string out;
+              0
+          | Error (`Overlap (a, b)) -> overlap_error a b)
 
 (* ── Entry point ─────────────────────────────────────────────────── *)
 
@@ -208,7 +276,7 @@ let () =
   match args with
   | [ _; "--apply-fixes"; path ] ->
       let src = read_all path in
-      exit (run_apply_fixes ~path ~src ())
+      exit (run_apply_fixes ~converge:true ~path ~src ())
   | [ _; "--apply-fixes-for"; rule_id; path ] ->
       let src = read_all path in
       exit (run_apply_fixes ~filter_id:rule_id ~path ~src ())
@@ -220,7 +288,7 @@ let () =
       exit (run_apply_fixes ~best_effort:true ~filter_id:rule_id ~path ~src ())
   | [ _; path ] when apply_env_on ->
       let src = read_all path in
-      exit (run_apply_fixes ~path ~src ())
+      exit (run_apply_fixes ~converge:true ~path ~src ())
   | [ _; path ] ->
       let src = read_all path in
       let tier, features = resolve_profile ~requested:`Auto ~src in
@@ -327,10 +395,13 @@ let () =
          <file.tex>\n\n\
          --apply-fixes  run validators, apply every rule's fix edits via \
          Cst_edit.apply_all,\n\
-        \               and emit the modified source to stdout. \
-         L0_APPLY_FIXES=1 is equivalent\n\
-        \               when no other flag is given. Overlapping fixes → \
-         stderr + exit 2.\n\
+        \               and emit the modified source to stdout. Iterates to a \
+         fixpoint\n\
+        \               (P1a) so cross-rule cascades resolve in one run; \
+         cycle-safe. \n\
+        \               L0_APPLY_FIXES=1 is equivalent when no other flag is \
+         given.\n\
+        \               Overlapping fixes → stderr + exit 2.\n\
          --apply-fixes-for RULE-ID  same as --apply-fixes but only applies \
          fixes from results\n\
         \               whose [r.id = RULE-ID]. Useful for incremental \


### PR DESCRIPTION
## What

`--apply-fixes` now iterates to a **fixpoint** instead of applying a single validator pass. Cross-rule cascades (one rule's fix enabling another) resolve in one invocation; cycle-safe.

## Why

Previously `--apply-fixes` ran the rules once, applied their fix edits, and emitted the result. When one rule's output only *enables* another rule, the result was left half-fixed and the user had to re-run the command until it stabilised. Example cascade:

```
word <0x85>      (CP-1252 ellipsis byte, invalid UTF-8)
  → STRUCT-001 inserts \documentclass
  → ENC-004 rewrites 0x85 → U+2026  (…)
  → SPC-025 deletes the space before the freshly-created ellipsis
  ⇒ word…
```

A single pass stopped at `word <U+2026>`; convergence yields `word…`.

## How — faithful to the safety gate

Each pass refreshes the src-dependent contexts (language profile, command spans, user macros, file context) for the evolving text, **exactly as a fresh `--apply-fixes` subprocess would**. That makes the in-process fixpoint byte-identical to iterating the CLI externally — which is precisely what `check_apply_fixes_safety.py` validates across all 330 corpus files. So the convergence behaviour is already gate-validated.

**Cycle-safe:** a per-pass digest seen-set detects oscillation and a 64-pass cap bounds runaway cascades. Both known oscillating producer pairs were reconciled at source (#417 dash, #418 CJK), so nothing oscillates today; if a future pair regresses, the loop emits the last stable state and warns rather than hanging. It emits `cur` (the text whose application re-enters the cycle), **not** the repeated state — so the safety gate's external loop still sees the cycle and flags the regression.

**Scope:** only the plain `--apply-fixes` (and `L0_APPLY_FIXES=1`) path converges. `--apply-fixes-for`, `--apply-fixes-best-effort`, and the best-effort-for variant keep their existing single-pass behaviour.

## Verification

- ✅ `test_apply_fixes_cli`: **19** cases (+2: cross-rule cascade convergence + idempotence)
- ✅ Safety gate: all **330** corpus files still converge to valid output
- ✅ Differential: **0 diffs** vs `v27.0.72` (this only touches the `--apply-fixes` path, not lint)
- ✅ Full `pre_release_check.py` green (local `cst-perf` is the known dev-load flake; CI ~646ms is the arbiter)

No version bump (CLI-behaviour improvement, 0-diff lint; no new producer) — same release-neutral class as #417/#418.