### PR TITLE
feat(P3 Phase 2 batch 6): vcu-only context-awareness for delimiter rules (TYPO-012/028/046)

### DIFF
--- a/latex-parse/src/test_context_exemption.ml
+++ b/latex-parse/src/test_context_exemption.ml
@@ -235,6 +235,33 @@ let cases =
         ("line comment", "% \\,\\, comment\n");
         ("inline math", "$\\,\\,$");
       ] );
+    (* TYPO-012/028/046 are the "vcu-only" rules: math is their OPERATING domain
+       (TYPO-012 fixes `5'`→`5^\prime` inside math; TYPO-028/046 rewrite the
+       `$$` / `\begin{math}` delimiters themselves), so they must NOT be exempt
+       in math — only in verbatim / comments / url. Hence a custom 3-context
+       list with no inline-math row. *)
+    ( "TYPO-012",
+      "the 6' board",
+      [
+        ("inline verbatim", "x \\verb|6'| y");
+        ("verbatim env", "\\begin{verbatim}\n6'\n\\end{verbatim}");
+        ("line comment", "% 6' here\n");
+      ] );
+    ( "TYPO-028",
+      "display $$x$$ here",
+      [
+        ("inline verbatim", "x \\verb|$$x$$| y");
+        ("verbatim env", "\\begin{verbatim}\n$$x$$\n\\end{verbatim}");
+        ("line comment", "% $$x$$ here\n");
+      ] );
+    ( "TYPO-046",
+      "math \\begin{math}x\\end{math} here",
+      [
+        ("inline verbatim", "x \\verb|\\begin{math}| y");
+        ( "verbatim env",
+          "\\begin{verbatim}\n\\begin{math}x\\end{math}\n\\end{verbatim}" );
+        ("line comment", "% \\begin{math}x\\end{math}\n");
+      ] );
   ]
 
 let () =

--- a/latex-parse/src/validators_l0_typo.ml
+++ b/latex-parse/src/validators_l0_typo.ml
@@ -669,10 +669,6 @@ let r_typo_012 : rule =
     in
     loop 0 []
   in
-  let fix_offsets s =
-    let math = find_math_ranges s in
-    List.filter (fun pos -> is_in_math_range math pos) (collect_offsets s)
-  in
   let mk_fix_edits offsets =
     List.map
       (fun pos ->
@@ -681,10 +677,27 @@ let r_typo_012 : rule =
           "^\\prime")
       offsets
   in
+  (* P3 context-aware (token-aware variant). TYPO-012 is an INVERSE rule: it
+     fixes `5'` → `5^\prime` only INSIDE math (outside math the apostrophe is
+     ambiguous, so it warns but does not auto-fix). It therefore needs a
+     verbatim/comment/url-only exemption, NOT the full exempt set (which would
+     suppress its math target). We derive "in math, not in vcu" as
+     [is_in_exempt_range exempt] (= vcu ∪ vcu-aware math) AND NOT
+     [is_in_exempt_range vcu]. Because [find_exempt_ranges] computes math on a
+     vcu-blanked copy, this also closes a latent bug where a stray `$` inside a
+     `\verb` listing made the raw [find_math_ranges] mis-pair `5'` as in-math
+     and corrupt the verbatim. Count skips vcu (a `5'` in a code listing is
+     literal) but still includes ordinary prose (the intended ambiguity
+     warning); the fix applies only in-math-not-vcu. *)
   let run s =
-    let cnt = List.length (collect_offsets s) in
+    let exempt = find_exempt_ranges s in
+    let vcu = find_verbatim_comment_url_ranges s in
+    let in_vcu off = is_in_exempt_range vcu off in
+    let in_math_only off = is_in_exempt_range exempt off && not (in_vcu off) in
+    let all = collect_offsets s in
+    let cnt = List.length (List.filter (fun off -> not (in_vcu off)) all) in
     if cnt > 0 then
