### PR TITLE
feat(v27.1.0 / P3 Phase 3): promote 30 context-aware TYPO rules to the default set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,36 @@
 
 All notable changes to LaTeX Perfectionist are documented here.
 
+## [v27.1.0] — 2026-06-27
+
+**P3 Phase 3 — 30 context-aware TYPO rules promoted from the pilot set to the
+DEFAULT rule set.** This is the first behaviour-changing release of the P3
+workstream: rules that previously fired only under `L0_VALIDATORS=pilot` now
+fire in the default lint path.
+
+Over P3 Phase 2 (batches 1–6, PRs #424/#425/#428/#429/#430/#431) these 30 rules
+were made **context-aware**: their count *and* fix both skip protected regions
+(verbatim / comments / math / url) via `find_exempt_ranges` — or, for the
+delimiter rules TYPO-012/028/046, the verbatim/comment/url-only subset — so they
+no longer false-positive in code listings, comments, or math. That cleared the
+post-pilot gate (FP review + perf smoke), so the rules graduate
+(`rules_v3.yaml` maturity Draft→Implemented) and are appended to the **default**
+branch of `Validators.get_rules` via the new `rules_typo_promoted` list. They
+remain in the pilot branch via `rules_pilot` / `rules_vpd_gen`, so neither
+branch double-fires.
+
+Promoted (full spec-complete set, incl. the Unicode-first dash/quote standard):
+TYPO-001, -002, -003, -004, -005, -009, -010, -012, -013, -015, -016, -017,
+-018, -021, -022, -027, -028, -032, -033, -034, -037, -038, -042, -046, -049,
+-051, -053, -055, -057, -061.
+
+No new fix producers (**101** unchanged — promotion changes *when* these
+already-counted rules fire, not *whether* they produce fixes). All 330 lint
+corpus files converge to a fixpoint under default `--apply-fixes` (no
+oscillation). Full `dune runtest` green; pilot-mode apply-fixes safety 330/330;
+all pre-release consistency gates green. The default lint output now changes
+(intended). Minor version bump (first default-behaviour feature release of v27).
+
 ## [v27.0.72] — 2026-06-18
 
 **+1 fix producer: TYPO-057** (Missing thin-space before °C/°F → insert `\,`

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ dune exec latex-parse/src/validators_cli.exe -- --layer l2 paper.tex
 | `L0_PROM_ADDR` | `127.0.0.1:9109` | Prometheus TCP bind address |
 | `L0_USE_SIMD_XXH` | unset | Set to `1` for SIMD xxHash acceleration |
 
-## Current Status — v27.0.72 (June 2026)
+## Current Status — v27.1.0 (June 2026)
 
 All layers (L0-L4) implemented. L3 file-based validators (PNG/JPEG/PDF/font). ML v2 byte classifier trained (F1=0.9799) and formally verified:
 - **Build**: `dune build` compiles the SIMD service, benches, and the Coq proof tree (55 core + 114 generated + 1 ML) via `(coq.theory)` stanzas.

--- a/docs/PROOF_GUIDE.md
+++ b/docs/PROOF_GUIDE.md
@@ -141,7 +141,7 @@ Runs on every push and PR. Cannot be bypassed.
 
 ---
 
-## Current State (v27.0.72)
+## Current State (v27.1.0)
 
 - **1,400 theorems/lemmas** across 170 files
 - **637 faithful proofs** (VPD-pattern match, exact Coq model)

--- a/dune-project
+++ b/dune-project
@@ -1,5 +1,5 @@
 (lang dune 3.10)
-(version 27.0.72)
+(version 27.1.0)
 (using coq 0.8)
 (name latex-perfectionist)
 (generate_opam_files true)

--- a/generated/project_facts.json
+++ b/generated/project_facts.json
@@ -1,7 +1,7 @@
 {
-  "version": "v27.0.72",
+  "version": "v27.1.0",
   "release_state": "rc",
-  "release_date": "2026-06-18",
+  "release_date": "2026-06-27",
   "generated_by": "scripts/tools/generate_project_facts.py",
   "rules": {
     "total_specified": 660,

--- a/governance/project_facts.yaml
+++ b/governance/project_facts.yaml
@@ -1,6 +1,6 @@
-version: v27.0.72
+version: v27.1.0
 release_state: rc
-release_date: '2026-06-18'
+release_date: '2026-06-27'
 generated_by: scripts/tools/generate_project_facts.py
 rules:
   total_specified: 660

--- a/latex-parse/src/validators.ml
+++ b/latex-parse/src/validators.ml
@@ -210,7 +210,12 @@ let get_rules () : rule list =
     match Sys.getenv_opt "L0_VALIDATORS" with
     | Some ("1" | "true" | "pilot" | "PILOT") ->
         rules_pilot @ rules_vpd_gen @ rules_enc_char_spc @ rules_l1
-    | _ -> rules_basic @ rules_enc_char_spc @ rules_l1
+    | _ ->
+        (* P3 Phase 3: the 30 context-aware TYPO rules graduated from pilot to
+           the DEFAULT set ([rules_typo_promoted]). Appended to the default
+           branch only — the pilot branch already includes them via
+           [rules_pilot] / [rules_vpd_gen]. *)
+        rules_basic @ rules_enc_char_spc @ rules_l1 @ rules_typo_promoted
   in
   if not !_dag_validated then (
     _dag_validated := true;

--- a/latex-parse/src/validators_l0_typo.ml
+++ b/latex-parse/src/validators_l0_typo.ml
@@ -2662,3 +2662,47 @@ let rules_vpd_gen : rule list =
   ]
 
 (* END VPD-generated validators *)
+
+(* ── P3 Phase 3: TYPO rules promoted from the pilot set to the DEFAULT set ──
+   These 30 TYPO rules were made context-aware in P3 Phase 2 (batches 1–6):
+   their count and fix both skip protected regions (verbatim / comments / math /
+   url) via [find_exempt_ranges] — or, for the delimiter rules TYPO-012/028/
+   046, the verbatim/comment/url-only subset — so they no longer false-positive
+   in code listings, comments, or math. With that post-pilot gate cleared, they
+   graduate (rules_v3.yaml maturity Draft→Implemented) and are appended to the
+   DEFAULT branch of [Validators.get_rules]. They remain present in the pilot
+   branch via [rules_pilot] / [rules_vpd_gen]; this list is added to the DEFAULT
+   branch ONLY, so neither branch double-fires. *)
+let rules_typo_promoted : rule list =
+  [
+    r_typo_001;
+    r_typo_002;
+    r_typo_003;
+    r_typo_004;
+    r_typo_005;
+    r_typo_009;
+    r_typo_010;
+    r_typo_012;
+    r_typo_013;
+    r_typo_015;
+    r_typo_016;
+    r_typo_017;
+    r_typo_018;
+    r_typo_021;
+    r_typo_022;
+    r_typo_027;
+    r_typo_028;
+    r_typo_032;
+    r_typo_033;
+    r_typo_034;
+    r_typo_037;
+    r_typo_038;
+    r_typo_042;
+    r_typo_046;
+    r_typo_049;
+    r_typo_051;
+    r_typo_053;
+    r_typo_055;
+    r_typo_057;
+    r_typo_061;
+  ]

--- a/specs/README.md
+++ b/specs/README.md
@@ -4,7 +4,7 @@
 
 | Directory / file | Contents |
 |------------------|----------|
-| `v27/` | **Current release** (v27.0.x — currently shipping the Bucket A fix-producer cadence; latest tag `v27.0.72`): master spec (`V27_REPO_EXACT_MASTER_SPEC.{md,yaml}`), cadence + ledger (`V27_FIX_PRODUCER_CADENCE.md`, `FIX_PRODUCER_LEDGER.md`), faithful-semantics / L3-AST / apply-edits / T5 / WS8 plan docs |
+| `v27/` | **Current release** (v27.0.x — currently shipping the Bucket A fix-producer cadence; latest tag `v27.1.0`): master spec (`V27_REPO_EXACT_MASTER_SPEC.{md,yaml}`), cadence + ledger (`V27_FIX_PRODUCER_CADENCE.md`, `FIX_PRODUCER_LEDGER.md`), faithful-semantics / L3-AST / apply-edits / T5 / WS8 plan docs |
 | `v26/` | Prior release (v26.2): master spec (`V26_REPO_EXACT_MASTER_SPEC.{md,yaml}`), `language_contract.{md,yaml}`, `compilation_guarantee_stack.md`, `compilation_profiles.yaml`, `partial_document_semantics.{md,yaml}`, `V26_2_PLAN.md` |
 | `REPO_EXACT_MISSING_ARCHITECTURE_MEMO_V26_V27.md` | Authoritative architecture memo (11 pieces, v26/v27 plan) |
 | `rules/` | `rules_v3.yaml` (660 rules, 644 non-reserved, 16 reserved), `rule_contracts.yaml` / `.json` (per-rule metadata), golden YAML test fixtures |

--- a/specs/rules/README.md
+++ b/specs/rules/README.md
@@ -40,7 +40,7 @@
   - Impl: 6
   - Reserved: 16 (future families; do not implement yet)
 - Fix producers (`produces_fix: true` in `rule_contracts.yaml`): 101 as of
-  v27.0.72.  See `../v27/V27_FIX_PRODUCER_CADENCE.md` for cadence and
+  v27.1.0.  See `../v27/V27_FIX_PRODUCER_CADENCE.md` for cadence and
   `../v27/FIX_PRODUCER_LEDGER.md` for the per-rule shipping ledger.
 
 ## Implementation Guidance (When to Start)

--- a/specs/rules/rules_v3.yaml
+++ b/specs/rules/rules_v3.yaml
@@ -155,7 +155,7 @@
   description: "ASCII straight quotes (\" … \") must be curly quotes"
   precondition: L0_Lexer
   default_severity: Error
-  maturity: Draft
+  maturity: Implemented
   owner: "@lint-team"
   fix: auto_replace
 
@@ -164,7 +164,7 @@
   runtime_message: "Triple hyphen --- should be em‑dash —"
   precondition: L0_Lexer
   default_severity: Warning
-  maturity: Draft
+  maturity: Implemented
   owner: "@lint-team"
   fix: auto_replace
 
@@ -172,7 +172,7 @@
   description: "Triple hyphen --- should be em‑dash —"
   precondition: L0_Lexer
   default_severity: Warning
-  maturity: Draft
+  maturity: Implemented
   owner: "@lint-team"
   fix: auto_replace
 
@@ -180,7 +180,7 @@
   description: "TeX double back‑tick ``…'' not allowed; use opening curly quotes"
   precondition: L0_Lexer
   default_severity: Warning
-  maturity: Draft
+  maturity: Implemented
   owner: "@lint-team"
   fix: auto_replace
 
@@ -188,7 +188,7 @@
   description: "Ellipsis typed as three periods ...; use \\dots"
   precondition: L0_Lexer
   default_severity: Warning
-  maturity: Draft
+  maturity: Implemented
   owner: "@lint-team"
   fix: auto_replace
 
@@ -220,7 +220,7 @@
   description: "Non‑breaking space ~ used incorrectly at line start"
   precondition: L0_Lexer
   default_severity: Warning
-  maturity: Draft
+  maturity: Implemented
   owner: "@lint-team"
   fix: null
 
@@ -228,7 +228,7 @@
   description: "Space before punctuation , . ; : ? !"
   precondition: L0_Lexer
   default_severity: Info
-  maturity: Draft
+  maturity: Implemented
   owner: "@lint-team"
   fix: remove_space
 
@@ -244,7 +244,7 @@
   description: "Straight apostrophe ' used for minutes/feet; use ^\\prime or ′"
   precondition: L0_Lexer
   default_severity: Warning
-  maturity: Draft
+  maturity: Implemented
   owner: "@lint-team"
   fix: auto_replace
 
@@ -252,7 +252,7 @@
   description: "ASCII back‑tick ` used as opening quote"
   precondition: L0_Lexer
   default_severity: Warning
-  maturity: Draft
+  maturity: Implemented
   owner: "@lint-team"
   fix: auto_replace
 
@@ -268,7 +268,7 @@
   description: "Double \\% in source; likely stray percent"
   precondition: L0_Lexer
   default_severity: Warning
-  maturity: Draft
+  maturity: Implemented
   owner: "@lint-team"
   fix: null
 
@@ -276,7 +276,7 @@
   description: "Non‑breaking space ~ missing before \\cite / \\ref"
   precondition: L0_Lexer
   default_severity: Info
-  maturity: Draft
+  maturity: Implemented
   owner: "@lint-team"
   fix: insert_nbsp
 
@@ -284,7 +284,7 @@
   description: "TeX accent commands (\\'{e}) in text; prefer UTF‑8 é"
   precondition: L0_Lexer
   default_severity: Info
-  maturity: Draft
+  maturity: Implemented
   owner: "@lint-team"
   fix: auto_utf8
 
@@ -292,7 +292,7 @@
   description: "Multiple consecutive spaces in text"
   precondition: L0_Lexer
   default_severity: Info
-  maturity: Draft
+  maturity: Implemented
   owner: "@lint-team"
   fix: collapse_spaces
 
@@ -316,7 +316,7 @@
   description: "Capital letter after ellipsis without space"
   precondition: L0_Lexer
   default_severity: Info
-  maturity: Draft
+  maturity: Implemented
   owner: "@lint-team"
   fix: insert_space
 
@@ -324,7 +324,7 @@
   description: "Space before closing punctuation ) ] }"
   precondition: L0_Lexer
   default_severity: Info
-  maturity: Draft
+  maturity: Implemented
   owner: "@lint-team"
   fix: remove_space
 
@@ -364,7 +364,7 @@
   description: "Multiple exclamation marks ‼"
   precondition: L0_Lexer
   default_severity: Info
-  maturity: Draft
+  maturity: Implemented
   owner: "@style-council"
   fix: null
 
@@ -372,7 +372,7 @@
   description: "Use of ``$$'' display math delimiter"
   precondition: L0_Lexer
   default_severity: Error
-  maturity: Draft
+  maturity: Implemented
   owner: "@math-rules"
   fix: replace_with_equation
 
@@ -404,7 +404,7 @@
   description: "Comma before \\cite"
   precondition: L0_Lexer
   default_severity: Warning
-  maturity: Draft
+  maturity: Implemented
   owner: "@lint-team"
   fix: null
 
@@ -412,7 +412,7 @@
   description: "Abbreviation et.al without space"
   precondition: L0_Lexer
   default_severity: Warning
-  maturity: Draft
+  maturity: Implemented
   owner: "@lint-team"
   fix: insert_space
 
@@ -420,7 +420,7 @@
   description: "Spurious space before footnote command \\footnote"
   precondition: L0_Lexer
   default_severity: Info
-  maturity: Draft
+  maturity: Implemented
   owner: "@lint-team"
   fix: remove_space
 
@@ -444,7 +444,7 @@
   description: "Space before comma"
   precondition: L0_Lexer
   default_severity: Info
-  maturity: Draft
+  maturity: Implemented
   owner: "@lint-team"
   fix: remove_space
 
@@ -452,7 +452,7 @@
   description: "E‑mail address not in \\href"
   precondition: L0_Lexer
   default_severity: Info
-  maturity: Draft
+  maturity: Implemented
   owner: "@lint-team"
   fix: wrap_href
 
@@ -484,7 +484,7 @@
   description: "Multiple consecutive question marks ??"
   precondition: L0_Lexer
   default_severity: Info
-  maturity: Draft
+  maturity: Implemented
   owner: "@style-council"
   fix: null
 
@@ -516,7 +516,7 @@
   description: "Use of $begin:math:text$ … $end:math:text$ instead of $…$"
   precondition: L0_Lexer
   default_severity: Info
-  maturity: Draft
+  maturity: Implemented
   owner: "@math-rules"
   fix: null
 
@@ -540,7 +540,7 @@
   description: "Space after opening quote"
   precondition: L0_Lexer
   default_severity: Info
-  maturity: Draft
+  maturity: Implemented
   owner: "@lint-team"
   fix: remove_space
 
@@ -556,7 +556,7 @@
   description: "Figure space U+2009 used instead of \\thinspace macro"
   precondition: L0_Lexer
   default_severity: Warning
-  maturity: Draft
+  maturity: Implemented
   owner: "@lint-team"
   fix: replace_with_macro
 
@@ -572,7 +572,7 @@
   description: "Unicode ⋯ (U+22EF) leader forbidden; use \\dots instead"
   precondition: L0_Lexer
   default_severity: Warning
-  maturity: Draft
+  maturity: Implemented
   owner: "@lint-team"
   fix: auto_replace
 
@@ -588,7 +588,7 @@
   description: "Consecutive thin‑spaces (\\,\\,) prohibited; collapse"
   precondition: L0_Lexer
   default_severity: Info
-  maturity: Draft
+  maturity: Implemented
   owner: "@lint-team"
   fix: collapse_spaces
 
@@ -604,7 +604,7 @@
   description: "Missing thin‑space before °C/°F or \\si{\\celsius}"
   precondition: L0_Lexer
   default_severity: Info
-  maturity: Draft
+  maturity: Implemented
   owner: "@math-rules"
   fix: null
 
@@ -636,7 +636,7 @@
   description: "Unicode × (U+00D7) in text; prefer \\times via math mode"
   precondition: L0_Lexer
   default_severity: Info
-  maturity: Draft
+  maturity: Implemented
   owner: "@math-rules"
   fix: auto_replace
 

--- a/specs/v27/V27_FIX_PRODUCER_CADENCE.md
+++ b/specs/v27/V27_FIX_PRODUCER_CADENCE.md
@@ -1,7 +1,7 @@
 # V27_FIX_PRODUCER_CADENCE — Rolling fix-producer extension to full coverage
 
 **Goal:** Bring the catalogue of 660 lint rules from the 32 fix-producing
-rules at plan authoring (101 shipped as of v27.0.72) to full coverage where
+rules at plan authoring (101 shipped as of v27.1.0) to full coverage where
 mechanically safe, with
 explicit deferral of NLP-required and unsafe-without-context rules.
 
@@ -146,7 +146,7 @@ from `FIX_PRODUCER_LEDGER.md`, ship, update.
   v27.0.5+**; enforced every release cycle via
   `scripts/tools/run_differential_test.py`.
 - [ ] Bucket A shipped fully by v27.2.0 (target).  **IN PROGRESS** —
-  101/458 (~22%) shipped as of v27.0.72.  Original v27.2.0 target
+  101/458 (~22%) shipped as of v27.1.0.  Original v27.2.0 target
   assumed ≥10 producers/release; at the actual cadence pace this
   milestone is on track for a later release.
 - [ ] Bucket B + C shipped fully by v27.4.0 (target).  **NOT


### PR DESCRIPTION
## What

**The first behaviour-changing release of the P3 workstream.** The 30 TYPO rules made context-aware in Phase 2 (batches 1–6: #424/#425/#428/#429/#430/#431) graduate from the pilot set to the **DEFAULT** rule set — they now fire in the default lint path, not only under `L0_VALIDATORS=pilot`.

Scope confirmed as **full spec-complete** (incl. the Unicode-first dash/quote standard).

## Mechanism

- **Runtime** (`validators.ml`): default branch of `get_rules()` gains `@ rules_typo_promoted` — a new explicit 30-rule list in `validators_l0_typo.ml`. The **pilot branch is untouched** (it already includes these via `rules_pilot` / `rules_vpd_gen`), so neither branch double-fires. Tier gating (`_filter_by_tier`) keys on language-profile `project_scope`, not maturity, so list membership is what makes them fire (in LP_Core/Extended).
- **Registry/spec**: `rules_v3.yaml` maturity Draft→Implemented for the 30; `generate_project_facts` + `generate_rule_contracts` regenerated.
- **Release**: version 27.0.72→**27.1.0**; `bump_release.py` refreshed 6 prose labels; CHANGELOG v27.1.0 entry.

**Producer count unchanged at 101** — promotion changes *when* these already-counted rules fire, not *whether* they produce fixes.

## Promotion set

`TYPO-001, 002, 003, 004, 005, 009, 010, 012, 013, 015, 016, 017, 018, 021, 022, 027, 028, 032, 033, 034, 037, 038, 042, 046, 049, 051, 053, 055, 057, 061`

## Intended impact

This **changes default lint output** (the point of the release). Quantified on the lint corpus: **96 of 330 files** now produce new/changed default-mode diagnostics — every document using `--`, `---`, ``` ``..'' ```, straight quotes, `...`, etc. now gets the Unicode-first diagnostics/fixes by default.

## Verification

- TYPO rules now fire in default mode (verified via CLI).
- **Default-mode `--apply-fixes` converges to a fixpoint on all 330 lint corpus files — no oscillation.**
- Full `dune runtest` green; context-exemption 145, typo-fix 412, golden 355, validators-typo 187.
- Pilot-mode apply-fixes safety unchanged **330/330**.
- Consistency gates green: version-labels (v27.1.0 / 101 / 105 docs), fix-producer-ledger in sync, doc-refs, severity-drift, rule_contracts (660, acyclic), release-integrity (CHANGELOG coherent).

> Note: `run_differential_test.py` reports FAIL by design here — it flags *any* default-output change, and these changes are intended. It is a local tool, not a CI gate.

On merge: tag **v27.1.0**.