### PR TITLE
feat(P3): context-exemption layer + TYPO-002 token-aware retrofit

### DIFF
--- a/latex-parse/src/dune
+++ b/latex-parse/src/dune
@@ -180,6 +180,16 @@
  (libraries latex_parse_lib))
 
 (test
+ (name test_exempt_ranges)
+ (modules test_exempt_ranges)
+ (libraries latex_parse_lib test_helpers unix))
+
+(test
+ (name test_context_exemption)
+ (modules test_context_exemption)
+ (libraries latex_parse_lib test_helpers unix))
+
+(test
  (name test_tokenizer_props)
  (modules test_tokenizer_props)
  (libraries latex_parse_lib))

--- a/latex-parse/src/test_context_exemption.ml
+++ b/latex-parse/src/test_context_exemption.ml
@@ -1,0 +1,45 @@
+(** Context-exemption regression gate (P3 token-aware variants).
+
+    Asserts that each retrofitted pilot rule fires on a genuine deviation in
+    ordinary prose, but stays SILENT when the same deviation is inside a
+    protected region (inline/env verbatim, line comment, or math). This is the
+    post-pilot-gate property that makes a Draft rule safe to promote to the
+    default set: it enforces the project's typographic standard without
+    false-positiving on code listings, comments, or math.
+
+    Add a row to [cases] as each rule is made context-aware; the rule's needle
+    must appear verbatim in each [plain]/[ctx] string. *)
+
+open Test_helpers
+
+(* (rule id, prose input that MUST fire, [(context label, input that MUST be
+   silent)]). Each exempt input embeds the same deviation inside a protected
+   region. *)
+let cases =
+  [
+    ( "TYPO-002",
+      "ordinary text a -- b here",
+      [
+        ("inline verbatim", "x \\verb|a -- b| y");
+        ("verbatim env", "\\begin{verbatim}\na -- b\n\\end{verbatim}");
+        ("line comment", "% a -- b comment\n");
+        ("inline math", "$a -- b$");
+      ] );
+  ]
+
+let () =
+  (* Pilot rules are gated behind L0_VALIDATORS; enable for this suite. *)
+  Unix.putenv "L0_VALIDATORS" "pilot";
+  List.iter
+    (fun (id, plain, exempt_cases) ->
+      run (Printf.sprintf "%s fires on a prose deviation" id) (fun tag ->
+          expect (fires id plain) (tag ^ ": " ^ id ^ " should fire on prose"));
+      List.iter
+        (fun (ctx, src) ->
+          run (Printf.sprintf "%s is exempt inside %s" id ctx) (fun tag ->
+              expect (does_not_fire id src)
+                (tag ^ ": " ^ id ^ " must not fire inside " ^ ctx)))
+        exempt_cases)
+    cases;
+  Unix.putenv "L0_VALIDATORS" "";
+  finalise "context-exemption"

