### PR TITLE
feat(P3 Phase 2 batch 3): context-aware retrofit of 5 math-aware TYPO rules

### DIFF
--- a/latex-parse/src/test_context_exemption.ml
+++ b/latex-parse/src/test_context_exemption.ml
@@ -113,6 +113,46 @@ let cases =
         ("line comment", "% wow!! comment\n");
         ("inline math", "$n!!$");
       ] );
+    ( "TYPO-017",
+      "caf\\'{e} menu",
+      [
+        ("inline verbatim", "x \\verb|\\'{e}| y");
+        ("verbatim env", "\\begin{verbatim}\n\\'{e}\n\\end{verbatim}");
+        ("line comment", "% \\'{e} comment\n");
+        ("inline math", "math $\\'{e}$ here");
+      ] );
+    ( "TYPO-032",
+      "see ,\\cite here",
+      [
+        ("inline verbatim", "x \\verb|,\\cite| y");
+        ("verbatim env", "\\begin{verbatim}\n,\\cite\n\\end{verbatim}");
+        ("line comment", "% ,\\cite comment\n");
+        ("inline math", "$,\\cite$");
+      ] );
+    ( "TYPO-042",
+      "what?? now",
+      [
+        ("inline verbatim", "x \\verb|??| y");
+        ("verbatim env", "\\begin{verbatim}\nwhat??\n\\end{verbatim}");
+        ("line comment", "% what?? comment\n");
+        ("inline math", "$a ?? b$");
+      ] );
+    ( "TYPO-057",
+      "heat 45\xc2\xb0C now",
+      [
+        ("inline verbatim", "x \\verb|45\xc2\xb0| y");
+        ("verbatim env", "\\begin{verbatim}\n45\xc2\xb0\n\\end{verbatim}");
+        ("line comment", "% 45\xc2\xb0 comment\n");
+        ("inline math", "$45\xc2\xb0$");
+      ] );
+    ( "TYPO-061",
+      "width 3 \xc3\x97 4 cm",
+      [
+        ("inline verbatim", "x \\verb|\xc3\x97| y");
+        ("verbatim env", "\\begin{verbatim}\n\xc3\x97\n\\end{verbatim}");
+        ("line comment", "% \xc3\x97 comment\n");
+        ("inline math", "$a \xc3\x97 b$");
+      ] );
   ]
 
 let () =

