### PR TITLE
feat(P3 Phase 2 batch 1): context-aware retrofit of 6 pilot TYPO rules

### DIFF
--- a/latex-parse/src/test_context_exemption.ml
+++ b/latex-parse/src/test_context_exemption.ml
@@ -25,6 +25,54 @@ let cases =
         ("line comment", "% a -- b comment\n");
         ("inline math", "$a -- b$");
       ] );
+    ( "TYPO-003",
+      "ordinary text a --- b here",
+      [
+        ("inline verbatim", "x \\verb|a --- b| y");
+        ("verbatim env", "\\begin{verbatim}\na --- b\n\\end{verbatim}");
+        ("line comment", "% a --- b comment\n");
+        ("inline math", "$a --- b$");
+      ] );
+    ( "TYPO-004",
+      "they said ``hello'' loudly",
+      [
+        ("inline verbatim", "x \\verb|``hello''| y");
+        ("verbatim env", "\\begin{verbatim}\n``hello''\n\\end{verbatim}");
+        ("line comment", "% ``hello'' comment\n");
+        ("inline math", "$``hello''$");
+      ] );
+    ( "TYPO-005",
+      "wait ... and see",
+      [
+        ("inline verbatim", "x \\verb|...| y");
+        ("verbatim env", "\\begin{verbatim}\na ... b\n\\end{verbatim}");
+        ("line comment", "% wait ... comment\n");
+        ("inline math", "$a + ... + z$");
+      ] );
+    ( "TYPO-010",
+      "apples , oranges here",
+      [
+        ("inline verbatim", "x \\verb|a , b| y");
+        ("verbatim env", "\\begin{verbatim}\na , b\n\\end{verbatim}");
+        ("line comment", "% a , b comment\n");
+        ("inline math", "$a , b$");
+      ] );
+    ( "TYPO-033",
+      "see Smith et.al here",
+      [
+        ("inline verbatim", "x \\verb|et.al| y");
+        ("verbatim env", "\\begin{verbatim}\net.al\n\\end{verbatim}");
+        ("line comment", "% et.al comment\n");
+        ("inline math", "$et.al$");
+      ] );
+    ( "TYPO-037",
+      "apples , oranges here",
+      [
+        ("inline verbatim", "x \\verb|a , b| y");
+        ("verbatim env", "\\begin{verbatim}\na , b\n\\end{verbatim}");
+        ("line comment", "% a , b comment\n");
+        ("inline math", "$a , b$");
+      ] );
   ]
 
 let () =

--- a/latex-parse/src/test_typo_fix.ml
+++ b/latex-parse/src/test_typo_fix.ml
@@ -414,19 +414,21 @@ let () =
         && List.length edits = 2)
         (tag ^ ": equation env preserved"));
 
