### PR TITLE
fix(ci): drop broken Microsoft/Azure apt repos before apt-get update

### DIFF
--- a/.github/actions/setup-ocaml-env/action.yml
+++ b/.github/actions/setup-ocaml-env/action.yml
@@ -42,6 +42,14 @@ runs:
       if: runner.os == 'Linux'
       shell: bash
       run: |
+        # Drop third-party apt repos baked into the GitHub runner image that
+        # the project does not need (packages.microsoft.com azure-cli / prod).
+        # These intermittently 403 / lose their signing key, making a bare
+        # `apt-get update` exit 100 and kill every job that uses this action
+        # (e.g. the nightly fuzz run on 2026-06-25). Removal is safe: none of
+        # the packages below come from a Microsoft/Azure repo.
+        sudo rm -f /etc/apt/sources.list.d/microsoft* \
+                   /etc/apt/sources.list.d/*azure* 2>/dev/null || true
         sudo apt-get update
         sudo apt-get install -y \
           bubblewrap \
@@ -95,6 +103,10 @@ runs:
       if: inputs.system-packages != ''
       shell: bash
       run: |
+        # Same guard as the base system-packages step: drop the broken
+        # Microsoft/Azure apt repos before updating (see comment above).
+        sudo rm -f /etc/apt/sources.list.d/microsoft* \
+                   /etc/apt/sources.list.d/*azure* 2>/dev/null || true
         sudo apt-get update -y
         sudo apt-get install -y ${{ inputs.system-packages }}
 


### PR DESCRIPTION
## What

Harden the shared `setup-ocaml-env` composite action (used by 25+ workflows): remove the runner image's `packages.microsoft.com` (azure-cli / prod) apt sources before each `sudo apt-get update`.

## Why

Those third-party repos intermittently return **403 Forbidden** / lose their signing key on GitHub runner images. When they do, a bare `apt-get update` exits 100 and **kills the job before any project step runs**.

This took down the **2026-06-25 Nightly Fuzzing** run — failed in **16 s** in the apt step, never reached the fuzzer (the 06-24 run was a clean 9m32s) — which then auto-filed issue #426:

```
E: The repository '...azure-cli noble InRelease' is no longer signed.
E: Failed to fetch .../ubuntu/24.04/prod/dists/noble/InRelease  403  Forbidden
##[error]Process completed with exit code 100.
```

Pure runner infrastructure — not a fuzz finding or code regression. (A rerun on a healthy runner already passed, confirming it was transient; this makes it durable so it stops recurring and spamming false `bug`/`fuzz` issues.)

## Change

`sudo rm -f /etc/apt/sources.list.d/microsoft* /etc/apt/sources.list.d/*azure*` before `apt-get update`, in both the base and extra-packages steps. Safe — none of the installed packages (bubblewrap, gcc/g++-multilib, mercurial, musl-tools, rsync, opam deps) come from a Microsoft/Azure repo. YAML validated.

Closes #426.