-      let fix = mk_fix_edits (fix_offsets s) in
+      let fix = mk_fix_edits (List.filter in_math_only all) in
       if fix = [] then
         Some
           (mk_result ~id:"TYPO-012" ~severity:Warning
@@ -1274,10 +1287,21 @@ let r_typo_028 : rule =
       (find_all_non_overlapping s needle)
   in
   let rec pairs = function a :: b :: rest -> (a, b) :: pairs rest | _ -> [] in
+  (* P3 context-aware (token-aware variant): this rule operates ON the `$$`
+     delimiters, so it needs a verbatim/comment/url-only exemption — NOT the
+     full exempt set (which treats `$$…$$` as a math range and would suppress
+     the rule's own target). A `$$` inside a `\verb`/`lstlisting` listing or a
+     comment is literal and must not be counted or rewritten. *)
   let run s =
-    let cnt = count_substring s needle / 2 in
+    let vcu = find_verbatim_comment_url_ranges s in
+    let cnt = count_in_text vcu s needle / 2 in
     if cnt > 0 then
-      let pair_offsets = pairs (unescaped_offsets s) in
+      let non_vcu_offsets =
+        List.filter
+          (fun off -> not (is_in_exempt_range vcu off))
+          (unescaped_offsets s)
+      in
+      let pair_offsets = pairs non_vcu_offsets in
       let fix =
         List.concat_map
           (fun (open_off, close_off) ->
@@ -2379,9 +2403,21 @@ let r_typo_046 : rule =
       (fun off -> not (is_escaped_command s off))
       (find_all_non_overlapping s needle)
   in
+  (* P3 context-aware (token-aware variant): this rule operates ON the
+     `\begin{math}` / `\end{math}` delimiters, so (like TYPO-028) it needs a
+     verbatim/comment/url-only exemption — NOT the full exempt set, which treats
+     the math env as a range and would suppress the rule's own target. A
+     `\begin{math}` shown literally in a code listing or comment must not be
+     counted or rewritten. *)
   let run s =
-    let begin_offsets = collect_unescaped s begin_needle in
-    let end_offsets = collect_unescaped s end_needle in
+    let vcu = find_verbatim_comment_url_ranges s in
+    let collect needle =
+      List.filter
+        (fun off -> not (is_in_exempt_range vcu off))
+        (collect_unescaped s needle)
+    in
+    let begin_offsets = collect begin_needle in
+    let end_offsets = collect end_needle in
     let cnt = List.length begin_offsets + List.length end_offsets in
     if cnt > 0 then (
       (* Round-1 ultrathink audit: detect adjacent begin/end pairs (empty math


### PR DESCRIPTION
## What

P3 Phase 2, batch 6 — the **"vcu-only" group**: TYPO-012, -028, -046. Follows #424/#425/#428/#429/#430.

Unlike previous batches, these rules **operate on math** rather than skipping it:
- **TYPO-012** fixes `5'`→`5^\prime` *inside* math (inverse rule),
- **TYPO-028** rewrites the `$$` display-math delimiters,
- **TYPO-046** rewrites the `\begin{math}` delimiters.

So `find_exempt_ranges` (which includes math) would suppress their own target. They instead use a **verbatim/comment/url-only** exemption via `find_verbatim_comment_url_ranges` — correct in math, silent in code listings / comments.

## Per-rule

- **TYPO-012** (inverse): "in math" is now `is_in_exempt_range(exempt) AND NOT is_in_exempt_range(vcu)`. Since `find_exempt_ranges` computes math on a vcu-**blanked** copy, this also **closes a latent corruption bug** — previously the raw `find_math_ranges` mis-paired a stray `$` inside `\verb` and rewrote the verbatim `5'`. Verified end-to-end:

  ```
  in:  Code: \verb|$5'$| and math $7'$ end.
  out: Code: \verb|$5'$| and math $7^\prime$ end.
  ```

  Count skips vcu but still warns on ambiguous prose `5'`; fix applies only in-math-not-vcu.
- **TYPO-028** (`$$`→`\[\]`): count + paired-fix offsets skip `$$` inside vcu.
- **TYPO-046** (`\begin{math}`→`$`): begin/end delimiter offsets skip vcu.

## Verification

- `test_context_exemption`: +3 rows → **145 cases**, each with a custom 3-context list (inline verbatim / verbatim env / line comment) and **no inline-math row** — math is these rules' operating domain, not an exempt region.
- All existing TYPO-012/028/046 tests preserved (none placed the target in verbatim).
- golden **355**, typo-fix **412**, validators-typo **187**, full `dune runtest` green.
- `check_apply_fixes_safety.py`: **330/330** converge.
- `run_differential_test.py` vs **v27.0.72**: **0 diffs**.
- `dune fmt` clean. No version bump (still pilot-gated).