-  run "TYPO-004 fix: still fires count on '' in math (no-fix path)" (fun tag ->
-      (* Math-only `` or '' should still report (count > 0) but no auto-fix.
-         Round-8 audit: previously asserted only [List.length edits = 0], which
-         can't disambiguate "rule didn't fire" from "rule fired but emitted no
-         fix". Now also asserts [fires_with_count] = 2 to verify the rule DOES
-         fire (count = 2 because the source contains two '' pairs at offsets 3
-         and 9), and the fix list is empty because both pairs are inside
-         math. *)
+  run "TYPO-004 stays silent when '' is only in math (P3 context-aware)"
+    (fun tag ->
+      (* P3 token-aware retrofit: the count now derives from the exempt-filtered
+         offsets (find_exempt_ranges), so `` / '' that occur ONLY inside math
+         (double-prime `$f''(x)$`) are neither counted nor fixed — the rule is
+         fully SILENT, not the former "fires count=2, no fix" behaviour. A
+         no-fix Warning inside math is itself a false positive; eliminating it is
+         the post-pilot-gate property for promoting TYPO-004 to the default
+         set. (Pairs outside math are still counted and fixed — see the
+         interleaved-math test below.) *)
       let src = "$f''(x) g''(x)$" in
       let edits = fix_edits "TYPO-004" src in
       expect
-        (fires_with_count "TYPO-004" src 2 && List.length edits = 0)
-        (tag ^ ": rule fires with count=2, no fix edits"));
+        (does_not_fire "TYPO-004" src && List.length edits = 0)
+        (tag ^ ": rule silent, no fix edits"));
 
   run "TYPO-004 does not fire on clean source" (fun tag ->
       expect

--- a/latex-parse/src/test_typo_fix.ml
+++ b/latex-parse/src/test_typo_fix.ml
@@ -420,8 +420,8 @@ let () =
          offsets (find_exempt_ranges), so `` / '' that occur ONLY inside math
          (double-prime `$f''(x)$`) are neither counted nor fixed — the rule is
          fully SILENT, not the former "fires count=2, no fix" behaviour. A
-         no-fix Warning inside math is itself a false positive; eliminating it is
-         the post-pilot-gate property for promoting TYPO-004 to the default
+         no-fix Warning inside math is itself a false positive; eliminating it
+         is the post-pilot-gate property for promoting TYPO-004 to the default
          set. (Pairs outside math are still counted and fixed — see the
          interleaved-math test below.) *)
       let src = "$f''(x) g''(x)$" in

--- a/latex-parse/src/validators_l0_typo.ml
+++ b/latex-parse/src/validators_l0_typo.ml
@@ -143,6 +143,19 @@ let mk_replace_edits (s : string) (needle : string) (replacement : string) :
       Cst_edit.replace ~start_offset:off ~end_offset:(off + nlen) replacement)
     (find_all_non_overlapping s needle)
 
