### PR TITLE
feat(P3 Phase 2 batch 5): context-aware retrofit of 5 more TYPO rules

### DIFF
--- a/latex-parse/src/test_context_exemption.ml
+++ b/latex-parse/src/test_context_exemption.ml
@@ -193,6 +193,48 @@ let cases =
         ("line comment", "% \xe2\x8b\xaf z\n");
         ("inline math", "$a \xe2\x8b\xaf z$");
       ] );
+    (* TYPO-009 fires only on a `~` at the START of a line, which can only sit
+       inside a protected region in a multi-line environment (verbatim env or
+       display math) — inline verbatim / line comment cannot host a line-start
+       `~`, so this rule uses a custom 2-context list. *)
+    ( "TYPO-009",
+      "~text at line start",
+      [
+        ("verbatim env", "\\begin{verbatim}\n~code line\n\\end{verbatim}");
+        ("display math", "\\[\n~x = 1\n\\]");
+      ] );
+    ( "TYPO-016",
+      "see \\cite{x} here",
+      [
+        ("inline verbatim", "x \\verb| \\cite{a}| y");
+        ("verbatim env", "\\begin{verbatim}\n \\cite{a}\n\\end{verbatim}");
+        ("line comment", "% see \\cite{a} here\n");
+        ("inline math", "$a \\cite{x} b$");
+      ] );
+    ( "TYPO-018",
+      "a  b here",
+      [
+        ("inline verbatim", "x \\verb|a  b| y");
+        ("verbatim env", "\\begin{verbatim}\na  b\n\\end{verbatim}");
+        ("line comment", "% a  b comment\n");
+        ("inline math", "$a  b$");
+      ] );
+    ( "TYPO-021",
+      "wait...And then",
+      [
+        ("inline verbatim", "x \\verb|...A| y");
+        ("verbatim env", "\\begin{verbatim}\n...A\n\\end{verbatim}");
+        ("line comment", "% ...A comment\n");
+        ("inline math", "$...A$");
+      ] );
+    ( "TYPO-055",
+      "a\\,\\,b here",
+      [
+        ("inline verbatim", "x \\verb|\\,\\,| y");
+        ("verbatim env", "\\begin{verbatim}\n\\,\\,\n\\end{verbatim}");
+        ("line comment", "% \\,\\, comment\n");
+        ("inline math", "$\\,\\,$");
+      ] );
   ]
 
 let () =

--- a/latex-parse/src/validators_l0_typo.ml
+++ b/latex-parse/src/validators_l0_typo.ml
@@ -518,23 +518,35 @@ let r_typo_008 : rule =
   { id = "TYPO-008"; run; languages = [] }
 
 let r_typo_009 : rule =
+  (* P3 context-aware (token-aware variant): count + fix skip line-start `~`
+     positions inside the exempt set (verbatim / comments / math / url) — a `~`
+     at the start of a verbatim line is a literal tilde, not a misused
+     non-breaking space. Count and edits are derived together so they stay
+     consistent. *)
   let run s =
     let n = String.length s in
