### PR TITLE
feat(P3 Phase 2 batch 8): context-aware retrofit of 7 diagnose-only rules

### DIFF
--- a/latex-parse/src/test_context_exemption.ml
+++ b/latex-parse/src/test_context_exemption.ml
@@ -296,6 +296,66 @@ let cases =
         ("line comment", "% note-\n");
         ("inline math", "$a-\nb$");
       ] );
+    (* Diagnose-only typography rules (count-exemption only; no fix). *)
+    ( "TYPO-041",
+      "end.\\ldots more",
+      [
+        ("inline verbatim", "x \\verb|.\\ldots| y");
+        ("verbatim env", "\\begin{verbatim}\n.\\ldots\n\\end{verbatim}");
+        ("line comment", "% .\\ldots\n");
+        ("inline math", "$.\\ldots$");
+      ] );
+    ( "TYPO-047",
+      "use \\section*{x} here",
+      [
+        ("inline verbatim", "x \\verb|\\section*| y");
+        ("verbatim env", "\\begin{verbatim}\n\\section*\n\\end{verbatim}");
+        ("line comment", "% \\section*\n");
+        ("inline math", "$\\section*$");
+      ] );
+    ( "TYPO-052",
+      "a < b > c",
+      [
+        ("inline verbatim", "x \\verb|<>| y");
+        ("verbatim env", "\\begin{verbatim}\n< >\n\\end{verbatim}");
+        ("line comment", "% < >\n");
+        ("inline math", "$a < b$");
+      ] );
+    ( "TYPO-054",
+      "see a\xe2\x80\x93b range",
+      [
+        ("inline verbatim", "x \\verb|a\xe2\x80\x93b| y");
+        ("verbatim env", "\\begin{verbatim}\na\xe2\x80\x93b\n\\end{verbatim}");
+        ("line comment", "% a\xe2\x80\x93b\n");
+        ("inline math", "$a\xe2\x80\x93b$");
+      ] );
+    ( "TYPO-056",
+      "caf\\'{e} here",
+      [
+        ("inline verbatim", "x \\verb|\\'{e}| y");
+        ("verbatim env", "\\begin{verbatim}\n\\'{e}\n\\end{verbatim}");
+        ("line comment", "% \\'{e}\n");
+        ("inline math", "$\\'{e}$");
+      ] );
+    ( "TYPO-058",
+      "a sc\xce\xb1le word",
+      [
+        ("inline verbatim", "x \\verb|\xce\xb1| y");
+        ("verbatim env", "\\begin{verbatim}\n\xce\xb1\n\\end{verbatim}");
+        ("line comment", "% \xce\xb1\n");
+        ("inline math", "$\xce\xb1$");
+      ] );
+    (* TYPO-036 (3+ consecutive all-caps words) needs a leading/trailing word
+       boundary, which inline math / inline verbatim cannot supply around the
+       phrase — so it uses a custom 2-context list where the phrase sits inside
+       a comment / verbatim env with real space boundaries. *)
+    ( "TYPO-036",
+      "THIS IS SHOUTING here",
+      [
+        ("line comment", "% THIS IS SHOUTING now\n");
+        ( "verbatim env",
+          "\\begin{verbatim}\n THIS IS SHOUTING \n\\end{verbatim}" );
+      ] );
   ]
 
 let () =

--- a/latex-parse/src/validators_l0_typo.ml
+++ b/latex-parse/src/validators_l0_typo.ml
@@ -1528,12 +1528,16 @@ let r_typo_036 : rule =
     Re_compat.regexp
       {|\(^\|[ \t({]\)[A-Z][A-Z]+ [A-Z][A-Z]+ [A-Z][A-Z]+\($\|[ \t.,;:!?)}]\)|}
   in
+  (* P3 context-aware (token-aware variant): diagnose-only count skips matches
+     inside the exempt set (verbatim / comments / math / url). *)
   let run s =
+    let exempt = find_exempt_ranges s in
     let rec loop i acc =
       try
         let _mr, _ = Re_compat.search_forward re s i in