--- a/latex-parse/src/test_typo_fix.ml
+++ b/latex-parse/src/test_typo_fix.ml
@@ -933,10 +933,10 @@ let () =
         (tag ^ ": one question mark, no fire"));
 
   run "TYPO-042 fix: skips ?? inside $..$ math (audit-aware)" (fun tag ->
-      (* `??` inside math is unusual but math-aware filtering keeps the producer
-         consistent with v27.0.6+ producers. The fix offset is suppressed; the
-         count still reflects the match (no math filter on count, by design —
-         see comment on r_typo_042 for the 0-differential rationale). *)
+      (* `??` inside math is unusual but the P3 context-aware retrofit skips it
+         in BOTH count and fix (exempt set = verbatim / comments / math / url),
+         so the math `??` here is neither counted nor collapsed; only the plain
+         `??` is. This test asserts the fix (edits = 1). *)
       let src = "math $a ?? b$ then plain ?? end" in
       let edits = fix_edits "TYPO-042" src in
       let out = apply_all src edits in

--- a/latex-parse/src/validators_l0_typo.ml
+++ b/latex-parse/src/validators_l0_typo.ml
@@ -822,10 +822,6 @@ let r_typo_017 : rule =
     in
     loop 0 []
   in
-  let fix_offsets s =
-    let math = find_math_ranges s in
-    List.filter (fun pos -> not (is_in_math_range math pos)) (collect_offsets s)
-  in
   let mk_fix_edits s offsets =
     List.map
       (fun pos ->
@@ -835,10 +831,20 @@ let r_typo_017 : rule =
           (Printf.sprintf "\\%c%c" accent letter))
       offsets
   in
+  (* P3 context-aware (token-aware variant): count + fix both derive from the
+     accent-command matches OUTSIDE the exempt set (verbatim / comments / math /
+     url), superseding the v27.0.18 math-only filter. A literal `\'{e}` inside a
+     verbatim listing or comment is left untouched and not reported. *)
   let run s =
-    let cnt = List.length (collect_offsets s) in
+    let exempt = find_exempt_ranges s in
+    let offsets =
+      List.filter
+        (fun pos -> not (is_in_exempt_range exempt pos))
+        (collect_offsets s)
+    in
+    let cnt = List.length offsets in
     if cnt > 0 then
-      let fix = mk_fix_edits s (fix_offsets s) in
+      let fix = mk_fix_edits s offsets in
       if fix = [] then
         Some
           (mk_result ~id:"TYPO-017" ~severity:Info
@@ -1363,19 +1369,24 @@ let r_typo_032 : rule =
     in
     loop 0 []
   in
-  let fix_offsets s =
-    let math = find_math_ranges s in
-    List.filter (fun pos -> not (is_in_math_range math pos)) (collect_offsets s)
-  in
   let mk_fix_edits offsets =
     List.map
       (fun pos -> Cst_edit.replace ~start_offset:pos ~end_offset:(pos + 1) "")
       offsets
   in
+  (* P3 context-aware (token-aware variant): count + fix both derive from the
+     comma-before-\cite matches OUTSIDE the exempt set (verbatim / comments /
+     math / url), superseding the v27.0.14 math-only filter. *)
   let run s =
-    let cnt = List.length (collect_offsets s) in
+    let exempt = find_exempt_ranges s in
+    let offsets =
+      List.filter
+        (fun pos -> not (is_in_exempt_range exempt pos))
+        (collect_offsets s)
+    in
+    let cnt = List.length offsets in
     if cnt > 0 then
-      let fix = mk_fix_edits (fix_offsets s) in
+      let fix = mk_fix_edits offsets in
       Some
         (mk_result_with_fix ~id:"TYPO-032" ~severity:Warning
            ~message:"Comma before \\cite" ~count:cnt ~fix)
@@ -1675,14 +1686,20 @@ let r_typo_041 : rule =
    (overlapping semantics) so the differential output vs v27.0.14 is unchanged
    for non-math input. *)
 let r_typo_042 : rule =
+  (* P3 context-aware (token-aware variant): count + fix both skip the exempt
+     set (verbatim / comments / math / url) via [find_exempt_ranges]. This
+     supersedes the earlier "math filter on fix offsets only; count tallies
+     everywhere" design — counting only non-exempt occurrences makes the rule
+     fully silent in protected regions. *)
   let run s =
-    let cnt = count_substring s "??" in
+    let exempt = find_exempt_ranges s in
+    let cnt = count_in_text exempt s "??" in
     if cnt > 0 then
-      let math = find_math_ranges s in
       let runs = find_consecutive_runs s '?' ~min_len:2 in
       let fix_runs =
         List.filter
-          (fun (start_offset, _) -> not (is_in_math_range math start_offset))
+          (fun (start_offset, _) ->
+            not (is_in_exempt_range exempt start_offset))
           runs
       in
       let fix =
@@ -2086,12 +2103,19 @@ let r_typo_055 : rule =
    after the matched digit), so the thin space is inserted there. *)
 let r_typo_057 : rule =
   let re = Re_compat.regexp "[0-9]\xc2\xb0" in
+  (* P3 context-aware (token-aware variant): skip digit+degree matches inside
+     the exempt set (verbatim / comments / math / url) so a literal `25°C` in a
+     code listing or comment, or a degree in math, is neither counted nor
+     fixed. *)
   let run s =
+    let exempt = find_exempt_ranges s in
     let rec loop i cnt offs =
       try
         let _mr, _ = Re_compat.search_forward re s i in
         let mbeg = Re_compat.match_beginning _mr in