-    let starts = if n > 0 && String.unsafe_get s 0 = '~' then 1 else 0 in
-    let cnt = starts + count_substring s "\n~" in
-    if cnt > 0 then (
-      let edits = ref [] in
-      if starts = 1 then
-        edits := Cst_edit.replace ~start_offset:0 ~end_offset:1 "" :: !edits;
-      let i = ref 0 in
-      while !i < n - 1 do
-        if String.unsafe_get s !i = '\n' && String.unsafe_get s (!i + 1) = '~'
-        then
-          edits :=
-            Cst_edit.replace ~start_offset:(!i + 1) ~end_offset:(!i + 2) ""
-            :: !edits;
-        incr i
-      done;
+    let exempt = find_exempt_ranges s in
+    let edits = ref [] in
+    let cnt = ref 0 in
+    if n > 0 && String.unsafe_get s 0 = '~' && not (is_in_exempt_range exempt 0)
+    then (
+      incr cnt;
+      edits := Cst_edit.replace ~start_offset:0 ~end_offset:1 "" :: !edits);
+    let i = ref 0 in
+    while !i < n - 1 do
+      if
+        String.unsafe_get s !i = '\n'
+        && String.unsafe_get s (!i + 1) = '~'
+        && not (is_in_exempt_range exempt (!i + 1))
+      then (
+        incr cnt;
+        edits :=
+          Cst_edit.replace ~start_offset:(!i + 1) ~end_offset:(!i + 2) ""
+          :: !edits);
+      incr i
+    done;
+    let cnt = !cnt in
+    if cnt > 0 then
       let fix = List.rev !edits in
       if fix = [] then
         Some
@@ -545,7 +557,7 @@ let r_typo_009 : rule =
         Some
           (mk_result_with_fix ~id:"TYPO-009" ~severity:Warning
              ~message:"Non‑breaking space ~ used incorrectly at line start"
-             ~count:cnt ~fix))
+             ~count:cnt ~fix)
     else None
   in
   { id = "TYPO-009"; run; languages = [] }
@@ -769,7 +781,11 @@ let r_typo_015 : rule =
 (* TYPO-016: Non-breaking space ~ missing before \cite / \ref *)
 let r_typo_016 : rule =
   let re = Re_compat.regexp {| \\\(cite\|ref\)[^a-zA-Z]|} in
+  (* P3 context-aware (token-aware variant): count + fix skip matches whose
+     leading space is inside the exempt set (verbatim / comments / math / url),
+     so a ` \cite`/` \ref` in a code listing or comment is not rewritten. *)
   let run s =
+    let exempt = find_exempt_ranges s in
     let cnt = ref 0 in
     let edits = ref [] in
     let i = ref 0 in
@@ -778,10 +794,13 @@ let r_typo_016 : rule =
          let _mr, _ = Re_compat.search_forward re s !i in
          let mb = Re_compat.match_beginning _mr in
          (* Match shape: " \cite[^a-zA-Z]" or " \ref[^a-zA-Z]". The leading
-            space is at offset mb. Replace the space with `~`. *)
-         edits :=
-           Cst_edit.replace ~start_offset:mb ~end_offset:(mb + 1) "~" :: !edits;
-         incr cnt;
+            space is at offset mb. Replace the space with `~` (unless
+            exempt). *)
+         if not (is_in_exempt_range exempt mb) then (
+           edits :=
+             Cst_edit.replace ~start_offset:mb ~end_offset:(mb + 1) "~"
+             :: !edits;
+           incr cnt);
          i := Re_compat.match_end _mr
        done
      with Not_found -> ());
@@ -863,10 +882,18 @@ let r_typo_017 : rule =
    item E: fix collapses each maximal run of >= 2 spaces to a single space. *)
 let r_typo_018 : rule =
   let message = "Multiple consecutive spaces in text" in
+  (* P3 context-aware (token-aware variant): count + fix skip the exempt set
+     (verbatim / comments / math / url). Crucial for verbatim/lstlisting, where
+     runs of spaces are significant (code indentation/alignment) and must not be
+     collapsed; math whitespace is insignificant and comments are cosmetic. *)
   let run s =
-    let cnt = count_substring s "  " in
+    let exempt = find_exempt_ranges s in
+    let cnt = count_in_text exempt s "  " in
     if cnt > 0 then
-      let runs = find_consecutive_runs s ' ' ~min_len:2 in
+      let runs =
+        find_consecutive_runs s ' ' ~min_len:2
+        |> List.filter (fun (st, _) -> not (is_in_exempt_range exempt st))
+      in
       let fix =
         List.map
           (fun (start_offset, end_offset) ->
@@ -906,19 +933,25 @@ let r_typo_020 : rule =
    `...A` and `…A` (Unicode ellipsis U+2026) get the same insertion. *)
 let r_typo_021 : rule =
   let re = Re_compat.regexp {|\(\.\.\.\|…\)[A-Z]|} in
+  (* P3 context-aware (token-aware variant): count + fix skip matches whose
+     ellipsis is inside the exempt set (verbatim / comments / math / url). *)
   let run s =
