### PR TITLE
fix(v27.1.2): --apply-fixes deterministic best-effort (no overlap-abort)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 All notable changes to LaTeX Perfectionist are documented here.
 
+## [v27.1.2] — 2026-06-28
+
+**`--apply-fixes` no longer aborts on overlapping fixes — deterministic
+best-effort.** Promoting many fix-producing TYPO rules into the default set
+(v27.1.0) made it common for two rules to emit fix edits on overlapping source
+ranges (e.g. TYPO-005 `...`→`\dots` vs TYPO-010's space-before-the-ellipsis
+dot, or TYPO-010 vs TYPO-018 on `  !`). The strict all-or-nothing apply engine
+then refused to apply *any* fix and exited 2 — leaving `--apply-fixes` unusable
+on real documents (an exit-code-aware corpus probe found 6/330 files aborting).
+
+`--apply-fixes` now applies, per pass, the **maximal non-conflicting subset**
+of edits (deterministic best-effort, first-by-rule-order wins a conflict) and
+iterates to a fixpoint, so an edit that loses a conflict on one pass is
+re-attempted once the winning edit has changed the text. The result is never
+corrupting (the applied subset is pairwise non-conflicting) and converges
+(cycle-detection + cap unchanged). All 330 corpus files now apply with **zero
+aborts** in both pilot and default mode. `--apply-fixes-for RULE-ID` stays
+strict (a single rule's edits must not self-overlap).
+
+Engine hygiene already in v27.1.1 (`Cst_edit.apply_all`/`apply_best_effort`
+dedup of exact-duplicate edits) is retained. The safety gate
+(`check_apply_fixes_safety.py`) is hardened to inspect **exit codes** (an abort
+previously looked like "converged to empty" because the error goes to stderr)
+and to sweep **default mode** as well, so an overlap-abort regression now fails
+the gate. No producer-count change (**101** unchanged).
+
 ## [v27.1.1] — 2026-06-28
 
 **Bug-fix + impl-vs-spec hygiene release.** An adversarial review of the v27.1.0

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ dune exec latex-parse/src/validators_cli.exe -- --layer l2 paper.tex
 | `L0_PROM_ADDR` | `127.0.0.1:9109` | Prometheus TCP bind address |
 | `L0_USE_SIMD_XXH` | unset | Set to `1` for SIMD xxHash acceleration |
 
-## Current Status — v27.1.1 (June 2026)
+## Current Status — v27.1.2 (June 2026)
 
 All layers (L0-L4) implemented. L3 file-based validators (PNG/JPEG/PDF/font). ML v2 byte classifier trained (F1=0.9799) and formally verified:
 - **Build**: `dune build` compiles the SIMD service, benches, and the Coq proof tree (55 core + 114 generated + 1 ML) via `(coq.theory)` stanzas.

--- a/docs/PROOF_GUIDE.md
+++ b/docs/PROOF_GUIDE.md
@@ -141,7 +141,7 @@ Runs on every push and PR. Cannot be bypassed.
 
 ---
 
-## Current State (v27.1.1)
+## Current State (v27.1.2)
 
 - **1,400 theorems/lemmas** across 170 files
 - **637 faithful proofs** (VPD-pattern match, exact Coq model)

--- a/dune-project
+++ b/dune-project
@@ -1,5 +1,5 @@
 (lang dune 3.10)
-(version 27.1.1)
+(version 27.1.2)
 (using coq 0.8)
 (name latex-perfectionist)
 (generate_opam_files true)

--- a/generated/project_facts.json
+++ b/generated/project_facts.json
@@ -1,5 +1,5 @@
 {
-  "version": "v27.1.1",
+  "version": "v27.1.2",
   "release_state": "rc",
   "release_date": "2026-06-28",
   "generated_by": "scripts/tools/generate_project_facts.py",

--- a/governance/project_facts.yaml
+++ b/governance/project_facts.yaml
@@ -1,4 +1,4 @@
-version: v27.1.1
+version: v27.1.2
 release_state: rc
 release_date: '2026-06-28'
 generated_by: scripts/tools/generate_project_facts.py

--- a/latex-parse/src/validators_cli.ml
+++ b/latex-parse/src/validators_cli.ml
@@ -199,40 +199,49 @@ let apply_fixes_cap = 64
 let run_apply_fixes_converge ?filter_id ~path ~src () =
   let seen = Hashtbl.create 16 in
   Hashtbl.replace seen (Digest.string src) ();
+  (* v27.1.2: each pass applies the maximal NON-CONFLICTING subset of edits
+     (deterministic best-effort, [Cst_edit.apply_best_effort] — first-by-rule-
+     order wins a conflict) instead of the former strict [Rewrite_engine.apply],
+     which ABORTED the whole document if ANY two promoted rules emitted
+     overlapping edits (e.g. TYPO-005 `...`→`\dots` vs TYPO-010 space-before-the
+     ellipsis dot). Promoting many fix-producers into the default set made such
+     overlaps common, so all-or-nothing left `--apply-fixes` unusable on real
+     documents. Best-effort never corrupts (the applied subset is pairwise
+     non-conflicting); an edit that loses a conflict on one pass is re-attempted
+     on the next once the winning edit has changed the text, so the converge
+     loop still drives every compatible fix to a fixpoint. Cycle-detection + the
+     cap keep it terminating exactly as before. *)
   let rec loop cur passes =
     ignore (resolve_profile ~requested:`Auto ~src:cur);
     ignore (setup_all ~path ~src:cur ~log_path:None);
     let results = Latex_parse_lib.Validators.run_all cur in
     let edits = collect_fix_edits ?filter_id results in
-    if edits = [] then Ok cur
+    if edits = [] then cur
     else
-      match Latex_parse_lib.Rewrite_engine.apply ~source:cur ~edits with
-      | Error _ as e -> if passes = 0 then e else Ok cur
-      | Ok nxt ->
-          if String.equal nxt cur then Ok cur
-          else
-            let dn = Digest.string nxt in
-            if Hashtbl.mem seen dn then (
-              eprintf
-                "# apply-fixes: fix cycle detected after %d pass(es); emitting \
-                 last stable state (contradictory producers)\n"
-                (passes + 1);
-              Ok cur)
-            else if passes + 1 >= apply_fixes_cap then (
-              eprintf
-                "# apply-fixes: reached the %d-pass cap without a fixpoint; \
-                 emitting latest state\n"
-                apply_fixes_cap;
-              Ok nxt)
-            else (
-              Hashtbl.replace seen dn ();
-              loop nxt (passes + 1))
+      let nxt, _applied, _skipped =
+        Latex_parse_lib.Cst_edit.apply_best_effort cur edits
+      in
+      if String.equal nxt cur then cur
+      else
+        let dn = Digest.string nxt in
+        if Hashtbl.mem seen dn then (
+          eprintf
+            "# apply-fixes: fix cycle detected after %d pass(es); emitting \
+             last stable state (contradictory producers)\n"
+            (passes + 1);
+          cur)
+        else if passes + 1 >= apply_fixes_cap then (
+          eprintf
+            "# apply-fixes: reached the %d-pass cap without a fixpoint; \
+             emitting latest state\n"
+            apply_fixes_cap;
+          nxt)
+        else (
+          Hashtbl.replace seen dn ();
+          loop nxt (passes + 1))
   in
-  match loop src 0 with
-  | Ok out ->
-      print_string out;
-      0
-  | Error (`Overlap (a, b)) -> overlap_error a b
+  print_string (loop src 0);
+  0
 
 let run_apply_fixes ?filter_id ?(best_effort = false) ?(converge = false) ~path
     ~src () =
@@ -393,19 +402,23 @@ let () =
          [--profile auto|lp-core|lp-extended|lp-foreign] [--advisory] \
          [--project <root.tex>] [--layer l0|l1|l2|l3|l4] [--log <file.log>] \
          <file.tex>\n\n\
-         --apply-fixes  run validators, apply every rule's fix edits via \
-         Cst_edit.apply_all,\n\
-        \               and emit the modified source to stdout. Iterates to a \
-         fixpoint\n\
-        \               (P1a) so cross-rule cascades resolve in one run; \
-         cycle-safe. \n\
-        \               L0_APPLY_FIXES=1 is equivalent when no other flag is \
-         given.\n\
-        \               Overlapping fixes → stderr + exit 2.\n\
+         --apply-fixes  run validators, apply every rule's fix edits and emit \
+         the\n\
+        \               modified source to stdout. Iterates to a fixpoint \
+         (P1a) so\n\
+        \               cross-rule cascades resolve in one run; cycle-safe. \
+         Each pass\n\
+        \               applies the maximal NON-CONFLICTING subset \
+         (deterministic\n\
+        \               best-effort, rule-order priority), so overlapping \
+         fixes from\n\
+        \               different rules never abort the document (v27.1.2). \
+         L0_APPLY_FIXES=1\n\
+        \               is equivalent when no other flag is given.\n\
          --apply-fixes-for RULE-ID  same as --apply-fixes but only applies \
          fixes from results\n\
-        \               whose [r.id = RULE-ID]. Useful for incremental \
-         adoption (v26.3).\n\
+        \               whose [r.id = RULE-ID] (strict; a single rule's edits \
+         must not self-overlap). Useful for incremental adoption (v26.3).\n\
          --apply-fixes-best-effort  v26.4: applies the maximal non-conflicting \
          subset of fixes\n\
         \               via Cst_edit.apply_best_effort. Reports the skipped \

--- a/scripts/tools/check_apply_fixes_safety.py
+++ b/scripts/tools/check_apply_fixes_safety.py
@@ -78,15 +78,20 @@ def lint_counts(binp: str, path: str, env) -> dict[str, int]:
     return d
 
 
-def apply_once(binp: str, path: str, env) -> str:
-    out = subprocess.run(
+def apply_once(binp: str, path: str, env):
+    """Return (text, returncode). returncode != 0 means the CLI refused to apply
+    (e.g. exit 2 = E.apply-fixes.overlap) — the error goes to stderr so stdout is
+    empty, which earlier silently looked like 'converged to empty'."""
+    r = subprocess.run(
         [binp, "--apply-fixes", path], capture_output=True, text=True, env=env
-    ).stdout
-    return "\n".join(l for l in out.splitlines() if not l.startswith("# "))
+    )
+    text = "\n".join(l for l in r.stdout.splitlines() if not l.startswith("# "))
+    return text, r.returncode
 
 
 def fixpoint(binp: str, path: str, env):
-    """Return (converged: bool, final_text: str, passes: int)."""
+    """Return (status, final_text, passes) where status is one of
+    'converged' | 'cycle' | 'cap' | 'aborted'."""
     cur = open(path, encoding="utf-8", errors="ignore").read()
     seen = {cur.rstrip("\n")}
     for n in range(1, MAX_PASSES + 1):
@@ -94,16 +99,18 @@ def fixpoint(binp: str, path: str, env):
             t.write(cur)
             tp = t.name
         try:
-            nxt = apply_once(binp, tp, env)
+            nxt, rc = apply_once(binp, tp, env)
         finally:
             os.unlink(tp)
+        if rc != 0:
+            return "aborted", cur, n  # CLI refused (exit code) — NOT convergence
         if nxt.rstrip("\n") == cur.rstrip("\n"):
-            return True, cur, n  # stable fixpoint
+            return "converged", cur, n  # stable fixpoint
         if nxt.rstrip("\n") in seen:
-            return False, nxt, n  # cycle (oscillation)
+            return "cycle", nxt, n  # oscillation
         seen.add(nxt.rstrip("\n"))
         cur = nxt
-    return False, cur, MAX_PASSES  # did not stabilise within cap
+    return "cap", cur, MAX_PASSES  # did not stabilise within cap
 
 
 def allowlisted(path: str) -> bool:
@@ -133,14 +140,27 @@ def main() -> int:
         if os.path.isfile(f)
     )
 
-    nonconv, new_err, bad_utf8 = [], [], []
+    # Also exercise DEFAULT mode (no L0_VALIDATORS) — the promoted TYPO rules now
+    # fire there, and overlapping fix edits among them must NOT abort
+    # --apply-fixes (regression guard for the v27.1.2 best-effort apply engine).
+    default_env = dict(os.environ)
+    default_env.pop("L0_VALIDATORS", None)
+
+    nonconv, new_err, bad_utf8, aborted = [], [], [], []
     for f in files:
-        base = lint_counts(binp, f, env)
-        converged, final, passes = fixpoint(binp, f, env)
         rel = os.path.relpath(f, ns.repo)
-        if not converged:
+        # Default-mode abort check (cheap: one apply-fixes call, inspect exit code).
+        _, drc = apply_once(binp, f, default_env)
+        if drc not in (0,):
+            aborted.append(f"{rel}: default-mode --apply-fixes exited {drc} (overlap-abort?)")
+        base = lint_counts(binp, f, env)
+        status, final, passes = fixpoint(binp, f, env)
+        if status == "aborted":
+            aborted.append(f"{rel}: pilot-mode --apply-fixes aborted (exit code)")
+            continue
+        if status != "converged":
             if not allowlisted(rel):
-                nonconv.append(f"{rel}: did not converge in {MAX_PASSES} passes (contradictory producers?)")
+                nonconv.append(f"{rel}: did not converge in {MAX_PASSES} passes ({status})")
             continue
         try:
             final.encode("utf-8")
@@ -165,8 +185,13 @@ def main() -> int:
         for v in new_err:
             print(f"  info: {v}")
 
-    # Hard safety violations: non-convergence (oscillation) + invalid output.
-    violations = nonconv + [f"{b}: fixpoint output not valid UTF-8" for b in bad_utf8]
+    # Hard safety violations: --apply-fixes refusing to apply (overlap-abort) in
+    # either mode, non-convergence (oscillation), and invalid output.
+    violations = (
+        aborted
+        + nonconv
+        + [f"{b}: fixpoint output not valid UTF-8" for b in bad_utf8]
+    )
     if violations:
         print(f"[apply-fixes-safety] FAIL: {len(violations)} hard safety violation(s) "
               f"across {len(files)} corpus files:", file=sys.stderr)
@@ -174,7 +199,8 @@ def main() -> int:
             print(f"  {v}", file=sys.stderr)
         return 1
     print(f"[apply-fixes-safety] PASS: all {len(files)} corpus files converge to valid "
-          f"output (pilot mode, ≤{MAX_PASSES} passes; {len(new_err)} informational count-rises).")
+          f"output with no apply-abort (pilot + default mode, ≤{MAX_PASSES} passes; "
+          f"{len(new_err)} informational count-rises).")
     return 0
 
 

--- a/specs/README.md
+++ b/specs/README.md
@@ -4,7 +4,7 @@
 
 | Directory / file | Contents |
 |------------------|----------|
-| `v27/` | **Current release** (v27.0.x — currently shipping the Bucket A fix-producer cadence; latest tag `v27.1.1`): master spec (`V27_REPO_EXACT_MASTER_SPEC.{md,yaml}`), cadence + ledger (`V27_FIX_PRODUCER_CADENCE.md`, `FIX_PRODUCER_LEDGER.md`), faithful-semantics / L3-AST / apply-edits / T5 / WS8 plan docs |
+| `v27/` | **Current release** (v27.0.x — currently shipping the Bucket A fix-producer cadence; latest tag `v27.1.2`): master spec (`V27_REPO_EXACT_MASTER_SPEC.{md,yaml}`), cadence + ledger (`V27_FIX_PRODUCER_CADENCE.md`, `FIX_PRODUCER_LEDGER.md`), faithful-semantics / L3-AST / apply-edits / T5 / WS8 plan docs |
 | `v26/` | Prior release (v26.2): master spec (`V26_REPO_EXACT_MASTER_SPEC.{md,yaml}`), `language_contract.{md,yaml}`, `compilation_guarantee_stack.md`, `compilation_profiles.yaml`, `partial_document_semantics.{md,yaml}`, `V26_2_PLAN.md` |
 | `REPO_EXACT_MISSING_ARCHITECTURE_MEMO_V26_V27.md` | Authoritative architecture memo (11 pieces, v26/v27 plan) |
 | `rules/` | `rules_v3.yaml` (660 rules, 644 non-reserved, 16 reserved), `rule_contracts.yaml` / `.json` (per-rule metadata), golden YAML test fixtures |

--- a/specs/rules/README.md
+++ b/specs/rules/README.md
@@ -40,7 +40,7 @@
   - Impl: 6
   - Reserved: 16 (future families; do not implement yet)
 - Fix producers (`produces_fix: true` in `rule_contracts.yaml`): 101 as of
-  v27.1.1.  See `../v27/V27_FIX_PRODUCER_CADENCE.md` for cadence and
+  v27.1.2.  See `../v27/V27_FIX_PRODUCER_CADENCE.md` for cadence and
   `../v27/FIX_PRODUCER_LEDGER.md` for the per-rule shipping ledger.
 
 ## Implementation Guidance (When to Start)

--- a/specs/v27/V27_FIX_PRODUCER_CADENCE.md
+++ b/specs/v27/V27_FIX_PRODUCER_CADENCE.md
@@ -1,7 +1,7 @@
 # V27_FIX_PRODUCER_CADENCE — Rolling fix-producer extension to full coverage
 
 **Goal:** Bring the catalogue of 660 lint rules from the 32 fix-producing
-rules at plan authoring (101 shipped as of v27.1.1) to full coverage where
+rules at plan authoring (101 shipped as of v27.1.2) to full coverage where
 mechanically safe, with
 explicit deferral of NLP-required and unsafe-without-context rules.
 
@@ -146,7 +146,7 @@ from `FIX_PRODUCER_LEDGER.md`, ship, update.
   v27.0.5+**; enforced every release cycle via
   `scripts/tools/run_differential_test.py`.
 - [ ] Bucket A shipped fully by v27.2.0 (target).  **IN PROGRESS** —
-  101/458 (~22%) shipped as of v27.1.1.  Original v27.2.0 target
+  101/458 (~22%) shipped as of v27.1.2.  Original v27.2.0 target
   assumed ≥10 producers/release; at the actual cadence pace this
   milestone is on track for a later release.
 - [ ] Bucket B + C shipped fully by v27.4.0 (target).  **NOT


### PR DESCRIPTION
## What

`--apply-fixes` no longer **aborts the whole document** when two promoted rules emit overlapping fix edits. It now applies the **maximal non-conflicting subset** per pass (deterministic best-effort, first-by-rule-order wins) and iterates to a fixpoint.

## Why

The v27.1.0 promotion put many fix-producing TYPO rules in the default set, so overlapping fix edits became common (e.g. TYPO-005 `...`→`\dots` vs TYPO-010's space-before-the-ellipsis dot; TYPO-010 vs TYPO-018 on `  !`). The strict engine refused *all* fixes and exited 2 — an exit-code-aware corpus probe found **6/330 files aborting**. (This was invisible because the abort writes to stderr, so stdout looked empty/"converged".)

## Changes

- **`run_apply_fixes_converge`** uses `Cst_edit.apply_best_effort` (deterministic, rule-order priority) instead of strict `Rewrite_engine.apply`. Never corrupting (applied subset is pairwise non-conflicting); converges via the existing fixpoint loop + cycle-detection + cap. A losing edit is re-attempted once the winner changes the text.
- **`--apply-fixes-for RULE-ID`** stays strict (a single rule's edits must not self-overlap). Help text updated.
- **Hardened `check_apply_fixes_safety.py`**: now inspects **exit codes** (an abort previously read as "converged to empty"—the same blind spot as the manual probe) and sweeps **default mode** as well. An overlap-abort regression now *fails* the gate.

## Verification

- **0 aborts across all 330 corpus files** in pilot *and* default mode (was 6).
- Full `dune runtest` green; `apply-fixes-cli` 19, `cst-edit` 27 (+2 dedup tests from v27.1.1).
- Pilot+default safety gate PASS (330/330 converge). All consistency gates green.
- version **27.1.2**; producer count **101** unchanged.