-        ignore _mr;
-        loop (Re_compat.match_end _mr) (acc + 1)
+        let mb = Re_compat.match_beginning _mr in
+        let acc' = if is_in_exempt_range exempt mb then acc else acc + 1 in
+        loop (Re_compat.match_end _mr) acc'
       with Not_found -> acc
     in
     let cnt = loop 0 0 in
@@ -1666,11 +1670,15 @@ let r_typo_038 : rule =
 
 (* Incorrect spacing around \ldots *)
 let r_typo_041 : rule =
+  (* P3 context-aware (token-aware variant): diagnose-only count skips the
+     exempt set (verbatim / comments / math / url) so `\ldots` spacing inside a
+     code listing or comment is not flagged. *)
   let run s =
+    let exempt = find_exempt_ranges s in
     let cnt =
-      count_substring s ".\\ldots"
-      + count_substring s "\\ldots."
-      + count_substring s ",\\ldots"
+      count_in_text exempt s ".\\ldots"
+      + count_in_text exempt s "\\ldots."
+      + count_in_text exempt s ",\\ldots"
     in
     if cnt > 0 then
       Some
@@ -1975,13 +1983,14 @@ let r_typo_051 : rule =
 
 (* Unescaped < or > in text *)
 let r_typo_052 : rule =
+  (* P3 context-aware (token-aware variant): count moves from
+     strip_math_segments + count_char to count_in_text over the full exempt set
+     — equivalent on math (still skips `<`/`>` inside `$..$`), and additionally
+     skips verbatim / comments / url, where `<`/`>` are literal (e.g. code,
+     `\url{a<b}`). *)
   let run s =