+    let exempt = find_exempt_ranges s in
     let cnt = ref 0 in
     let edits = ref [] in
     let i = ref 0 in
     (try
        while true do
          let _mr, _ = Re_compat.search_forward re s !i in
+         let mb = Re_compat.match_beginning _mr in
          let me = Re_compat.match_end _mr in
-         (* Insert a space immediately before the capital letter at me-1. *)
-         edits :=
-           Cst_edit.replace ~start_offset:(me - 1) ~end_offset:(me - 1) " "
-           :: !edits;
-         incr cnt;
+         (* Insert a space immediately before the capital letter at me-1 (unless
+            the match is inside a protected region). *)
+         if not (is_in_exempt_range exempt mb) then (
+           edits :=
+             Cst_edit.replace ~start_offset:(me - 1) ~end_offset:(me - 1) " "
+             :: !edits;
+           incr cnt);
          i := me
        done
      with Not_found -> ());
@@ -2074,10 +2107,14 @@ let r_typo_054 : rule =
    that share no bytes. *)
 let r_typo_055 : rule =
   let needle = "\\,\\," in
+  (* P3 context-aware (token-aware variant): count + fix skip the exempt set
+     (verbatim / comments / math / url) so a literal `\,\,` in a code listing is
+     left untouched. *)
   let run s =
-    let cnt = count_substring s needle in
+    let exempt = find_exempt_ranges s in
+    let cnt = count_in_text exempt s needle in
     if cnt > 0 then
-      let offsets = find_all_non_overlapping s needle in
+      let offsets = occurrences_in_text exempt s needle in
       let fix =
         List.map
           (fun off ->


### PR DESCRIPTION
## What

P3 Phase 2, batch 5. Retrofits **TYPO-009, -016, -018, -021, -055** onto the context-exemption layer (`find_exempt_ranges` = verbatim / comments / math / url), so each rule's **count and fix both skip protected regions** — fully silent there, the post-pilot-gate property for promotion. Follows #424/#425/#428/#429.

These are the remaining **"standard exempt"** producers (skip the protected region; do *not* operate on its delimiters).

## Per-rule

- **TYPO-009** (line-start `~` → delete): count + edits merged, both skip exempt line-start positions — a `~` starting a verbatim line is a literal tilde, not a misused NBSP.
- **TYPO-016** (` \cite`/` \ref` → `~`, regex): skip matches whose leading space is in the exempt set.
- **TYPO-018** (multiple spaces → single): exempt-aware count + run collapse. Critical for verbatim/lstlisting, where space runs are significant (indentation/alignment) and must **not** be collapsed.
- **TYPO-021** (capital after ellipsis → insert space, regex): skip matches whose ellipsis is in the exempt set.
- **TYPO-055** (`\,\,` → `\,`): exempt-aware count + fix.

## Deferred (not this batch)

- **TYPO-028** (`$$`→`\[\]`) and **TYPO-046** (`\begin{math}`→`$`) operate *on* the math delimiters, which `find_exempt_ranges` treats as math ranges — swapping would stop them converting their own targets. Like TYPO-012 (inverse inside-math rule), they need a **verbatim/comment/url-only** exemption; grouped for a later vcu-helper batch.
- **TYPO-035** (French NBSP before `; : ! ?`) is locale-specific (`languages=[]`) and directly conflicts with TYPO-010 (which deletes that space); not a universal-default promotion candidate.

## Verification

- `test_context_exemption`: +5 rows → **133 cases**. TYPO-009 uses a custom 2-context list (a line-start `~` can only be protected inside a multi-line verbatim env or display math).
- No obsolete count-in-math tests for these rules.
- golden **355**, typo-fix **412**, validators-typo **187**, exempt-ranges **23**, full `dune runtest` green.
- `check_apply_fixes_safety.py`: **330/330** converge.
- `run_differential_test.py` vs **v27.0.72**: **0 diffs** (pilot-only → default lint unchanged).
- `dune fmt` clean. No version bump (still pilot-gated).