-        loop (Re_compat.match_end _mr) (cnt + 1) (mbeg :: offs)
+        let mend = Re_compat.match_end _mr in
+        if is_in_exempt_range exempt mbeg then loop mend cnt offs
+        else loop mend (cnt + 1) (mbeg :: offs)
       with Not_found -> (cnt, List.rev offs)
     in
     let cnt, offs = loop 0 0 [] in
@@ -2120,20 +2144,21 @@ let r_typo_057 : rule =
    Severity Info preserved. *)
 let r_typo_061 : rule =
   let needle = "\xc3\x97" in
-  let mk_fix_edits s =
-    let math = find_math_ranges s in
-    let outside off = not (is_in_math_range math off) in
-    let offsets = List.filter outside (find_all_non_overlapping s needle) in
+  (* P3 context-aware (token-aware variant): count moves from
+     [strip_math_segments] to [count_in_text exempt] (equivalent on math, also
+     skips verbatim / comments / url); fix offsets come from the same exempt
+     set. A literal `×` inside a code listing is left untouched. *)
+  let mk_fix_edits exempt s =
     List.map
       (fun off ->
         Cst_edit.replace ~start_offset:off ~end_offset:(off + 2) "$\\times$")
-      offsets
+      (occurrences_in_text exempt s needle)
   in
   let run s =
-    let stripped = strip_math_segments s in
-    let cnt = count_substring stripped needle in
+    let exempt = find_exempt_ranges s in
+    let cnt = count_in_text exempt s needle in
     if cnt > 0 then
-      let fix = mk_fix_edits s in
+      let fix = mk_fix_edits exempt s in
       if fix = [] then
         Some
           (mk_result ~id:"TYPO-061" ~severity:Info


### PR DESCRIPTION
## What

P3 Phase 2, batch 3. Retrofits **TYPO-017, -032, -042, -057, -061** onto the context-exemption layer (`find_exempt_ranges` = verbatim / comments / math / url), so each rule's **count and fix both skip protected regions** — fully silent there, the post-pilot-gate property for promotion. Follows #424 (batch 1) and #425 (batch 2).

## Theme

These are the "act outside math" producers that already filtered by `find_math_ranges` / `strip_math_segments`. Swapping to `find_exempt_ranges` is a **strict superset** (math ⊂ exempt) that adds verbatim/comment/url coverage. Where the count formerly tallied everywhere and only the fix was math-filtered (TYPO-017/032/042), the **count is now exempt-filtered too**, so a no-fix Warning no longer surfaces inside a protected region.

## Per-rule

- **TYPO-017** (`\'{e}`→`\'e`): count + fix from accent matches outside the exempt set (was count-everywhere/fix-math-only).
- **TYPO-032** (comma before `\cite`): same; thin-space-comma guard kept.
- **TYPO-042** (`??`→`?`): exempt-aware count + run filter (mirrors TYPO-027). Updated the stale "no math filter on count, by design" test comment.
- **TYPO-057** (thin space before °C/°F): **adds** exempt-awareness — it had **no** context filter before, so it now skips degrees in verbatim/comment/math instead of firing everywhere.
- **TYPO-061** (`×`→`$\times$`): count `strip_math_segments` → `count_in_text exempt`; fix from `occurrences_in_text` (mirrors TYPO-005).

## Excluded

**TYPO-012** is the *inverse* rule (fixes `5'`→`5^\prime` **inside** math). `find_exempt_ranges` exempts math, which would wrongly suppress its target region. It needs a verbatim/comment/url-only exemption — deferred to a later batch.

## Verification

- `test_context_exemption`: +5 rows → **85 cases** (each rule fires on prose, silent in inline-verbatim / verbatim-env / comment / math).
- No existing test asserted a count-in-math value for these rules, so none broke (the math-skip tests assert *edits* only).
- golden **355**, typo-fix **412**, validators-typo **187**, exempt-ranges **23**, full `dune runtest` green.
- `check_apply_fixes_safety.py`: **330/330** converge.
- `run_differential_test.py` vs **v27.0.72**: **0 diffs** (pilot-only → default lint unchanged).
- `dune fmt` clean. No version bump (still pilot-gated).