### PR TITLE
fix(v27.1.4): verbatim/comment/url corruption safety fix — ~46 producers + permanent gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 All notable changes to LaTeX Perfectionist are documented here.
 
+## [v27.1.4] — 2026-06-28
+
+**Verbatim/comment/url corruption safety fix — ~43 fix producers + permanent
+gate.** A whole class of older fix producers (those predating the P3 context
+layer) rewrote bytes the author wrote *literally* — inside a `verbatim` /
+`lstlisting` / `minted` environment, an inline `\verb|..|`, a `%` comment, or a
+`\url{..}` target. Replacing a fullwidth char with ASCII, deleting a control
+byte or BOM, or (for math-targeting rules) rewriting `\frac`/`''` inside a `$..$`
+that happens to sit in a verbatim block all silently corrupt literal content the
+lint-output differential cannot see. An exhaustive audit (per-rule empirical +
+a torture-document sweep) found **30 character/encoding replacers, ENC-002 (BOM),
+11 MATH-\* producers, and SCRIPT-016** all affected.
+
+Fix: two shared constructors in `Validators_common` —
+`mk_result_with_fix_exempt` (drops every edit inside verbatim/`\verb`/comment/
+url/math; for prose-targeting char/encoding rules) and
+`mk_result_with_fix_vcu_exempt` (drops only verbatim/comment/url, **keeping**
+genuine in-math edits; for MATH-targeting rules). The **diagnostic count is
+untouched** in every case — the occurrence is still tallied, only the *fix* is
+withheld inside protected regions — so default-mode lint output is byte-identical
+(`run_differential_test.py`: 330 files, 0 diffs vs v27.1.3). Producer count
+unchanged at 104 (this fixes existing producers, adds none).
+
+New gate **`scripts/tools/check_verbatim_safety.py`** (wired into
+`pre_release_check`) plants a battery of every known producer trigger between
+sentinels inside each protected-region kind and fails if `--apply-fixes` (pilot
++ default) changes a single byte — so the corruption can never recur for an
+existing or newly added producer.
+
 ## [v27.1.3] — 2026-06-28
 
 **Fix-producer batch 9 — 3 new producers (101 → 104).** Three diagnose-only

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ dune exec latex-parse/src/validators_cli.exe -- --layer l2 paper.tex
 | `L0_PROM_ADDR` | `127.0.0.1:9109` | Prometheus TCP bind address |
 | `L0_USE_SIMD_XXH` | unset | Set to `1` for SIMD xxHash acceleration |
 
-## Current Status — v27.1.3 (June 2026)
+## Current Status — v27.1.4 (June 2026)
 
 All layers (L0-L4) implemented. L3 file-based validators (PNG/JPEG/PDF/font). ML v2 byte classifier trained (F1=0.9799) and formally verified:
 - **Build**: `dune build` compiles the SIMD service, benches, and the Coq proof tree (55 core + 114 generated + 1 ML) via `(coq.theory)` stanzas.
@@ -227,7 +227,7 @@ bash scripts/latency_smoke_expand.sh 200
 
 ---
 
-**Status**: v27.1.3 released. 644 validators implemented, **104 fix-producing rules**, 1,400 theorems across 170 Coq files (0 admits, 0 axioms), ML v2 byte classifier trained (F1=0.9799, proved). Compile-guarantee contract + byte-lossless CST + rewrite engine + per-rule fix producers + conflict-aware merging live. v27 WS8 (final discharge of T6/T7 against `proofs/PdflatexModel.v`) shipped in v27.0.0; the `apply_edits` rewrite-engine universal correspondence between OCaml `Cst_edit.apply_all` and Coq `apply_edits_parallel` shipped in v27.0.4 (`apply_edits_cursor_eq_parallel` Theorem, Qed, Closed under the global context). The Bucket A fix-producer cadence has been rolling since v27.0.5, adding 1–3 producers per patch release; see [`specs/v27/V27_FIX_PRODUCER_CADENCE.md`](specs/v27/V27_FIX_PRODUCER_CADENCE.md) and [`specs/v27/FIX_PRODUCER_LEDGER.md`](specs/v27/FIX_PRODUCER_LEDGER.md) for per-rule shipping status and bucket assignments.
+**Status**: v27.1.4 released. 644 validators implemented, **104 fix-producing rules**, 1,400 theorems across 170 Coq files (0 admits, 0 axioms), ML v2 byte classifier trained (F1=0.9799, proved). Compile-guarantee contract + byte-lossless CST + rewrite engine + per-rule fix producers + conflict-aware merging live. v27 WS8 (final discharge of T6/T7 against `proofs/PdflatexModel.v`) shipped in v27.0.0; the `apply_edits` rewrite-engine universal correspondence between OCaml `Cst_edit.apply_all` and Coq `apply_edits_parallel` shipped in v27.0.4 (`apply_edits_cursor_eq_parallel` Theorem, Qed, Closed under the global context). The Bucket A fix-producer cadence has been rolling since v27.0.5, adding 1–3 producers per patch release; see [`specs/v27/V27_FIX_PRODUCER_CADENCE.md`](specs/v27/V27_FIX_PRODUCER_CADENCE.md) and [`specs/v27/FIX_PRODUCER_LEDGER.md`](specs/v27/FIX_PRODUCER_LEDGER.md) for per-rule shipping status and bucket assignments.
 
 ### First‑Token Latency (Tier A target ≤ 350 µs)
 

--- a/docs/PROOF_GUIDE.md
+++ b/docs/PROOF_GUIDE.md
@@ -141,7 +141,7 @@ Runs on every push and PR. Cannot be bypassed.
 
 ---
 