--- a/latex-parse/src/test_exempt_ranges.ml
+++ b/latex-parse/src/test_exempt_ranges.ml
@@ -1,0 +1,116 @@
+(** Unit tests for the context-exemption scanner (P3 token-aware variants):
+    [Validators_common.find_exempt_ranges] / [is_in_exempt_range].
+
+    The scanner identifies byte ranges where typography/lexical rules must NOT
+    fire — verbatim spans, line comments, url targets, and math. These tests pin
+    each context, the math-masking correctness (a `$` inside a comment/verbatim
+    is literal, not a math toggle), and boundary behaviour. *)
+
+open Latex_parse_lib.Validators_common
+open Test_helpers
+
+(* Byte offset of the first occurrence of [sub] in [s] (or -1). *)
+let find_sub s sub =
+  let n = String.length s and m = String.length sub in
+  let rec go i =
+    if i + m > n then -1 else if String.sub s i m = sub then i else go (i + 1)
+  in
+  go 0
+
+(* Is the first occurrence of [sub] inside an exempt range? *)
+let exempt s sub =
+  let i = find_sub s sub in
+  if i < 0 then failwith ("test bug: substring not found: " ^ sub)
+  else is_in_exempt_range (find_exempt_ranges s) i
+
+let () =
+  (* ── Comments ──────────────────────────────────────────────────────── *)
+  run "comment body is exempt" (fun tag ->
+      expect (exempt "ok % a -- b dash\nmore" "-- b") (tag ^ ": -- in comment"));
+  run "text before a comment is NOT exempt" (fun tag ->
+      expect
+        (not (exempt "real -- text % c\n" "-- text"))
+        (tag ^ ": prose dash before % stays live"));
+  run "escaped percent is not a comment" (fun tag ->
+      expect
+        (not (exempt "cost 50\\% and -- here\n" "-- here"))
+        (tag ^ ": \\% does not open a comment"));
+
+  (* ── Inline verbatim ───────────────────────────────────────────────── *)
+  run "\\verb|..| body is exempt" (fun tag ->
+      expect (exempt "x \\verb|a -- b| y" "-- b") (tag ^ ": -- inside \\verb"));
+  run "\\verb*|..| body is exempt" (fun tag ->
+      expect (exempt "x \\verb*|a -- b| y" "-- b") (tag ^ ": -- inside \\verb*"));
+  run "\\lstinline|..| body is exempt" (fun tag ->
+      expect
+        (exempt "x \\lstinline|a -- b| y" "-- b")
+        (tag ^ ": -- inside \\lstinline"));
+  run "\\verbatim-like command is NOT misparsed as \\verb" (fun tag ->
+      (* \verbatiminput{f} — letter after \verb means it is not inline \verb;
+         the `--` in following prose must stay live. *)
+      expect
+        (not (exempt "\\verbatiminput{f} then -- here" "-- here"))
+        (tag ^ ": letter-delimiter guard"));
+  run "text after \\verb|..| is live again" (fun tag ->
+      expect
+        (not (exempt "\\verb|code| then -- prose" "-- prose"))
+        (tag ^ ": dash after the closing delimiter fires"));
+
+  (* ── Verbatim environments ─────────────────────────────────────────── *)
+  run "verbatim environment body is exempt" (fun tag ->
+      expect
+        (exempt "\\begin{verbatim}\na -- b\n\\end{verbatim}" "-- b")
+        (tag ^ ": -- inside verbatim env"));
+  run "lstlisting environment body is exempt" (fun tag ->
+      expect
+        (exempt "\\begin{lstlisting}\nx -- y\n\\end{lstlisting}" "-- y")
+        (tag ^ ": -- inside lstlisting"));
+  run "non-verbatim environment body is NOT exempt" (fun tag ->
+      expect
+        (not (exempt "\\begin{itemize}\n\\item -- z\n\\end{itemize}" "-- z"))
+        (tag ^ ": itemize is ordinary prose"));
+
+  (* ── Math (composition) ────────────────────────────────────────────── *)
+  run "$..$ inline math is exempt" (fun tag ->
+      expect (exempt "t $a -- b$ u" "-- b") (tag ^ ": -- in $..$"));
+  run "\\(..\\) inline math is exempt" (fun tag ->
+      expect (exempt "t \\(a -- b\\) u" "-- b") (tag ^ ": -- in \\(..\\)"));
+  run "\\[..\\] display math is exempt" (fun tag ->
+      expect (exempt "t \\[a -- b\\] u" "-- b") (tag ^ ": -- in \\[..\\]"));
+  run "equation environment is exempt" (fun tag ->
+      expect
+        (exempt "\\begin{equation}\na -- b\n\\end{equation}" "-- b")
+        (tag ^ ": -- in equation env"));
+
+  (* ── Math masking: a $ in a comment/verbatim must not toggle math ──── *)
+  run "stray $ in a comment does not desync later math" (fun tag ->
+      (* The `$` in the comment must NOT open math; the prose `-- here` after
+         the comment line must therefore stay LIVE (not swallowed by phantom
+         math). *)
+      let s = "% price is $5 today\nreal -- here and $x$ end" in
+      expect (not (exempt s "-- here")) (tag ^ ": comment $ neutralised"));
+  run "real math after a comment-$ still detected" (fun tag ->
+      let s = "% $ stray\nkeep $a -- b$ exempt" in
+      expect (exempt s "-- b") (tag ^ ": $a -- b$ still math"));
+  run "$ inside verbatim is literal, not math" (fun tag ->
+      expect
+        (not (exempt "\\verb|$| then -- prose" "-- prose"))
+        (tag ^ ": verbatim $ does not open math"));
+
+  (* ── URLs ──────────────────────────────────────────────────────────── *)
+  run "\\url{..} target is exempt" (fun tag ->
+      expect
+        (exempt "see \\url{http://a--b.com} now" "--b")
+        (tag ^ ": -- inside \\url"));
+  run "\\href first arg exempt, link text live" (fun tag ->
+      let s = "\\href{http://a--b.com}{the -- text}" in
+      expect (exempt s "--b") (tag ^ ": url arg exempt");
+      expect (not (exempt s "-- text")) (tag ^ ": link text is prose"));
+
+  (* ── Plain text + boundaries ───────────────────────────────────────── *)
+  run "plain prose is never exempt" (fun tag ->
+      expect (not (exempt "just a -- dash here" "-- dash")) (tag ^ ": live"));
+  run "empty string yields no ranges" (fun tag ->
+      expect (find_exempt_ranges "" = []) (tag ^ ": no ranges"));
+
+  finalise "exempt-ranges"