-    let cnt =
-      (fun s ->
-        let s = strip_math_segments s in
-        count_char s '<' + count_char s '>')
-        s
-    in
+    let exempt = find_exempt_ranges s in
+    let cnt = count_in_text exempt s "<" + count_in_text exempt s ">" in
     if cnt > 0 then
       Some
         (mk_result ~id:"TYPO-052" ~severity:Warning
@@ -2037,12 +2046,16 @@ let r_typo_053 : rule =
 (* Hair-space required after en-dash in word-word ranges *)
 let r_typo_054 : rule =
   let re = Re_compat.regexp "[a-zA-Z]\xe2\x80\x93[a-zA-Z]" in
+  (* P3 context-aware (token-aware variant): diagnose-only count skips matches
+     inside the exempt set (verbatim / comments / math / url). *)
   let run s =
+    let exempt = find_exempt_ranges s in
     let rec loop i acc =
       try
         let _mr, _ = Re_compat.search_forward re s i in
-        ignore _mr;
-        loop (Re_compat.match_end _mr) (acc + 1)
+        let mb = Re_compat.match_beginning _mr in
+        let acc' = if is_in_exempt_range exempt mb then acc else acc + 1 in
+        loop (Re_compat.match_end _mr) acc'
       with Not_found -> acc
     in
     let cnt = loop 0 0 in
@@ -2418,8 +2431,12 @@ let r_typo_046 : rule =
 
 (* Starred \section* used where numbered section expected *)
 let r_typo_047 : rule =
+  (* P3 context-aware (token-aware variant): diagnose-only count skips the
+     exempt set so a literal `\section*` in a code listing or comment is not
+     flagged. *)
   let run s =
-    let cnt = count_substring s "\\section*" in
+    let exempt = find_exempt_ranges s in
+    let cnt = count_in_text exempt s "\\section*" in
     if cnt > 0 then
       Some
         (mk_result ~id:"TYPO-047" ~severity:Info
@@ -2477,12 +2494,17 @@ let r_typo_049 : rule =
 (* Legacy TeX accent command found *)
 let r_typo_056 : rule =
   let re = Re_compat.regexp "\\\\['^`\"~=.][{][a-zA-Z][}]" in
+  (* P3 context-aware (token-aware variant): diagnose-only count skips matches
+     inside the exempt set (verbatim / comments / math / url). Same accent regex
+     as TYPO-017 (which fixes them); this is the legacy-accent warning. *)
   let run s =
+    let exempt = find_exempt_ranges s in
     let rec loop i acc =
       try
         let _mr, _ = Re_compat.search_forward re s i in
-        ignore _mr;
-        loop (Re_compat.match_end _mr) (acc + 1)
+        let mb = Re_compat.match_beginning _mr in
+        let acc' = if is_in_exempt_range exempt mb then acc else acc + 1 in
+        loop (Re_compat.match_end _mr) acc'
       with Not_found -> acc
     in
     let cnt = loop 0 0 in
@@ -2496,15 +2518,20 @@ let r_typo_056 : rule =
 
 (* Greek homograph letter found in Latin text *)
 let r_typo_058 : rule =
+  (* P3 context-aware (token-aware variant): count skips the exempt set. Crucial
+     for MATH — a literal Greek letter inside `$..$` is a legitimate math
+     symbol, not a Latin homograph, so it must not be flagged; verbatim/comments
+     are likewise exempt. *)
   let run s =
+    let exempt = find_exempt_ranges s in
     let cnt =
-      count_substring s "\xce\xb1"
-      + count_substring s "\xce\xb5"
-      + count_substring s "\xce\xb9"
-      + count_substring s "\xce\xbf"
-      + count_substring s "\xcf\x81"
-      + count_substring s "\xcf\x82"
-      + count_substring s "\xcf\x85"
+      count_in_text exempt s "\xce\xb1"
+      + count_in_text exempt s "\xce\xb5"
+      + count_in_text exempt s "\xce\xb9"
+      + count_in_text exempt s "\xce\xbf"
+      + count_in_text exempt s "\xcf\x81"
+      + count_in_text exempt s "\xcf\x82"
+      + count_in_text exempt s "\xcf\x85"
     in
     if cnt > 0 then
       Some


### PR DESCRIPTION
## What

Retrofits the **diagnose-only** (warning, no-fix) typography rules **TYPO-036, -041, -047, -052, -054, -056, -058** onto the context-exemption layer. Their **count** now skips the exempt set (verbatim / comments / math / url), so they no longer warn on a deviation that is literal inside a code listing, comment, or math.

## Per-rule (count-exemption only)

- **TYPO-036** (3+ all-caps "shouting"): skip regex matches in exempt.
- **TYPO-041** (`\ldots` spacing): `count_in_text` over the 3 needles.
- **TYPO-047** (`\section*`): `count_in_text`.
- **TYPO-052** (unescaped `<`/`>`): count moves `strip_math_segments`+`count_char` → `count_in_text` (equivalent on math, adds verbatim/comment/url).
- **TYPO-054** (hair-space after en-dash, regex): skip matches in exempt.
- **TYPO-056** (legacy TeX accents — same regex as TYPO-017): skip matches in exempt.
- **TYPO-058** (Greek homograph letters): `count_in_text` over the 7 needles — crucial for **math**, where a literal Greek letter is a legitimate symbol, not a Latin homograph.

## Deferred (target *is* a protected region, or semantic)

- **TYPO-040** (long inline math — math is its target → vcu-only later), **TYPO-060** (scans inside verbatim for curly quotes by design), **TYPO-063** (U+2011 in URLs — url is its target), **TYPO-044** (semantic acronym-first-use). The buggy scanners TYPO-043/045 stay pilot-gated.

## Scope

Not promoted — pilot-only, **default output unchanged**.

## Verification

- `test_context_exemption`: +7 rows → **194 cases** (TYPO-036 uses a custom 2-context list — its all-caps regex needs word boundaries inline contexts can't supply).
- golden **355**, typo-fix **412**, validators-typo **187**, full `dune runtest` green.
- Pilot apply-fixes safety **330/330**. No version bump.

Brings every cleanly-retrofittable pilot TYPO rule to context-aware: **41 rules now FP-clean in protected regions** (30 promoted + 11 pilot).