+(** [mk_replace_edits_exempt exempt s needle replacement] — context-aware
+    counterpart of [mk_replace_edits]: emits a non-overlapping [needle] →
+    [replacement] replace for every occurrence OUTSIDE the [exempt] ranges
+    (verbatim / comments / math / url), via [occurrences_in_text]. Use in a
+    retrofitted rule so its fix never touches a protected region. *)
+let mk_replace_edits_exempt exempt (s : string) (needle : string)
+    (replacement : string) : Cst_edit.t list =
+  let nlen = String.length needle in
+  List.map
+    (fun off ->
+      Cst_edit.replace ~start_offset:off ~end_offset:(off + nlen) replacement)
+    (occurrences_in_text exempt s needle)
+
 let r_typo_002 : rule =
   let message = "Double hyphen -- should be en‑dash –" in
   (* P3 context-aware (token-aware variant): count + fix derive from the same
@@ -190,49 +203,31 @@ let r_typo_002 : rule =
 
 let r_typo_003 : rule =
   let message = "Triple hyphen --- should be em‑dash —" in
-  let mk_fix_edits s =
-    List.map
-      (fun off -> Cst_edit.replace ~start_offset:off ~end_offset:(off + 3) "—")
-      (find_all_non_overlapping s "---")
-  in
+  (* P3 context-aware (token-aware variant): count + fix both derive from the
+     same exempt-filtered offsets, so `---` inside verbatim / comments / math /
+     url is ignored (literal there), not flagged. Replaces the former
+     string-level `count_substring` default branch and the incomplete
+     `L0_TOKEN_AWARE` Tokenizer_lite branch (Tokenizer_lite has no
+     comment/verbatim kinds, so it could not skip those regions). Count keeps
+     [count_substring]'s overlapping semantics on prose, preserving the
+     TYPO-002⇄TYPO-003 conflict tie-break (which compares counts). *)
   let run s =
-    match Sys.getenv_opt "L0_TOKEN_AWARE" with
-    | Some ("1" | "true" | "on") ->
-        let open Tokenizer_lite in
-        let toks = tokenize s in
-        let cnt =
-          let rec loop c = function
-            | [] -> c
-            | a :: b :: c' :: rest -> (
-                match (a.ch, b.ch, c'.ch) with
-                | Some '-', Some '-', Some '-' -> loop (c + 1) (b :: c' :: rest)
-                | _ -> loop c (b :: c' :: rest))
-            | _ -> c
-          in
-          loop 0 toks
-        in
-        if cnt > 0 then
-          let fix = mk_fix_edits s in
-          if fix = [] then
-            Some
-              (mk_result ~id:"TYPO-003" ~severity:Warning ~message ~count:cnt)
-          else
-            Some
-              (mk_result_with_fix ~id:"TYPO-003" ~severity:Warning ~message
-                 ~count:cnt ~fix)
-        else None
-    | _ ->
-        let cnt = count_substring s "---" in
-        if cnt > 0 then
-          let fix = mk_fix_edits s in
-          if fix = [] then
-            Some
-              (mk_result ~id:"TYPO-003" ~severity:Warning ~message ~count:cnt)
-          else
-            Some
-              (mk_result_with_fix ~id:"TYPO-003" ~severity:Warning ~message
-                 ~count:cnt ~fix)
-        else None
+    let exempt = find_exempt_ranges s in
+    let cnt = count_in_text exempt s "---" in
+    if cnt > 0 then
+      let fix =
+        List.map
+          (fun off ->
+            Cst_edit.replace ~start_offset:off ~end_offset:(off + 3) "—")
+          (occurrences_in_text exempt s "---")
+      in
+      if fix = [] then
+        Some (mk_result ~id:"TYPO-003" ~severity:Warning ~message ~count:cnt)
+      else
+        Some
+          (mk_result_with_fix ~id:"TYPO-003" ~severity:Warning ~message
+             ~count:cnt ~fix)
+    else None
   in
   { id = "TYPO-003"; run; languages = [] }
 
@@ -249,11 +244,17 @@ let r_typo_004 : rule =
      scripts/validate_messages.sh extractor doesn't follow let-bindings and the
      `messages` CI gate would mis-pair TYPO-003 with TYPO-004's message string
      (per feedback_silent_gate_failures memo). *)
-  let mk_fix_edits s =
-    let math = find_math_ranges s in
-    let outside off = not (is_in_math_range math off) in
-    let bt_offsets = List.filter outside (find_all_non_overlapping s "``") in
-    let ap_offsets = List.filter outside (find_all_non_overlapping s "''") in
+  (* P3 context-aware (token-aware variant): both count and fix now skip the
+     full exempt set (verbatim / comments / math / url) via [find_exempt_ranges],
+     superseding the v27.0.6 math-only [find_math_ranges] filter. Counting only
+     non-exempt occurrences makes the rule fully SILENT in protected regions —
+     the post-pilot-gate property for promotion — rather than the former
+     "fires count, no fix" behaviour that still surfaced a Warning inside math.
+     `` and '' inside math/verbatim are literal (e.g. `$f''(x)$` double-prime),
+     so they are neither reported nor fixed. *)
+  let mk_fix_edits exempt s =
+    let bt_offsets = occurrences_in_text exempt s "``" in
+    let ap_offsets = occurrences_in_text exempt s "''" in
     List.map
       (fun off ->
         Cst_edit.replace ~start_offset:off ~end_offset:(off + 2) "\xe2\x80\x9c")
@@ -265,9 +266,10 @@ let r_typo_004 : rule =
         ap_offsets
   in
   let run s =
-    let cnt = count_substring s "``" + count_substring s "''" in
+    let exempt = find_exempt_ranges s in
+    let cnt = count_in_text exempt s "``" + count_in_text exempt s "''" in
     if cnt > 0 then
-      let fix = mk_fix_edits s in
+      let fix = mk_fix_edits exempt s in
       if fix = [] then
         Some
           (mk_result ~id:"TYPO-004" ~severity:Warning
@@ -302,20 +304,22 @@ let r_typo_005 : rule =
 
      Message inlined per round-3 v27.0.6 pattern (validate_messages.sh extractor
      doesn't follow let-bindings). *)
-  let mk_fix_edits s =
-    let math = find_math_ranges s in
-    let outside off = not (is_in_math_range math off) in
-    let offsets = List.filter outside (find_all_non_overlapping s "...") in
+  (* P3 context-aware (token-aware variant): the count, formerly taken on the
+     math-stripped buffer ([count_substring (strip_math_segments s) "..."]), now
+     uses [count_in_text exempt s "..."] — equivalent on math (still skips `...`
+     inside `$1,2,...,n$`) and additionally skips verbatim / comments / url. Fix
+     offsets come from the same exempt set. *)
+  let mk_fix_edits exempt s =
     List.map
       (fun off ->
         Cst_edit.replace ~start_offset:off ~end_offset:(off + 3) "\\dots")
-      offsets
+      (occurrences_in_text exempt s "...")
   in
   let run s =
-    let stripped = strip_math_segments s in
-    let cnt = count_substring stripped "..." in
+    let exempt = find_exempt_ranges s in
+    let cnt = count_in_text exempt s "..." in
     if cnt > 0 then
-      let fix = mk_fix_edits s in
+      let fix = mk_fix_edits exempt s in
       if fix = [] then
         Some
           (mk_result ~id:"TYPO-005" ~severity:Warning
@@ -551,13 +555,25 @@ let r_typo_010 : rule =
      semantic preserved); only the fix-set shrinks at `;`/`:` offsets, where
      SPC-016/021's 1-byte delete emits instead of TYPO-010's 2-byte→1-byte
      replace. *)
+  (* P3 context-aware (token-aware variant): count + fix both skip the exempt
+     set (verbatim / comments / math / url) via [find_exempt_ranges], replacing
+     the former string-level `count_substring` default branch and the
+     `L0_TOKEN_AWARE` Tokenizer_lite branch (which had no comment/verbatim
+     kinds). Count still tallies all 6 punct chars (` ,` ` .` ` ;` ` :` ` ?`
+     ` !`); the fix-set still excludes `;`/`:` (delegated to SPC-016/SPC-021,
+     v27.0.60), and now additionally skips any space-before-punct inside a
+     protected region. *)
   let punct_chars = [ ','; '.'; '?'; '!' ] in
-  let mk_fix_edits s =
+  let mk_fix_edits exempt s =
     let n = String.length s in
     let edits = ref [] in
     let i = ref 0 in
     while !i < n - 1 do
-      if s.[!i] = ' ' && List.mem s.[!i + 1] punct_chars then (
+      if
+        s.[!i] = ' '
+        && List.mem s.[!i + 1] punct_chars
+        && not (is_in_exempt_range exempt !i)
+      then (
         edits :=
           Cst_edit.replace ~start_offset:!i ~end_offset:(!i + 2)
             (String.make 1 s.[!i + 1])
@@ -568,48 +584,20 @@ let r_typo_010 : rule =
     List.rev !edits
   in
   let run s =
-    match Sys.getenv_opt "L0_TOKEN_AWARE" with
-    | Some ("1" | "true" | "on") ->
-        let open Tokenizer_lite in
-        let toks = tokenize s in
-        let is_punct = function
-          | Some (',' | '.' | ';' | ':' | '?' | '!') -> true
-          | _ -> false
-        in
-        let cnt =
-          let rec loop c = function
-            | [] -> c
-            | a :: b :: rest -> (
-                match (a.kind, b.kind, b.ch) with
-                | Space, Symbol, ch when is_punct ch -> loop (c + 1) (b :: rest)
-                | _ -> loop c (b :: rest))
-            | _ -> c
-          in
-          loop 0 toks
-        in
-        if cnt > 0 then
-          let fix = mk_fix_edits s in
-          if fix = [] then
-            Some (mk_result ~id:"TYPO-010" ~severity:Info ~message ~count:cnt)
-          else
-            Some
-              (mk_result_with_fix ~id:"TYPO-010" ~severity:Info ~message
-                 ~count:cnt ~fix)
-        else None
-    | _ ->
-        let combos = [ " ,"; " ."; " ;"; " :"; " ?"; " !" ] in
-        let cnt =
-          List.fold_left (fun acc sub -> acc + count_substring s sub) 0 combos
-        in
-        if cnt > 0 then
-          let fix = mk_fix_edits s in
-          if fix = [] then
-            Some (mk_result ~id:"TYPO-010" ~severity:Info ~message ~count:cnt)
-          else
-            Some
-              (mk_result_with_fix ~id:"TYPO-010" ~severity:Info ~message
-                 ~count:cnt ~fix)
-        else None
+    let exempt = find_exempt_ranges s in
+    let combos = [ " ,"; " ."; " ;"; " :"; " ?"; " !" ] in
+    let cnt =
+      List.fold_left (fun acc sub -> acc + count_in_text exempt s sub) 0 combos
+    in
+    if cnt > 0 then
+      let fix = mk_fix_edits exempt s in
+      if fix = [] then
+        Some (mk_result ~id:"TYPO-010" ~severity:Info ~message ~count:cnt)
+      else
+        Some
+          (mk_result_with_fix ~id:"TYPO-010" ~severity:Info ~message ~count:cnt
+             ~fix)
+    else None
   in
   { id = "TYPO-010"; run; languages = [] }
 
@@ -1363,10 +1351,14 @@ let r_typo_032 : rule =
    "et.al" with "et al.". *)
 let r_typo_033 : rule =
   let message = "Abbreviation et.al without space" in
+  (* P3 context-aware (token-aware variant): count + fix skip the exempt set
+     (verbatim / comments / math / url) so `et.al` inside a code listing or
+     comment is not flagged. *)
   let run s =
-    let cnt = count_substring s "et.al" in
+    let exempt = find_exempt_ranges s in
+    let cnt = count_in_text exempt s "et.al" in
     if cnt > 0 then
-      let fix = mk_replace_edits s "et.al" "et al." in
+      let fix = mk_replace_edits_exempt exempt s "et.al" "et al." in
       if fix = [] then
         Some (mk_result ~id:"TYPO-033" ~severity:Warning ~message ~count:cnt)
       else
@@ -1514,10 +1506,14 @@ let r_typo_036 : rule =
 (* Space before comma. v26.3 §3 item E: fix replaces " ," with ",". *)
 let r_typo_037 : rule =
   let message = "Space before comma" in
+  (* P3 context-aware (token-aware variant): count + fix skip the exempt set
+     (verbatim / comments / math / url). Same `<space>,` target as TYPO-010's
+     comma branch; both made context-aware together this batch. *)
   let run s =
-    let cnt = count_substring s " ," in
+    let exempt = find_exempt_ranges s in
+    let cnt = count_in_text exempt s " ," in
     if cnt > 0 then
-      let fix = mk_replace_edits s " ," "," in
+      let fix = mk_replace_edits_exempt exempt s " ," "," in
       if fix = [] then
         Some (mk_result ~id:"TYPO-037" ~severity:Info ~message ~count:cnt)
       else

--- a/latex-parse/src/validators_l0_typo.ml
+++ b/latex-parse/src/validators_l0_typo.ml
@@ -245,13 +245,13 @@ let r_typo_004 : rule =
      `messages` CI gate would mis-pair TYPO-003 with TYPO-004's message string
      (per feedback_silent_gate_failures memo). *)
   (* P3 context-aware (token-aware variant): both count and fix now skip the
-     full exempt set (verbatim / comments / math / url) via [find_exempt_ranges],
-     superseding the v27.0.6 math-only [find_math_ranges] filter. Counting only
-     non-exempt occurrences makes the rule fully SILENT in protected regions —
-     the post-pilot-gate property for promotion — rather than the former
-     "fires count, no fix" behaviour that still surfaced a Warning inside math.
-     `` and '' inside math/verbatim are literal (e.g. `$f''(x)$` double-prime),
-     so they are neither reported nor fixed. *)
+     full exempt set (verbatim / comments / math / url) via
+     [find_exempt_ranges], superseding the v27.0.6 math-only [find_math_ranges]
+     filter. Counting only non-exempt occurrences makes the rule fully SILENT in
+     protected regions — the post-pilot-gate property for promotion — rather
+     than the former "fires count, no fix" behaviour that still surfaced a
+     Warning inside math. `` and '' inside math/verbatim are literal (e.g.
+     `$f''(x)$` double-prime), so they are neither reported nor fixed. *)
   let mk_fix_edits exempt s =
     let bt_offsets = occurrences_in_text exempt s "``" in
     let ap_offsets = occurrences_in_text exempt s "''" in
@@ -559,8 +559,8 @@ let r_typo_010 : rule =
      set (verbatim / comments / math / url) via [find_exempt_ranges], replacing
      the former string-level `count_substring` default branch and the
      `L0_TOKEN_AWARE` Tokenizer_lite branch (which had no comment/verbatim
-     kinds). Count still tallies all 6 punct chars (` ,` ` .` ` ;` ` :` ` ?`
-     ` !`); the fix-set still excludes `;`/`:` (delegated to SPC-016/SPC-021,
+     kinds). Count still tallies all 6 punct chars (` ,` ` .` ` ;` ` :` ` ?` `
+     !`); the fix-set still excludes `;`/`:` (delegated to SPC-016/SPC-021,
      v27.0.60), and now additionally skips any space-before-punct inside a
      protected region. *)
   let punct_chars = [ ','; '.'; '?'; '!' ] in


### PR DESCRIPTION
## What

P3 Phase 2, batch 1. Retrofits **TYPO-003, -004, -005, -010, -033, -037** onto the context-exemption layer landed in #423, so each rule's **count and fix both derive from exempt-filtered offsets** (`find_exempt_ranges` = verbatim / comments / math / url). The rules are now fully **silent inside protected regions** instead of false-positiving there — the post-pilot-gate property required before a Draft pilot rule can graduate to the default set.

## Why

The pilot TYPO rules are spec-defined best practices but were string-level / context-blind (firing inside `\verb`, verbatim envs, `%` comments, `$math$`). Making them context-aware is the prerequisite (RULES_PILOT_TODO "FP review") for promotion. #423 built the layer + proved it on TYPO-002; this batch extends it.

## Per-rule

- **TYPO-003** (`---`→em-dash): drop the string-level `count_substring` branch and the incomplete `L0_TOKEN_AWARE` Tokenizer_lite branch (no comment/verbatim kinds). Count via `count_in_text` (overlap semantics preserved → TYPO-002⇄003 conflict tie-break unchanged), fix via `occurrences_in_text`. Mirrors TYPO-002.
- **TYPO-004** (``` ``..'' ```→curly): replace the v27.0.6 math-only filter with the full exempt set for **both** count and fix. The former "fires count, no fix" inside math was itself an FP and is removed — `$f''(x)$` double-prime is now neither reported nor fixed.
- **TYPO-005** (`...`→`\dots`): count moves from `strip_math_segments` to `count_in_text` (equivalent on math, additionally skips verbatim/comment/url).
- **TYPO-010** (space before punct): exempt-aware count + byte-scan fix; drop Tokenizer_lite branch. `;`/`:` delegation to SPC-016/021 kept.
- **TYPO-033** (`et.al`) and **TYPO-037** (space before comma): exempt-aware via new helper `mk_replace_edits_exempt`.

## Tests / verification

- `test_context_exemption`: +6 rows → **35 cases** (each rule fires on prose, silent in inline-verbatim / verbatim-env / comment / math). Updated the now-obsolete TYPO-004 "fires count in math" test to assert silence.
- golden **355**, typo-fix **412**, validators-typo **187**, exempt-ranges **23**, full `dune runtest` green.
- `check_apply_fixes_safety.py`: **330/330** converge (no oscillation).
- `run_differential_test.py` vs **v27.0.72**: **0 diffs** (pilot-only → default lint output unchanged).
- No version bump (rules still pilot-gated; promotion is Phase 3).