--- a/latex-parse/src/validators_common.ml
+++ b/latex-parse/src/validators_common.ml
@@ -402,6 +402,174 @@ let range_is_inline_math (s : string) ((a, _b) : int * int) : bool =
     (s.[a] = '$' && s.[a + 1] <> '$') || (s.[a] = '\\' && s.[a + 1] = '(')
   else s.[a] = '$'
 
+(* ── Context-exemption ranges (P3 token-aware variants) ───────────────────
+   Byte ranges where typographic / lexical lint rules must NOT fire because the
+   bytes are not ordinary prose: verbatim spans, line comments, and url/href
+   targets — composed with [find_math_ranges] for math. The pilot L0 rules were
+   string-level and context-blind (docs/archive/RULES_PILOT_TODO.md: "Runtime
+   implementation is string-level; token-aware variants will follow post L0
+   tokenizer rewire"), so they fired on `--`, `...`, ``..'' etc. inside code
+   listings, comments and math. Composing a rule's candidate offsets with
+   [is_in_exempt_range (find_exempt_ranges s)] makes it skip those regions — the
+   post-pilot-gate prerequisite for graduating a Draft rule to the default
+   set. *)
+
+(* Environments whose body is verbatim (literal bytes, no typography
+   applies). *)
+let verbatim_envs =
+  [
+    "verbatim";
+    "verbatim*";
+    "Verbatim";
+    "Verbatim*";
+    "BVerbatim";
+    "LVerbatim";
+    "lstlisting";
+    "minted";
+    "alltt";
+    "comment";
+    "listing";
+  ]
+
+(** [find_verbatim_comment_url_ranges s] — single left-to-right pass returning
+    the byte ranges covered by line comments (`%`..EOL, respecting `\%`),
+    inline verbatim (`\verb<d>..<d>`, `\verb*`, `\lstinline<d>..<d>`), verbatim
+    environments ([verbatim_envs]), and url targets (`\url{..}`, `\nolinkurl`,
+    `\path`, and the FIRST argument of `\href{..}{..}`). Precedence is positional
+    — whichever region opens first wins, and the scanner jumps past a region's
+    end before looking for the next, so a `%`/`$`/`\verb` inside a verbatim span
+    (or a `$` inside a comment) is correctly treated as literal. *)
+let find_verbatim_comment_url_ranges (s : string) : (int * int) list =
+  let n = String.length s in
+  let tbl = Hashtbl.create 32 in
+  List.iter (fun e -> Hashtbl.replace tbl e ()) verbatim_envs;
+  let is_verb_env name = Hashtbl.mem tbl name in
+  let is_escaped idx =
+    let rec count back acc =
+      if back < 0 then acc
+      else if String.unsafe_get s back = '\\' then count (back - 1) (acc + 1)
+      else acc
+    in
+    count (idx - 1) 0 land 1 = 1
+  in
+  let starts_with p idx =
+    let pl = String.length p in
+    idx + pl <= n && String.sub s idx pl = p
+  in
+  let is_letter c = (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') in
+  (* End (exclusive) of the brace group whose opening `{` is at [open_pos]. *)
+  let brace_group_end open_pos =
+    let depth = ref 0 in
+    let k = ref open_pos in
+    let stop = ref None in
+    while !stop = None && !k < n do
+      (if not (is_escaped !k) then
+         match String.unsafe_get s !k with
+         | '{' -> incr depth
+         | '}' ->
+             decr depth;
+             if !depth = 0 then stop := Some (!k + 1)
+         | _ -> ());
+      incr k
+    done;
+    match !stop with Some e -> e | None -> n
+  in
+  let ranges = ref [] in
+  let i = ref 0 in
+  while !i < n do
+    let pos = !i in
+    let c = String.unsafe_get s pos in
+    if c = '%' && not (is_escaped pos) then (
+      let j = ref pos in
+      while !j < n && String.unsafe_get s !j <> '\n' do
+        incr j
+      done;
+      ranges := (pos, !j) :: !ranges;
+      i := !j)
+    else if c = '\\' && not (is_escaped pos) then
+      if starts_with "\\begin{" pos then (
+        let ns = pos + 7 in
+        let j = ref ns in
+        while !j < n && String.unsafe_get s !j <> '}' do
+          incr j
+        done;
+        if !j < n && is_verb_env (String.sub s ns (!j - ns)) then (
+          let name = String.sub s ns (!j - ns) in
+          let endp = "\\end{" ^ name ^ "}" in
+          let el = String.length endp in
+          let k = ref (!j + 1) in
+          while !k < n && not (starts_with endp !k) do
+            incr k
+          done;
+          let stop = if !k < n then !k + el else n in
+          ranges := (pos, stop) :: !ranges;
+          i := stop)
+        else i := pos + 1)
+      else if starts_with "\\verb" pos || starts_with "\\lstinline" pos then (
+        let cmdlen = if starts_with "\\lstinline" pos then 10 else 5 in
+        let after = ref (pos + cmdlen) in
+        if !after < n && String.unsafe_get s !after = '*' then incr after;
+        if !after < n && not (is_letter (String.unsafe_get s !after)) then (
+          (* The next char is the delimiter; non-letter guard avoids swallowing
+             longer command names (e.g. \verbatim, \verbatiminput). *)
+          let delim = String.unsafe_get s !after in
+          let k = ref (!after + 1) in
+          while !k < n && String.unsafe_get s !k <> delim do
+            incr k
+          done;
+          let stop = if !k < n then !k + 1 else n in
+          ranges := (pos, stop) :: !ranges;
+          i := stop)
+        else i := pos + 1)
+      else if
+        starts_with "\\url{" pos
+        || starts_with "\\nolinkurl{" pos
+        || starts_with "\\path{" pos
+      then (
+        let bpos = String.index_from s pos '{' in
+        let stop = brace_group_end bpos in
+        ranges := (pos, stop) :: !ranges;
+        i := stop)
+      else if starts_with "\\href{" pos then (
+        (* Only the first argument (the URL) is verbatim-ish; the link text is
+           ordinary prose, so exempt just `\href{..}`. *)
+        let bpos = pos + 5 in
+        let stop = brace_group_end bpos in
+        ranges := (pos, stop) :: !ranges;
+        i := stop)
+      else i := pos + 1
+    else i := pos + 1
+  done;
+  List.rev !ranges
+
+(** [find_exempt_ranges s] — all byte ranges where typography/lexical rules must
+    not fire: verbatim + comments + url targets
+    ([find_verbatim_comment_url_ranges]) plus math ([find_math_ranges]).
+
+    To detect math correctly, the verbatim/comment/url spans are first BLANKED
+    to spaces (offsets preserved) and [find_math_ranges] is run on the blanked
+    copy. [find_math_ranges] is itself context-blind about comments/verbatim, so
+    a stray `$` in a comment would otherwise desync all downstream math pairing;
+    blanking neutralises those bytes (a space is never a math toggle) without
+    shifting any offset, so the math ranges are accurate outside protected
+    regions. The result is sorted by start; overlaps are harmless for the
+    existential [is_in_exempt_range] check. *)
+let find_exempt_ranges (s : string) : (int * int) list =
+  let vcu = find_verbatim_comment_url_ranges s in
+  let blanked = Bytes.of_string s in
+  List.iter
+    (fun (a, b) ->
+      for k = a to b - 1 do
+        Bytes.set blanked k ' '
+      done)
+    vcu;
+  let math = find_math_ranges (Bytes.unsafe_to_string blanked) in
+  List.sort (fun (a, _) (c, _) -> compare a c) (List.rev_append vcu math)
+
+(** [is_in_exempt_range ranges off] — true iff [off] is inside any exempt range.
+    (Alias of the generic point-in-ranges test [is_in_math_range].) *)
+let is_in_exempt_range = is_in_math_range
+
 (** [is_ascii_context ?window ?candidate_bytes s off] — heuristic that returns
     [true] iff the byte window of size [window] (default 32) on each side of the
     candidate UTF-8 sequence at [off] (of length [candidate_bytes], default 3)

--- a/latex-parse/src/validators_l0_typo.ml
+++ b/latex-parse/src/validators_l0_typo.ml
@@ -81,6 +81,39 @@ let find_all_non_overlapping (s : string) (needle : string) : int list =
     in
     loop 0 []
 
+(* ── P3 context-aware match collection (token-aware variants) ──────────────
+   The pilot L0 rules are string-level and were context-blind, firing on
+   deviations inside verbatim / comments / math / url targets (the reason they
+   stayed `L0_VALIDATORS=pilot`-gated; see docs/archive/RULES_PILOT_TODO.md).
+   [occurrences_in_text] returns the offsets of [needle] that lie in ordinary
+   prose only, by filtering through a precomputed [exempt] = [find_exempt_ranges
+   s]. A retrofitted rule computes [exempt] once and derives BOTH its count and
+   its fix edits from the same filtered offsets, so they stay consistent and the
+   rule no longer false-positives in protected regions — the post-pilot-gate
+   prerequisite for graduating it to the default rule set. *)
+let occurrences_in_text exempt (s : string) (needle : string) : int list =
+  find_all_non_overlapping s needle
+  |> List.filter (fun off -> not (is_in_exempt_range exempt off))
+
+(* Overlapping count of [needle] in [s] outside exempt ranges. Preserves the
+   diagnostic-count semantics of [count_substring] (which allows overlaps — e.g.
+   "--" occurs twice in "---") while skipping protected regions. Using this for
+   the COUNT (and [occurrences_in_text] for the non-overlapping FIX offsets)
+   keeps a retrofitted rule's count identical to its string-level form on
+   ordinary prose, so DAG conflict resolution (which tie-breaks on count) and
+   the lint output are unchanged outside protected regions. *)
+let count_in_text exempt (s : string) (needle : string) : int =
+  let n = String.length s and m = String.length needle in
+  if m = 0 || n < m then 0
+  else
+    let rec loop i acc =
+      if i > n - m then acc
+      else if String.sub s i m = needle && not (is_in_exempt_range exempt i)
+      then loop (i + 1) (acc + 1)
+      else loop (i + 1) acc
+    in
+    loop 0 0
+
 (** [find_consecutive_runs s c ~min_len] — list of [(start, stop)] half-open
     ranges where [s] has a maximal run of character [c] of length at least
     [min_len]. Used by TYPO-018 to collapse multi-space runs to a single space. *)
@@ -112,65 +145,46 @@ let mk_replace_edits (s : string) (needle : string) (replacement : string) :
 
 let r_typo_002 : rule =
   let message = "Double hyphen -- should be en‑dash –" in
-  (* Fix-set delegation (oscillation fix): the fix leaves numeric/page ranges
-     (digit`--`digit) as `--`, the canonical LaTeX source form for a range
-     en-dash and the domain of TYPO-026 (`–`→`--` in page ranges). Without this,
-     TYPO-002 (`--`→`–`) and TYPO-026 form a contradictory pair that oscillates
-     forever under repeated --apply-fixes (found by
-     check_apply_fixes_safety.py). The COUNT is unchanged (every `--` is still
-     tallied) so lint output is identical (0 diff); only the fix-set is filtered
-     at range offsets — the same delegation pattern as TYPO-010→SPC-016/021 and
-     CHAR-016→CJK-001/002. *)
-  let mk_fix_edits s =
-    let n = String.length s in
-    let is_digit c = c >= '0' && c <= '9' in
-    let is_numeric_range off =
-      off > 0 && is_digit s.[off - 1] && off + 2 < n && is_digit s.[off + 2]
-    in
-    List.filter_map
-      (fun off ->
-        if is_numeric_range off then None
-        else Some (Cst_edit.replace ~start_offset:off ~end_offset:(off + 2) "–"))
-      (find_all_non_overlapping s "--")
-  in
+  (* P3 context-aware (token-aware variant): count + fix derive from the same
+     exempt-filtered offsets, so `--` inside verbatim / comments / math / url is
+     ignored (it is literal there), not just inside plain prose. This replaces
+     the former string-level `count_substring` default branch and the incomplete
+     `L0_TOKEN_AWARE` Tokenizer_lite branch (Tokenizer_lite has no
+     comment/verbatim kinds, so it could not skip those regions).
+
+     Fix-set delegation (oscillation fix): numeric/page ranges (digit`--`digit)
+     are left as `--`, the canonical LaTeX source form and TYPO-026's domain, so
+     TYPO-002 (`--`→`–`) and TYPO-026 do not oscillate under --apply-fixes
+     (check_apply_fixes_safety.py). The count still tallies every prose `--`;
+     only the fix is withheld at range offsets. *)
   let run s =
-    match Sys.getenv_opt "L0_TOKEN_AWARE" with
-    | Some ("1" | "true" | "on") ->
-        let open Tokenizer_lite in
-        let toks = tokenize s in
-        let cnt =
-          let rec loop c = function
-            | [] -> c
-            | a :: b :: rest -> (
-                match (a.ch, b.ch) with
-                | Some '-', Some '-' -> loop (c + 1) (b :: rest)
-                | _ -> loop c (b :: rest))
-            | _ -> c
-          in
-          loop 0 toks
-        in
-        if cnt > 0 then
-          let fix = mk_fix_edits s in
-          if fix = [] then
-            Some
-              (mk_result ~id:"TYPO-002" ~severity:Warning ~message ~count:cnt)
-          else
-            Some
-              (mk_result_with_fix ~id:"TYPO-002" ~severity:Warning ~message
-                 ~count:cnt ~fix)
-        else None
-    | _ ->
-        let cnt = count_substring s "--" in
-        if cnt > 0 then
-          let fix = mk_fix_edits s in
-          if fix = [] then
-            Some
-              (mk_result ~id:"TYPO-002" ~severity:Warning ~message ~count:cnt)
-          else
-            Some
-              (mk_result_with_fix ~id:"TYPO-002" ~severity:Warning ~message
-                 ~count:cnt ~fix)
-        else None
+    let exempt = find_exempt_ranges s in
+    (* Count keeps [count_substring]'s overlapping semantics (so "--" tallies 2
+       in "---" and the TYPO-002⇄TYPO-003 conflict tie-break is unchanged); the
+       fix uses non-overlapping offsets. Both skip exempt regions. *)
+    let cnt = count_in_text exempt s "--" in
+    if cnt > 0 then
+      let n = String.length s in
+      let is_digit c = c >= '0' && c <= '9' in
+      let is_numeric_range off =
+        off > 0 && is_digit s.[off - 1] && off + 2 < n && is_digit s.[off + 2]
+      in
+      let fix =
+        List.filter_map
+          (fun off ->
+            if is_numeric_range off then None
+            else
+              Some
+                (Cst_edit.replace ~start_offset:off ~end_offset:(off + 2) "–"))
+          (occurrences_in_text exempt s "--")
+      in
+      if fix = [] then
+        Some (mk_result ~id:"TYPO-002" ~severity:Warning ~message ~count:cnt)
+      else
+        Some
+          (mk_result_with_fix ~id:"TYPO-002" ~severity:Warning ~message
+             ~count:cnt ~fix)
+    else None
   in
   { id = "TYPO-002"; run; languages = [] }
 


### PR DESCRIPTION
## Context — following the specs

The pilot L0 **TYPO rules are spec-defined best practices** (`rules_v3.yaml`: `--`→en-dash, ` ``…'' `→curly quotes, `\'{e}`→UTF-8, all `fix: auto_replace`), but all carry **`maturity: Draft`** and are gated behind `L0_VALIDATORS=pilot`. The documented graduation path (`docs/archive/RULES_PILOT_TODO.md` — *"keep feature-flagged via `L0_VALIDATORS` until post-pilot gate"*) is blocked on an unchecked **"FP review with real-world corpus"** task.

The reason is concrete and spec-documented: the rules are **string-level and context-blind** — they fire on deviations inside verbatim, comments, math, and url targets. Confirmed: TYPO-002 fired in `\verb`, `verbatim`, `% comments`, and `$math$`. The spec names the remedy: *"token-aware variants will follow post L0 tokenizer rewire."*

This PR **builds that token-awareness** as a reusable layer and proves it on TYPO-002. It is the prerequisite for graduating the family to the default set; **no promotion happens here**.

## What's in it

- **`Validators_common.find_exempt_ranges`** — single-pass scanner for byte ranges where typography must not fire: line comments (respecting `\%`), inline verbatim (`\verb`/`\verb*`/`\lstinline<delim>…`), verbatim environments (`verbatim`/`lstlisting`/`minted`/…), and url targets (`\url`/`\nolinkurl`/`\path`/`\href` first arg) — composed with `find_math_ranges`. Verbatim/comment/url spans are **blanked before the math scan** so a stray `$` in a comment can't desync downstream math pairing. `is_in_exempt_range` is the predicate. → **`test_exempt_ranges`: 23 cases**.

- **`occurrences_in_text`** (non-overlapping offsets, for fixes) and **`count_in_text`** (overlapping count, preserving `count_substring`'s semantics so the diagnostic count — and the DAG conflict tie-break, which ranks on count — are unchanged on ordinary prose). *This subtlety caused a TYPO-002⇄003 conflict regression mid-development; `count_in_text` fixes it.*

- **TYPO-002 retrofitted** to a single context-aware path: count + fix derive from the same exempt-filtered offsets. Fires on prose `--`, silent in verbatim/comment/math/url. Drops the incomplete `L0_TOKEN_AWARE` `Tokenizer_lite` branch (that tokenizer has no comment/verbatim kinds). TYPO-026 numeric-range delegation preserved.

- **`test_context_exemption`** — the FP-regression gate: each retrofitted rule must fire on a prose deviation and stay silent in every protected context. Rows added per rule as the retrofit proceeds.

## Verification
- ✅ golden 355, typo-fix 412, `test_exempt_ranges` 23, `test_context_exemption` 5, full suite green
- ✅ apply-fixes safety: 330/330 converge
- ✅ differential: **0 diffs** vs v27.0.72 (default set unchanged — TYPO-002 is pilot-only)
- No version bump

## What follows (separate PRs)
Retrofit the remaining pilot TYPO rules in batches (each gated by `test_context_exemption`), complete the post-pilot perf smoke, then graduate the FP-clean rules `Draft`→`Implemented` and add them to the default set (the behavior-changing, version-bumped promotion).