-## Current State (v27.1.3)
+## Current State (v27.1.4)
 
 - **1,400 theorems/lemmas** across 170 files
 - **637 faithful proofs** (VPD-pattern match, exact Coq model)

--- a/dune-project
+++ b/dune-project
@@ -1,5 +1,5 @@
 (lang dune 3.10)
-(version 27.1.3)
+(version 27.1.4)
 (using coq 0.8)
 (name latex-perfectionist)
 (generate_opam_files true)

--- a/governance/project_facts.yaml
+++ b/governance/project_facts.yaml
@@ -1,4 +1,4 @@
-version: v27.1.3
+version: v27.1.4
 release_state: rc
 release_date: '2026-06-28'
 generated_by: scripts/tools/generate_project_facts.py

--- a/latex-parse/src/validators_common.ml
+++ b/latex-parse/src/validators_common.ml
@@ -621,6 +621,46 @@ let find_exempt_ranges (s : string) : (int * int) list =
     (Alias of the generic point-in-ranges test [is_in_math_range].) *)
 let is_in_exempt_range = is_in_math_range
 
+(** [mk_result_with_fix_exempt ~id ~severity ~message ~count ~src ~fix] —
+    exempt-aware constructor for character/whitespace fix producers. Drops every
+    edit in [fix] whose start offset falls inside a verbatim / inline \verb /
+    comment / url / math region of [src] (via [find_exempt_ranges]), then builds
+    a [mk_result_with_fix] from what survives, or a plain [mk_result] if nothing
+    does. [count] is supplied by the caller and is NOT touched — the diagnostic
+    still tallies every occurrence (so default-mode lint and the differential
+    are unchanged); only the FIX is withheld inside protected regions, where
+    rewriting literal bytes (a 3-byte fullwidth char → ASCII, a control byte or
+    BOM deleted, a tab expanded) would corrupt content the author wrote
+    verbatim. Centralises the P3 exempt principle for the older CHAR/CJK/ENC/SPC
+    producers that predate it (v27.1.4 verbatim-exemption safety fix). *)
+let mk_result_with_fix_exempt ~id ~severity ~message ~count ~src ~fix =
+  let exempt = find_exempt_ranges src in
+  let fix' =
+    List.filter
+      (fun (e : Cst_edit.t) -> not (is_in_exempt_range exempt e.start_offset))
+      fix
+  in
+  if fix' = [] then mk_result ~id ~severity ~message ~count
+  else mk_result_with_fix ~id ~severity ~message ~count ~fix:fix'
+
+(** [mk_result_with_fix_vcu_exempt ~id ~severity ~message ~count ~src ~fix] —
+    the MATH-targeting counterpart of [mk_result_with_fix_exempt]. A rule that
+    fixes inside math (e.g. MATH-014 `\frac`→`\tfrac`, SCRIPT-016 `''`→prime)
+    finds its targets via [find_math_ranges], which treats a `$..$` written
+    inside a `verbatim` / `\verb` / comment as math — so the fix would rewrite
+    that literal source. This drops only edits inside the verbatim/comment/url
+    ([find_verbatim_comment_url_ranges]) set, KEEPING genuine in-math edits (it
+    must not use the full exempt set, which includes math). Count is untouched. *)
+let mk_result_with_fix_vcu_exempt ~id ~severity ~message ~count ~src ~fix =
+  let vcu = find_verbatim_comment_url_ranges src in
+  let fix' =
+    List.filter
+      (fun (e : Cst_edit.t) -> not (is_in_exempt_range vcu e.start_offset))
+      fix
+  in
+  if fix' = [] then mk_result ~id ~severity ~message ~count
+  else mk_result_with_fix ~id ~severity ~message ~count ~fix:fix'
+
 (** [is_ascii_context ?window ?candidate_bytes s off] — heuristic that returns
     [true] iff the byte window of size [window] (default 32) on each side of the
     candidate UTF-8 sequence at [off] (of length [candidate_bytes], default 3)

--- a/latex-parse/src/validators_l0.ml
+++ b/latex-parse/src/validators_l0.ml
@@ -131,7 +131,7 @@ let r_enc_007 : rule =
           offsets
       in
       Some
-        (mk_result_with_fix ~id:"ENC-007" ~severity:Warning
+        (mk_result_with_fix_exempt ~src:s ~id:"ENC-007" ~severity:Warning
            ~message:"Zero‑width space U+200B present" ~count:cnt ~fix)
     else None
   in
@@ -175,7 +175,7 @@ let r_enc_012 : rule =
           offsets
       in
       Some
-        (mk_result_with_fix ~id:"ENC-012" ~severity:Error
+        (mk_result_with_fix_exempt ~src:s ~id:"ENC-012" ~severity:Error
            ~message:"C1 control characters U+0080–009F present" ~count:cnt ~fix)
     else None
   in
@@ -204,7 +204,7 @@ let r_enc_017 : rule =
           offsets
       in
       Some
-        (mk_result_with_fix ~id:"ENC-017" ~severity:Warning
+        (mk_result_with_fix_exempt ~src:s ~id:"ENC-017" ~severity:Warning
            ~message:"Soft hyphen U+00AD found in source" ~count:cnt ~fix)
     else None
   in
@@ -240,7 +240,7 @@ let r_enc_020 : rule =
           offsets
       in
       Some
-        (mk_result_with_fix ~id:"ENC-020" ~severity:Warning
+        (mk_result_with_fix_exempt ~src:s ~id:"ENC-020" ~severity:Warning
            ~message:"Invisible formatting mark U+200E/U+200F present" ~count:cnt
            ~fix)
     else None
@@ -269,7 +269,7 @@ let r_enc_021 : rule =
           offsets
       in
       Some
-        (mk_result_with_fix ~id:"ENC-021" ~severity:Warning
+        (mk_result_with_fix_exempt ~src:s ~id:"ENC-021" ~severity:Warning
            ~message:"WORD JOINER U+2060 present" ~count:cnt ~fix)
     else None
   in
@@ -304,7 +304,7 @@ let r_enc_022 : rule =
           offsets
       in
       Some
-        (mk_result_with_fix ~id:"ENC-022" ~severity:Warning
+        (mk_result_with_fix_exempt ~src:s ~id:"ENC-022" ~severity:Warning
            ~message:"Interlinear annotation chars U+FFF9–FFFB detected"
            ~count:cnt ~fix)
     else None
@@ -339,7 +339,7 @@ let r_enc_023 : rule =
           offsets
       in
       Some
-        (mk_result_with_fix ~id:"ENC-023" ~severity:Warning
+        (mk_result_with_fix_exempt ~src:s ~id:"ENC-023" ~severity:Warning
            ~message:"NARROW NB‑SPACE U+202F outside French context" ~count:cnt
            ~fix)
     else None
@@ -385,7 +385,7 @@ let r_enc_024 : rule =
           offsets
       in
       Some
-        (mk_result_with_fix ~id:"ENC-024" ~severity:Warning
+        (mk_result_with_fix_exempt ~src:s ~id:"ENC-024" ~severity:Warning
            ~message:"Bidirectional embeddings U+202A–U+202E present" ~count:cnt
            ~fix)
     else None
@@ -472,8 +472,8 @@ let r_enc_002 : rule =
         Some (mk_result ~id:"ENC-002" ~severity:Error ~message ~count:interior)
       else
         Some
-          (mk_result_with_fix ~id:"ENC-002" ~severity:Error ~message
-             ~count:interior ~fix)
+          (mk_result_with_fix_exempt ~src:s ~id:"ENC-002" ~severity:Error
+             ~message ~count:interior ~fix)
     else None
   in
   { id = "ENC-002"; run; languages = [] }
@@ -597,8 +597,8 @@ let r_enc_004 : rule =
         Some (mk_result ~id:"ENC-004" ~severity:Warning ~message ~count:!cnt)
       else
         Some
-          (mk_result_with_fix ~id:"ENC-004" ~severity:Warning ~message
-             ~count:!cnt ~fix)
+          (mk_result_with_fix_exempt ~src:s ~id:"ENC-004" ~severity:Warning
+             ~message ~count:!cnt ~fix)
     else None
   in
   { id = "ENC-004"; run; languages = [] }
@@ -873,7 +873,7 @@ let r_enc_016 : rule =
           offsets
       in
       Some
-        (mk_result_with_fix ~id:"ENC-016" ~severity:Warning
+        (mk_result_with_fix_exempt ~src:s ~id:"ENC-016" ~severity:Warning
            ~message:"Arabic numerals replaced by Unicode look‑alikes" ~count:cnt
            ~fix)
     else None
@@ -1034,7 +1034,7 @@ let r_enc_018 : rule =
           offsets
       in
       Some
-        (mk_result_with_fix ~id:"ENC-018" ~severity:Info
+        (mk_result_with_fix_exempt ~src:s ~id:"ENC-018" ~severity:Info
            ~message:"Non‑breaking hyphen U+2011 present outside URLs" ~count:cnt
            ~fix)
     else None
@@ -1157,7 +1157,7 @@ let r_char_005 : rule =
           !offsets
       in
       Some
-        (mk_result_with_fix ~id:"CHAR-005" ~severity:Error
+        (mk_result_with_fix_exempt ~src:s ~id:"CHAR-005" ~severity:Error
            ~message:"Control characters U+0000–001F present" ~count:cnt ~fix)
     else None
   in
@@ -1189,7 +1189,7 @@ let r_char_006 : rule =
           !offsets
       in
       Some
-        (mk_result_with_fix ~id:"CHAR-006" ~severity:Error
+        (mk_result_with_fix_exempt ~src:s ~id:"CHAR-006" ~severity:Error
            ~message:"Backspace U+0008 present" ~count:cnt ~fix)
     else None
   in
@@ -1216,7 +1216,7 @@ let r_char_007 : rule =
           !offsets
       in
       Some
-        (mk_result_with_fix ~id:"CHAR-007" ~severity:Error
+        (mk_result_with_fix_exempt ~src:s ~id:"CHAR-007" ~severity:Error
            ~message:"Bell/alert U+0007 present" ~count:cnt ~fix)
     else None
   in
@@ -1245,7 +1245,7 @@ let r_char_008 : rule =
           !offsets
       in
       Some
-        (mk_result_with_fix ~id:"CHAR-008" ~severity:Warning
+        (mk_result_with_fix_exempt ~src:s ~id:"CHAR-008" ~severity:Warning
            ~message:"Form feed U+000C present" ~count:cnt ~fix)
     else None
   in
@@ -1273,7 +1273,7 @@ let r_char_009 : rule =
           !offsets
       in
       Some
-        (mk_result_with_fix ~id:"CHAR-009" ~severity:Warning
+        (mk_result_with_fix_exempt ~src:s ~id:"CHAR-009" ~severity:Warning
            ~message:"Delete U+007F present" ~count:cnt ~fix)
     else None
   in
@@ -1303,7 +1303,7 @@ let r_char_013 : rule =
           offsets
       in
       Some
-        (mk_result_with_fix ~id:"CHAR-013" ~severity:Warning
+        (mk_result_with_fix_exempt ~src:s ~id:"CHAR-013" ~severity:Warning
            ~message:"Bidirectional isolate chars U+2066–U+2069 present"
            ~count:cnt ~fix)
     else None
@@ -1330,7 +1330,7 @@ let r_char_014 : rule =
           offsets
       in
       Some
-        (mk_result_with_fix ~id:"CHAR-014" ~severity:Warning
+        (mk_result_with_fix_exempt ~src:s ~id:"CHAR-014" ~severity:Warning
            ~message:"Unicode replacement � found – decoding error" ~count:cnt
            ~fix)
     else None
@@ -1423,7 +1423,7 @@ let r_char_017 : rule =
           offsets
       in
       Some
-        (mk_result_with_fix ~id:"CHAR-017" ~severity:Warning
+        (mk_result_with_fix_exempt ~src:s ~id:"CHAR-017" ~severity:Warning
            ~message:"Full‑width Latin letters detected" ~count:cnt ~fix)
     else None
   in
@@ -1479,7 +1479,7 @@ let r_char_018 : rule =
              ~message:"Deprecated ligature ﬀ/ﬁ/ﬂ characters present" ~count:cnt)
       else
         Some
-          (mk_result_with_fix ~id:"CHAR-018" ~severity:Info
+          (mk_result_with_fix_exempt ~src:s ~id:"CHAR-018" ~severity:Info
              ~message:"Deprecated ligature ﬀ/ﬁ/ﬂ characters present" ~count:cnt
              ~fix)
     else None
@@ -1576,8 +1576,8 @@ let r_char_016 : rule =
             !fix_edits
         in
         Some
-          (mk_result_with_fix ~id:"CHAR-016" ~severity:Warning ~message:msg
-             ~count:!cnt ~fix:sorted)
+          (mk_result_with_fix_exempt ~src:s ~id:"CHAR-016" ~severity:Warning
+             ~message:msg ~count:!cnt ~fix:sorted)
     else None
   in
   { id = "CHAR-016"; run; languages = [] }
@@ -1621,7 +1621,7 @@ let r_char_019 : rule =
              ~message:"Unicode minus U+2212 in text mode" ~count:cnt)
       else
         Some
-          (mk_result_with_fix ~id:"CHAR-019" ~severity:Info
+          (mk_result_with_fix_exempt ~src:s ~id:"CHAR-019" ~severity:Info
              ~message:"Unicode minus U+2212 in text mode" ~count:cnt ~fix)
     else None
   in
@@ -1755,7 +1755,7 @@ let r_char_012 : rule =
              ~count:!cnt)
       else
         Some
-          (mk_result_with_fix ~id:"CHAR-012" ~severity:Info
+          (mk_result_with_fix_exempt ~src:s ~id:"CHAR-012" ~severity:Info
              ~message:"Zero‑width joiner U+200D outside ligature context"
              ~count:!cnt ~fix)
     else None
@@ -1888,7 +1888,7 @@ let r_spc_003 : rule =
              ~count:!matched)
       else
         Some
-          (mk_result_with_fix ~id:"SPC-003" ~severity:Warning
+          (mk_result_with_fix_exempt ~src:s ~id:"SPC-003" ~severity:Warning
              ~message:"Hard tab precedes non‑tab text (mixed indent)"
              ~count:!matched ~fix)
     else None
@@ -1945,7 +1945,7 @@ let r_spc_005 : rule =
              ~message:"Trailing tab at end of line" ~count:!matched)
       else
         Some
-          (mk_result_with_fix ~id:"SPC-005" ~severity:Info
+          (mk_result_with_fix_exempt ~src:s ~id:"SPC-005" ~severity:Info
              ~message:"Trailing tab at end of line" ~count:!matched ~fix)
     else None
   in
@@ -3795,8 +3795,8 @@ let r_cjk_001 : rule =
           (mk_result ~id:"CJK-001" ~severity:Warning ~message:msg ~count:!cnt)
       else
         Some
-          (mk_result_with_fix ~id:"CJK-001" ~severity:Warning ~message:msg
-             ~count:!cnt ~fix:(List.rev !fix_edits))
+          (mk_result_with_fix_exempt ~src:s ~id:"CJK-001" ~severity:Warning
+             ~message:msg ~count:!cnt ~fix:(List.rev !fix_edits))
     else None
   in
   { id = "CJK-001"; run; languages = [ "zh"; "ja"; "ko" ] }
@@ -3839,8 +3839,8 @@ let r_cjk_002 : rule =
           (mk_result ~id:"CJK-002" ~severity:Warning ~message:msg ~count:!cnt)
       else
         Some
-          (mk_result_with_fix ~id:"CJK-002" ~severity:Warning ~message:msg
-             ~count:!cnt ~fix:(List.rev !fix_edits))
+          (mk_result_with_fix_exempt ~src:s ~id:"CJK-002" ~severity:Warning
+             ~message:msg ~count:!cnt ~fix:(List.rev !fix_edits))
     else None
   in
   { id = "CJK-002"; run; languages = [ "zh"; "ja"; "ko" ] }
@@ -3903,8 +3903,8 @@ let r_cjk_010 : rule =
           (mk_result ~id:"CJK-010" ~severity:Warning ~message:msg ~count:!cnt)
       else
         Some
-          (mk_result_with_fix ~id:"CJK-010" ~severity:Warning ~message:msg
-             ~count:!cnt ~fix:(List.rev !fix_edits))
+          (mk_result_with_fix_exempt ~src:s ~id:"CJK-010" ~severity:Warning
+             ~message:msg ~count:!cnt ~fix:(List.rev !fix_edits))
     else None
   in
   { id = "CJK-010"; run; languages = [ "zh"; "ja"; "ko" ] }
@@ -3947,8 +3947,8 @@ let r_cjk_014 : rule =
         Some (mk_result ~id:"CJK-014" ~severity:Info ~message:msg ~count:!cnt)
       else
         Some
-          (mk_result_with_fix ~id:"CJK-014" ~severity:Info ~message:msg
-             ~count:!cnt ~fix:(List.rev !fix_edits))
+          (mk_result_with_fix_exempt ~src:s ~id:"CJK-014" ~severity:Info
+             ~message:msg ~count:!cnt ~fix:(List.rev !fix_edits))
     else None
   in
   { id = "CJK-014"; run; languages = [ "zh"; "ja"; "ko" ] }

--- a/latex-parse/src/validators_l0_typo.ml
+++ b/latex-parse/src/validators_l0_typo.ml
@@ -377,7 +377,7 @@ let r_typo_006 : rule =
              ~message:"Tab character U+0009 forbidden" ~count:cnt)
       else
         Some
-          (mk_result_with_fix ~id:"TYPO-006" ~severity:Error
+          (mk_result_with_fix_exempt ~src:s ~id:"TYPO-006" ~severity:Error
              ~message:"Tab character U+0009 forbidden" ~count:cnt ~fix)
     else None
   in
@@ -731,7 +731,7 @@ let r_typo_014 : rule =
              ~message:{|Space before percent sign \%|} ~count:cnt)
       else
         Some
-          (mk_result_with_fix ~id:"TYPO-014" ~severity:Info
+          (mk_result_with_fix_exempt ~src:s ~id:"TYPO-014" ~severity:Info
              ~message:{|Space before percent sign \%|} ~count:cnt ~fix)
     else None
   in
@@ -1154,7 +1154,7 @@ let r_typo_025 : rule =
              ~message:{|Space before en‑dash in number range|} ~count:!cnt)
       else
         Some
-          (mk_result_with_fix ~id:"TYPO-025" ~severity:Warning
+          (mk_result_with_fix_exempt ~src:s ~id:"TYPO-025" ~severity:Warning
              ~message:{|Space before en‑dash in number range|} ~count:!cnt ~fix)
     else None
   in
@@ -1342,7 +1342,7 @@ let r_typo_029 : rule =
              ~message:{|Non‑breaking space after \ref missing|} ~count:cnt)
       else
         Some
-          (mk_result_with_fix ~id:"TYPO-029" ~severity:Info
+          (mk_result_with_fix_exempt ~src:s ~id:"TYPO-029" ~severity:Info
              ~message:{|Non‑breaking space after \ref missing|} ~count:cnt ~fix)
     else None
   in
@@ -1550,8 +1550,8 @@ let r_typo_035 : rule =
         Some (mk_result ~id:"TYPO-035" ~severity:Warning ~message ~count:cnt)
       else
         Some
-          (mk_result_with_fix ~id:"TYPO-035" ~severity:Warning ~message
-             ~count:cnt ~fix)
+          (mk_result_with_fix_exempt ~src:s ~id:"TYPO-035" ~severity:Warning
+             ~message ~count:cnt ~fix)
     else None
   in
   { id = "TYPO-035"; run; languages = [] }

--- a/latex-parse/src/validators_l1.ml
+++ b/latex-parse/src/validators_l1.ml
@@ -1193,7 +1193,7 @@ let l1_script_016_rule : rule =
              ~message:{|Prime on Greek letter typed '' not ^\prime|} ~count:!cnt)
       else
         Some
-          (mk_result_with_fix ~id:"SCRIPT-016" ~severity:Info
+          (mk_result_with_fix_vcu_exempt ~src:s ~id:"SCRIPT-016" ~severity:Info
              ~message:{|Prime on Greek letter typed '' not ^\prime|} ~count:!cnt
              ~fix)
     else None

--- a/latex-parse/src/validators_l1_math.ml
+++ b/latex-parse/src/validators_l1_math.ml
@@ -127,7 +127,7 @@ let l1_math_010_rule : rule =
              ~count:!cnt)
       else
         Some
-          (mk_result_with_fix ~id:"MATH-010" ~severity:Warning
+          (mk_result_with_fix_vcu_exempt ~src:s ~id:"MATH-010" ~severity:Warning
              ~message:{|Division symbol ÷ used; prefer \frac or solidus|}
              ~count:!cnt ~fix)
     else None
@@ -322,7 +322,7 @@ let l1_math_014_rule : rule =
              ~message:{|Inline \frac in running text|} ~count:cnt)
       else
         Some
-          (mk_result_with_fix ~id:"MATH-014" ~severity:Info
+          (mk_result_with_fix_vcu_exempt ~src:s ~id:"MATH-014" ~severity:Info
              ~message:{|Inline \frac in running text|} ~count:cnt ~fix)
     else None
   in
@@ -366,7 +366,7 @@ let l1_math_015_rule : rule =
              ~message:{|\stackrel used; prefer \overset|} ~count:!cnt)
       else
         Some
-          (mk_result_with_fix ~id:"MATH-015" ~severity:Warning
+          (mk_result_with_fix_vcu_exempt ~src:s ~id:"MATH-015" ~severity:Warning
              ~message:{|\stackrel used; prefer \overset|} ~count:!cnt ~fix)
     else None
   in
@@ -1284,7 +1284,7 @@ let l1_math_053_rule : rule =
              ~message:{|Space after \left( at line start|} ~count:cnt)
       else
         Some
-          (mk_result_with_fix ~id:"MATH-053" ~severity:Info
+          (mk_result_with_fix_vcu_exempt ~src:s ~id:"MATH-053" ~severity:Info
              ~message:{|Space after \left( at line start|} ~count:cnt ~fix)
     else None
   in
@@ -1519,7 +1519,7 @@ let l1_math_078_rule : rule =
              ~count:!cnt)
       else
         Some
-          (mk_result_with_fix ~id:"MATH-078" ~severity:Info
+          (mk_result_with_fix_vcu_exempt ~src:s ~id:"MATH-078" ~severity:Info
              ~message:{|Long arrow typed as --> instead of \longrightarrow|}
              ~count:!cnt ~fix)
     else None
@@ -1618,7 +1618,7 @@ let l1_math_082_rule : rule =
              ~count:!cnt)
       else
         Some
-          (mk_result_with_fix ~id:"MATH-082" ~severity:Warning
+          (mk_result_with_fix_vcu_exempt ~src:s ~id:"MATH-082" ~severity:Warning
              ~message:{|Negative thin space \! misused twice consecutively|}
              ~count:!cnt ~fix)
     else None
@@ -2440,7 +2440,7 @@ let l1_math_097_rule : rule =
              ~message:{|Arrow '=>' typed instead of \implies|} ~count:!cnt)
       else
         Some
-          (mk_result_with_fix ~id:"MATH-097" ~severity:Info
+          (mk_result_with_fix_vcu_exempt ~src:s ~id:"MATH-097" ~severity:Info
              ~message:{|Arrow '=>' typed instead of \implies|} ~count:!cnt ~fix)
     else None
   in
@@ -2536,7 +2536,7 @@ let l1_math_106_rule : rule =
              ~message:{|Misuse of \not=; prefer \neq|} ~count:!cnt)
       else
         Some
-          (mk_result_with_fix ~id:"MATH-106" ~severity:Info
+          (mk_result_with_fix_vcu_exempt ~src:s ~id:"MATH-106" ~severity:Info
              ~message:{|Misuse of \not=; prefer \neq|} ~count:!cnt ~fix)
     else None
   in
@@ -2576,7 +2576,7 @@ let l1_math_108_rule : rule =
              ~count:!cnt)
       else
         Some
-          (mk_result_with_fix ~id:"MATH-108" ~severity:Info
+          (mk_result_with_fix_vcu_exempt ~src:s ~id:"MATH-108" ~severity:Info
              ~message:{|Scalar product uses • (⋅) directly; require \cdot|}
              ~count:!cnt ~fix)
     else None

--- a/scripts/tools/check_verbatim_safety.py
+++ b/scripts/tools/check_verbatim_safety.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""check_verbatim_safety.py — protected-region (verbatim/comment/url) corruption gate.
+
+A fix producer must NEVER rewrite bytes the author wrote *literally*: inside a
+`verbatim`/`lstlisting`/`minted` environment, an inline `\\verb|..|` /
+`\\lstinline|..|`, a `%` line comment, or a `\\url{..}` target. Replacing a
+literal U+2212 with `-`, deleting a control byte, collapsing spaces, or rewriting
+`\\frac` inside such a region changes content the user deliberately typed — a
+silent corruption the lint-output differential cannot see (it only checks which
+rules fire and how many times, never what `--apply-fixes` *produces*).
+
+Most CHAR/CJK/ENC/TYPO character-replacement producers predate the P3 exempt
+layer and had this bug (30 confirmed in the v27.1.4 audit). The fix routed each
+through `Validators_common.mk_result_with_fix_exempt`, which drops any edit whose
+offset falls in a verbatim/comment/url/math range. This gate locks that in: it
+plants a battery of every known producer trigger between unique sentinels inside
+each protected-region kind, runs `--apply-fixes` (pilot AND default), and asserts
+the bytes between the sentinels are byte-identical afterwards. Any producer —
+existing or newly added — that corrupts a protected region fails the gate.
+
+Exit 0 if every protected region is preserved, 1 otherwise (listing each
+corrupted region with a before/after diff so the offending bytes are obvious).
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+import tempfile
+
+# A battery of byte sequences that fix producers are known to replace / delete /
+# collapse / insert-around. The point is breadth: if ANY producer fires inside a
+# protected region, the bytes between the sentinels change and the gate trips.
+# Grouped by family with a comment naming representative rule(s).
+BATTERY = (
+    b"ctl\x01here "  # CHAR-005 control U+0001
+    b"bell\x07 bs\x08 ff\x0c del\x7f "  # CHAR-006/007/008/009
+    b"zwj\xe2\x80\x8d lri\xe2\x81\xa6 lrm\xe2\x80\x8e bom\xef\xbb\xbf "  # CHAR-012/013/014, ENC-002/020
+    b"cp1252\x91\x92\x93\x94 "  # ENC-004 Windows-1252 C1 bytes
+    b"cjkcomma\xef\xbc\x8c cjkperiod\xef\xbc\x8e ideospace\xe3\x80\x80 "  # CJK-001/002/008
+    b"cjkpunct\xe3\x80\x81\xe3\x80\x82 middot\xe3\x83\xbb "  # CHAR-016, CJK-014/015
+    b"fwA\xef\xbc\xa1 fwB\xef\xbc\xa2 ligfi\xef\xac\x81 ligfl\xef\xac\x82 "  # CHAR-017/018
+    b"minus\xe2\x88\x92 times\xc3\x97 "  # CHAR-019 / MATH-083, TYPO-061
+    b"dash--range ellipsis... quotes''or`` "  # TYPO-002/026, TYPO-005, TYPO-004
+    b"angle<x>y amp&z "  # TYPO-052, TYPO-023
+    b"spaces   here trailing  \ttab\there "  # SPC-*/TYPO-018 whitespace
+    b"mathfrac$\\frac{a}{b}$ prime$\\alpha''$ "  # MATH-014 / SCRIPT-016 (math inside verbatim)
+)
+
+# Each protected region: (name, prefix_before_battery, suffix_after_battery).
+# Sentinels SREG_A .. bracket the battery so we can extract its exact bytes from
+# the (possibly offset-shifted) output without tracking edit positions.
+REGIONS = [
+    ("verbatim-env", b"\\begin{verbatim}\nSREG_VA ", b" SREG_VB\n\\end{verbatim}\n"),
+    ("lstlisting", b"\\begin{lstlisting}\nSREG_LA ", b" SREG_LB\n\\end{lstlisting}\n"),
+    ("inline-verb", b"text \\verb|SREG_IA ", b" SREG_IB| more\n"),
+    ("comment", b"%% SREG_CA ", b" SREG_CB\n"),
+    ("url", b"see \\url{http://x/SREG_UA", b"SREG_UB} ok\n"),
+]
+
+
+def build_torture() -> bytes:
+    out = [b"\\documentclass{article}\n"]
+    for _name, pre, suf in REGIONS:
+        out.append(pre + BATTERY + suf)
+    return b"".join(out)
+
+
+def cli(repo: str) -> str:
+    return os.path.join(repo, "_build/default/latex-parse/src/validators_cli.exe")
+
+
+def apply_fixes(binp: str, data: bytes, env) -> bytes:
+    with tempfile.NamedTemporaryFile("wb", suffix=".tex", delete=False) as t:
+        t.write(data)
+        tp = t.name
+    try:
+        r = subprocess.run([binp, "--apply-fixes", tp], capture_output=True, env=env)
+        # drop the leading "# profile=..." banner lines
+        lines = [ln for ln in r.stdout.split(b"\n") if not ln.startswith(b"# ")]
+        return b"\n".join(lines)
+    finally:
+        os.unlink(tp)
+
+
+def between(data: bytes, a: bytes, b: bytes):
+    i = data.find(a)
+    j = data.find(b, i + len(a)) if i >= 0 else -1
+    if i < 0 or j < 0:
+        return None
+    return data[i + len(a) : j]
+
+
+def check(binp: str, env, label: str, violations: list) -> None:
+    src = build_torture()
+    out = apply_fixes(binp, src, env)
+    for name, pre, suf in REGIONS:
+        # sentinels are the first token after pre and last before suf
+        sa = pre.split()[-1]
+        sb = suf.split()[0]
+        want = between(src, sa, sb)
+        got = between(out, sa, sb)
+        if want is None:
+            continue
+        if got is None:
+            violations.append(f"[{label}] {name}: region vanished (sentinels {sa!r}/{sb!r} missing in output)")
+        elif got != want:
+            violations.append(
+                f"[{label}] {name}: protected content CORRUPTED\n"
+                f"      before: {want!r}\n      after : {got!r}"
+            )
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--repo", default=".")
+    ns = ap.parse_args()
+    binp = cli(ns.repo)
+    if not os.path.isfile(binp):
+        subprocess.run(
+            ["opam", "exec", "--", "dune", "build", "latex-parse/src/validators_cli.exe"],
+            cwd=ns.repo, check=False,
+        )
+    if not os.path.isfile(binp):
+        print("[verbatim-safety] FAIL: validators_cli.exe not built", file=sys.stderr)
+        return 1
+
+    violations: list = []
+    pilot = dict(os.environ, L0_VALIDATORS="pilot")
+    default = dict(os.environ)
+    default.pop("L0_VALIDATORS", None)
+    check(binp, pilot, "pilot", violations)
+    check(binp, default, "default", violations)
+
+    if violations:
+        print(
+            f"[verbatim-safety] FAIL: {len(violations)} protected-region corruption(s). "
+            f"A fix producer rewrote literal bytes inside verbatim/\\verb/comment/url. "
+            f"Route its fix through Validators_common.mk_result_with_fix_exempt "
+            f"(or filter offsets by is_in_exempt_range):",
+            file=sys.stderr,
+        )
+        for v in violations:
+            print(f"  {v}", file=sys.stderr)
+        return 1
+    print(
+        "[verbatim-safety] PASS: all verbatim / lstlisting / \\verb / comment / url "
+        "regions byte-preserved under --apply-fixes (pilot + default)."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tools/pre_release_check.py
+++ b/scripts/tools/pre_release_check.py
@@ -83,6 +83,12 @@ BUILD_CHECKS = [
     # corruption). The lint-only differential cannot see fix output.
     (["python3", "scripts/tools/check_apply_fixes_safety.py", "--repo", "."],
      "apply-fixes safety", None),
+    # Protected-region (verbatim / \verb / lstlisting / comment / url) corruption
+    # gate: no fix producer may rewrite literal bytes the author typed verbatim.
+    # Plants every known producer trigger inside each protected-region kind and
+    # asserts --apply-fixes leaves them byte-identical (pilot + default).
+    (["python3", "scripts/tools/check_verbatim_safety.py", "--repo", "."],
+     "verbatim safety", None),
 ]
 
 

--- a/specs/README.md
+++ b/specs/README.md
@@ -4,7 +4,7 @@
 
 | Directory / file | Contents |
 |------------------|----------|
-| `v27/` | **Current release** (v27.0.x — currently shipping the Bucket A fix-producer cadence; latest tag `v27.1.3`): master spec (`V27_REPO_EXACT_MASTER_SPEC.{md,yaml}`), cadence + ledger (`V27_FIX_PRODUCER_CADENCE.md`, `FIX_PRODUCER_LEDGER.md`), faithful-semantics / L3-AST / apply-edits / T5 / WS8 plan docs |
+| `v27/` | **Current release** (v27.0.x — currently shipping the Bucket A fix-producer cadence; latest tag `v27.1.4`): master spec (`V27_REPO_EXACT_MASTER_SPEC.{md,yaml}`), cadence + ledger (`V27_FIX_PRODUCER_CADENCE.md`, `FIX_PRODUCER_LEDGER.md`), faithful-semantics / L3-AST / apply-edits / T5 / WS8 plan docs |
 | `v26/` | Prior release (v26.2): master spec (`V26_REPO_EXACT_MASTER_SPEC.{md,yaml}`), `language_contract.{md,yaml}`, `compilation_guarantee_stack.md`, `compilation_profiles.yaml`, `partial_document_semantics.{md,yaml}`, `V26_2_PLAN.md` |
 | `REPO_EXACT_MISSING_ARCHITECTURE_MEMO_V26_V27.md` | Authoritative architecture memo (11 pieces, v26/v27 plan) |
 | `rules/` | `rules_v3.yaml` (660 rules, 644 non-reserved, 16 reserved), `rule_contracts.yaml` / `.json` (per-rule metadata), golden YAML test fixtures |

--- a/specs/rules/README.md
+++ b/specs/rules/README.md
@@ -40,7 +40,7 @@
   - Impl: 6
   - Reserved: 16 (future families; do not implement yet)
 - Fix producers (`produces_fix: true` in `rule_contracts.yaml`): 104 as of
-  v27.1.3.  See `../v27/V27_FIX_PRODUCER_CADENCE.md` for cadence and
+  v27.1.4.  See `../v27/V27_FIX_PRODUCER_CADENCE.md` for cadence and
   `../v27/FIX_PRODUCER_LEDGER.md` for the per-rule shipping ledger.
 
 ## Implementation Guidance (When to Start)

--- a/specs/v27/V27_FIX_PRODUCER_CADENCE.md
+++ b/specs/v27/V27_FIX_PRODUCER_CADENCE.md
@@ -1,7 +1,7 @@
 # V27_FIX_PRODUCER_CADENCE — Rolling fix-producer extension to full coverage
 
 **Goal:** Bring the catalogue of 660 lint rules from the 32 fix-producing
-rules at plan authoring (104 shipped as of v27.1.3) to full coverage where
+rules at plan authoring (104 shipped as of v27.1.4) to full coverage where
 mechanically safe, with
 explicit deferral of NLP-required and unsafe-without-context rules.
 
@@ -146,7 +146,7 @@ from `FIX_PRODUCER_LEDGER.md`, ship, update.
   v27.0.5+**; enforced every release cycle via
   `scripts/tools/run_differential_test.py`.
 - [ ] Bucket A shipped fully by v27.2.0 (target).  **IN PROGRESS** —
-  104/458 (~23%) shipped as of v27.1.3.  Original v27.2.0 target
+  104/458 (~23%) shipped as of v27.1.4.  Original v27.2.0 target
   assumed ≥10 producers/release; at the actual cadence pace this
   milestone is on track for a later release.
 - [ ] Bucket B + C shipped fully by v27.4.0 (target).  **NOT


### PR DESCRIPTION
## Summary

A whole class of older fix producers (predating the P3 context layer) silently **rewrote bytes the author wrote literally** — inside `verbatim`/`lstlisting`/`minted`, inline `\verb|..|`, `%` comments, and `\url{..}` targets. Replacing a fullwidth char with ASCII, deleting a control byte/BOM, expanding a tab, or (for math-targeting rules) rewriting `\frac`/`''` inside a `$..$` that sits in a verbatim block all corrupt literal content — a class the lint-output differential cannot see (it only checks *which* rules fire, never what `--apply-fixes` *produces*).

An exhaustive audit (per-rule empirical + a torture-document sweep) found **~46 affected producers**, all fixed here. **No producers added; counts unchanged.**

## Fix

Two shared constructors in `Validators_common`:
- **`mk_result_with_fix_exempt`** — drops every fix edit inside verbatim/`\verb`/comment/url/**math**; for prose char/whitespace producers. Applied to 32: `CHAR-005..019`, `CJK-001/002/010/014`, `ENC-002/004/007/012/016..024`, `TYPO-006/014/025/029/035`, `SPC-003/005`.
- **`mk_result_with_fix_vcu_exempt`** — drops only verbatim/comment/url, **keeping** genuine in-math edits; for MATH-targeting producers. Applied to 10 `MATH-*` + `SCRIPT-016`.

The **diagnostic count is untouched** in every case (the occurrence is still tallied; only the *fix* is withheld inside protected regions), so default-mode lint output is byte-identical.

## Permanent gate — never again

New **`scripts/tools/check_verbatim_safety.py`** (wired into `pre_release_check`) plants a battery of every known producer trigger (control chars, CJK, fullwidth, ligatures, minus, BOM, dashes, quotes, whitespace, **tabs**, and `$math$`) between sentinels inside each protected-region kind, runs `--apply-fixes` (pilot + default), and **fails if a single byte changes**. This catches existing *and newly added* producers — the gate found ENC-002, the math-`$`-in-verbatim class, and a tab converter that the manual audit missed.

## Validation
- **Gate: PASS** — all verbatim/lstlisting/`\verb`/comment/url regions byte-preserved (pilot + default).
- **Differential: 0 diffs** vs v27.1.3 across 330 corpus files (no count changed).
- Build clean; producer count unchanged at 104.