### PR TITLE
feat(v27.1.5): 11 catalog-distinct fix producers (104 → 115)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 All notable changes to LaTeX Perfectionist are documented here.
 
+## [v27.1.5] — 2026-06-29
+
+**11 new catalog-distinct fix producers (104 → 115).** Implements the fix for 11
+rules that an earlier pass had wrongly dismissed as "redundant" — the catalogue
+ground truth (`conflicts_with` is empty for every one of them) shows they are
+distinct rules intended to coexist; where two producers emit the same edit it
+deduplicates at apply time, it is never a conflict.
+
+- **MATH-083** (`replace_with_hyphen`) — text-mode U+2212 → ASCII `-` (coexists
+  with CHAR-019; identical edits dedup).
+- **SCRIPT-019** (`replace_with_prime`) — bare `''` in math → `^{\prime\prime}`
+  (triple+ primes left to SCRIPT-012/022).
+- **SCRIPT-001** (`wrap_in_braces`) — multi-char subscript `x_12` → `x_{12}`.
+- **TYPO-023** (`escape_ampersand`) — bare `&` outside a tabular/array env → `\&`.
+- **TYPO-062** (`escape_backslash`) — literal backslash → `\textbackslash{}`,
+  **conservatively** (never rewrites a `\\` linebreak).
+- **SPC-006** (`convert_tabs`) — mixed space/tab indentation → spaces.
+- **SPC-018** (`insert_space`) — missing space after a sentence period.
+- **SPC-031** (`collapse_spaces`) — 3+ spaces after a period → one.
+- **SPC-034** (`remove_space`) — thin-space before an en-dash → removed.
+- **MATH-029** (`auto_replace`) — `eqnarray*`/`eqnarray` → `align*`/`align`.
+- **MATH-044** (`replace_with_symbol`) — `<=`/`>=` in math → `\le`/`\ge`.
+
+Each only ADDS a fix — diagnostic counts are untouched, so default-mode lint
+output is byte-identical (`run_differential_test.py`: 330 files, 0 diffs vs
+v27.1.4). Every producer is **verbatim-safety-gate clean** (built on the v27.1.4
+exempt/vcu layer) and idempotent. Implemented via worktree-isolated agents and
+applied to the tree under the full gate battery.
+
 ## [v27.1.4] — 2026-06-28
 
 **Verbatim/comment/url corruption safety fix — ~43 fix producers + permanent

--- a/README.md
+++ b/README.md
@@ -55,12 +55,12 @@ dune exec latex-parse/src/validators_cli.exe -- --layer l2 paper.tex
 | `L0_PROM_ADDR` | `127.0.0.1:9109` | Prometheus TCP bind address |
 | `L0_USE_SIMD_XXH` | unset | Set to `1` for SIMD xxHash acceleration |
 
-## Current Status — v27.1.4 (June 2026)
+## Current Status — v27.1.5 (June 2026)
 
 All layers (L0-L4) implemented. L3 file-based validators (PNG/JPEG/PDF/font). ML v2 byte classifier trained (F1=0.9799) and formally verified:
 - **Build**: `dune build` compiles the SIMD service, benches, and the Coq proof tree (55 core + 114 generated + 1 ML) via `(coq.theory)` stanzas.
 - **Proofs**: 170 Coq files, 1,400 theorems/lemmas. 644 per-rule soundness (637 faithful, 20 conservative, 3 conditional). 0 admits, 0 axioms. ML: `v2_span_extractor_sound` QED.
-- **Validators**: 644 rule IDs / 660 spec. 104 fix-producing rules (Bucket A rolling cadence). 19 L3 file-based + 12 expl3 rules.
+- **Validators**: 644 rule IDs / 660 spec. 115 fix-producing rules (Bucket A rolling cadence). 19 L3 file-based + 12 expl3 rules.
 - **Macros**: 520 production macros (441 symbols + 79 argsafe) with multi-arg support.
 - **ML Pipeline**: v2 ByteClassifier (CNN+BiLSTM, 538K params) trained on A100. F1=0.9799, precision=0.975, recall=0.985. Proved in `proofs/ML/SpanExtractorSound.v`.
 - **Performance**: Harnesses (`latex-parse/bench`, `scripts/perf_gate.sh`, `scripts/edit_window_gate.sh`) are in place. Latest runs on `perf_smoke_big` show p95 ≈ 2.73 ms (200 k iters) and ≈ 2.96 ms (1 M iters), with p99.9 ≈ 8.69 ms; the 4 KB edit-window bench lands at p95 ≈ 0.017 ms. See `core/l0_lexer/current_baseline_performance.json` and re-run after major changes.
@@ -227,7 +227,7 @@ bash scripts/latency_smoke_expand.sh 200
 
 ---
 
-**Status**: v27.1.4 released. 644 validators implemented, **104 fix-producing rules**, 1,400 theorems across 170 Coq files (0 admits, 0 axioms), ML v2 byte classifier trained (F1=0.9799, proved). Compile-guarantee contract + byte-lossless CST + rewrite engine + per-rule fix producers + conflict-aware merging live. v27 WS8 (final discharge of T6/T7 against `proofs/PdflatexModel.v`) shipped in v27.0.0; the `apply_edits` rewrite-engine universal correspondence between OCaml `Cst_edit.apply_all` and Coq `apply_edits_parallel` shipped in v27.0.4 (`apply_edits_cursor_eq_parallel` Theorem, Qed, Closed under the global context). The Bucket A fix-producer cadence has been rolling since v27.0.5, adding 1–3 producers per patch release; see [`specs/v27/V27_FIX_PRODUCER_CADENCE.md`](specs/v27/V27_FIX_PRODUCER_CADENCE.md) and [`specs/v27/FIX_PRODUCER_LEDGER.md`](specs/v27/FIX_PRODUCER_LEDGER.md) for per-rule shipping status and bucket assignments.
+**Status**: v27.1.5 released. 644 validators implemented, **115 fix-producing rules**, 1,400 theorems across 170 Coq files (0 admits, 0 axioms), ML v2 byte classifier trained (F1=0.9799, proved). Compile-guarantee contract + byte-lossless CST + rewrite engine + per-rule fix producers + conflict-aware merging live. v27 WS8 (final discharge of T6/T7 against `proofs/PdflatexModel.v`) shipped in v27.0.0; the `apply_edits` rewrite-engine universal correspondence between OCaml `Cst_edit.apply_all` and Coq `apply_edits_parallel` shipped in v27.0.4 (`apply_edits_cursor_eq_parallel` Theorem, Qed, Closed under the global context). The Bucket A fix-producer cadence has been rolling since v27.0.5, adding 1–3 producers per patch release; see [`specs/v27/V27_FIX_PRODUCER_CADENCE.md`](specs/v27/V27_FIX_PRODUCER_CADENCE.md) and [`specs/v27/FIX_PRODUCER_LEDGER.md`](specs/v27/FIX_PRODUCER_LEDGER.md) for per-rule shipping status and bucket assignments.
 
 ### First‑Token Latency (Tier A target ≤ 350 µs)
 

--- a/docs/PROOF_GUIDE.md
+++ b/docs/PROOF_GUIDE.md
@@ -141,7 +141,7 @@ Runs on every push and PR. Cannot be bypassed.
 
 ---
 
-## Current State (v27.1.4)
+## Current State (v27.1.5)
 
 - **1,400 theorems/lemmas** across 170 files
 - **637 faithful proofs** (VPD-pattern match, exact Coq model)

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,7 +15,7 @@ Comprehensive LaTeX document analysis and style validation system with 660 rules
 |--------|-------|
 | Rules specified | 660 (16 reserved) |
 | Rules shipped | 644 / 660 |
-| Fix-producing rules | 104 (Bucket A rolling cadence, see [V27_FIX_PRODUCER_CADENCE.md](../specs/v27/V27_FIX_PRODUCER_CADENCE.md)) |
+| Fix-producing rules | 115 (Bucket A rolling cadence, see [V27_FIX_PRODUCER_CADENCE.md](../specs/v27/V27_FIX_PRODUCER_CADENCE.md)) |
 | Soundness theorems | 644 per-rule (637 faithful, 20 conservative, 3 conditional) |
 | Total theorems/lemmas | 1,400 across 170 Coq files |
 | Performance p95 (L1 expand) | ≈ 2.8 ms (gate: 20 ms, Tier A) |

--- a/dune-project
+++ b/dune-project
@@ -1,5 +1,5 @@
 (lang dune 3.10)
-(version 27.1.4)
+(version 27.1.5)
 (using coq 0.8)
 (name latex-perfectionist)
 (generate_opam_files true)

--- a/governance/project_facts.yaml
+++ b/governance/project_facts.yaml
@@ -1,4 +1,4 @@
-version: v27.1.4
+version: v27.1.5
 release_state: rc
 release_date: '2026-06-28'
 generated_by: scripts/tools/generate_project_facts.py

--- a/latex-parse/src/validators_l0.ml
+++ b/latex-parse/src/validators_l0.ml
@@ -1969,10 +1969,49 @@ let r_spc_006 : rule =
         !seen_space_after_tab
     in
     let _, matched = any_line_pred s has_mixed_indent in
-    if matched > 0 then
-      Some
-        (mk_result ~id:"SPC-006" ~severity:Info
-           ~message:"Indentation mixes spaces and tabs" ~count:matched)
+    if matched > 0 then (
+      (* v27.x: fix producer (catalog token [convert_tabs]). The count above is
+         UNCHANGED — it still counts lines whose leading whitespace places a
+         space after a tab. The fix converts each leading-indentation tab on a
+         matched line to 4 spaces (same convention as TYPO-006), normalising the
+         indentation to all-spaces so the space-after-tab mix disappears.
+         Idempotent: a re-run finds no tabs in the indent, so no further edits.
+         Tabs inside verbatim/comment/url/math are left untouched via the shared
+         exempt set, falling back to a diagnose-only result if every edit
+         drops. *)
+      let exempt = find_exempt_ranges s in
+      let len = String.length s in
+      let edits = ref [] in
+      let process_line line_start line_end =
+        let line = String.sub s line_start (line_end - line_start) in
+        if has_mixed_indent line then
+          let j = ref line_start in
+          while !j < line_end && (s.[!j] = ' ' || s.[!j] = '\t') do
+            if s.[!j] = '\t' && not (is_in_exempt_range exempt !j) then
+              edits :=
+                Cst_edit.replace ~start_offset:!j ~end_offset:(!j + 1) "    "
+                :: !edits;
+            incr j
+          done
+      in
+      let cur = ref 0 in
+      let i = ref 0 in
+      while !i < len do
+        if s.[!i] = '\n' then (
+          process_line !cur !i;
+          cur := !i + 1);
+        incr i
+      done;
+      if !cur < len then process_line !cur len;
+      let fix = List.rev !edits in
+      if fix = [] then
+        Some
+          (mk_result ~id:"SPC-006" ~severity:Info
+             ~message:"Indentation mixes spaces and tabs" ~count:matched)
+      else
+        Some
+          (mk_result_with_fix ~id:"SPC-006" ~severity:Info
+             ~message:"Indentation mixes spaces and tabs" ~count:matched ~fix))
     else None
   in
   { id = "SPC-006"; run; languages = [] }
@@ -2601,15 +2640,53 @@ let r_spc_030 : rule =
   in
   { id = "SPC-030"; run; languages = [] }
 
-(* SPC-031: Three spaces after period *)
+(* SPC-031: Three spaces after period.
+
+   v27: fix producer (catalog token `collapse_spaces`). Count semantic is
+   UNCHANGED: `count_substring (strip_math_segments s) ". "` — one per period
+   followed by >=3 ASCII spaces, in math-stripped text. The fix collapses each
+   such run of spaces to a single space, building edits over the ORIGINAL source
+   `s` (absolute offsets) and dropping any edit that lands in an exempt range
+   (verbatim/\verb/comment/url/math) via `find_exempt_ranges`, falling back to
+   the diagnose-only result if every edit is dropped. Replacing a run of >=3
+   spaces with a single space is idempotent: a second pass finds no `. `. *)
 let r_spc_031 : rule =
   let run s =
-    let s = strip_math_segments s in
-    let cnt = count_substring s ".   " in
-    if cnt > 0 then
-      Some
-        (mk_result ~id:"SPC-031" ~severity:Info
-           ~message:"Three spaces after period" ~count:cnt)
+    let stripped = strip_math_segments s in
+    let cnt = count_substring stripped ".   " in
+    if cnt > 0 then (
+      let n = String.length s in
+      let exempt = find_exempt_ranges s in
+      let edits = ref [] in
+      let i = ref 0 in
+      while !i <= n - 4 do
+        if
+          s.[!i] = '.'
+          && s.[!i + 1] = ' '
+          && s.[!i + 2] = ' '
+          && s.[!i + 3] = ' '
+        then (
+          (* span the full run of ASCII spaces following the period *)
+          let j = ref (!i + 1) in
+          while !j < n && s.[!j] = ' ' do
+            incr j
+          done;
+          if not (is_in_exempt_range exempt !i) then
+            edits :=
+              Cst_edit.replace ~start_offset:(!i + 1) ~end_offset:!j " "
+              :: !edits;
+          i := !j)
+        else incr i
+      done;
+      let fix = List.rev !edits in
+      if fix = [] then
+        Some
+          (mk_result ~id:"SPC-031" ~severity:Info
+             ~message:"Three spaces after period" ~count:cnt)
+      else
+        Some
+          (mk_result_with_fix ~id:"SPC-031" ~severity:Info
+             ~message:"Three spaces after period" ~count:cnt ~fix))
     else None
   in
   { id = "SPC-031"; run; languages = [] }
@@ -2673,10 +2750,31 @@ let r_spc_034 : rule =
       + count_substring s "\xe2\x80\x89--"
     in
     if cnt > 0 then
-      Some
-        (mk_result ~id:"SPC-034" ~severity:Info
-           ~message:"Thin‑space before en‑dash in command‑line flags removed"
-           ~count:cnt)
+      (* Fix (remove_space): delete the U+2009 thin-space (3 bytes) before each
+         en-dash; the en-dash itself is preserved. The count above is computed
+         exactly as before (diagnostic semantics unchanged); only a fix-set is
+         added. Edits inside verbatim/comment/url/math are dropped via the
+         shared exempt ranges (prose-targeting rule). *)
+      let exempt = find_exempt_ranges s in
+      let offsets =
+        find_all_non_overlapping s "\xe2\x80\x89\xe2\x80\x93"
+        @ find_all_non_overlapping s "\xe2\x80\x89--"
+      in
+      let edits =
+        List.filter_map
+          (fun off ->
+            if is_in_exempt_range exempt off then None
+            else Some (Cst_edit.delete ~start_offset:off ~end_offset:(off + 3)))
+          offsets
+      in
+      let edits = List.sort Cst_edit.compare edits in
+      let message = "Thin‑space before en‑dash in command‑line flags removed" in
+      if edits = [] then
+        Some (mk_result ~id:"SPC-034" ~severity:Info ~message ~count:cnt)
+      else
+        Some
+          (mk_result_with_fix ~id:"SPC-034" ~severity:Info ~message ~count:cnt
+             ~fix:edits)
     else None
   in
   { id = "SPC-034"; run; languages = [] }
@@ -2794,23 +2892,52 @@ let r_spc_010 : rule =
   in
   { id = "SPC-010"; run; languages = [] }
 
-(* SPC-018: No space after sentence-ending period (period+uppercase) *)
+(* SPC-018: No space after sentence-ending period (period+uppercase).
+
+   v27.1.x: fix producer (insert_space). The diagnostic COUNT is computed
+   exactly as before — over [strip_math_segments s], so default-mode lint output
+   is byte-identical. The fix is computed separately by re-scanning the ORIGINAL
+   source [s] for the same `\.[A-Z]` pattern and inserting a single space
+   between the period and the uppercase letter (absolute byte offsets). Matches
+   inside math/verbatim/comment/url are dropped via the shared exempt set
+   ([find_exempt_ranges] / [is_in_exempt_range]); if every edit is exempt we
+   fall back to a fixless result. Idempotent: after the insert the bytes read `.
+   X`, which no longer matches `\.[A-Z]`. *)
 let r_spc_018 : rule =
   let re = Re_compat.regexp "\\.[A-Z]" in
   let run s =
-    let s = strip_math_segments s in
+    let s_stripped = strip_math_segments s in
     let rec loop i acc =
       try
-        let _mr, _ = Re_compat.search_forward re s i in
+        let _mr, _ = Re_compat.search_forward re s_stripped i in
         ignore _mr;
         loop (Re_compat.match_end _mr) (acc + 1)
       with Not_found -> acc
     in
     let cnt = loop 0 0 in
     if cnt > 0 then
-      Some
-        (mk_result ~id:"SPC-018" ~severity:Info
-           ~message:"No space after sentence‑ending period" ~count:cnt)
+      let exempt = find_exempt_ranges s in
+      let rec collect i acc =
+        try
+          let mr, _ = Re_compat.search_forward re s i in
+          let b = Re_compat.match_beginning mr in
+          let e = Re_compat.match_end mr in
+          let acc =
+            if is_in_exempt_range exempt b then acc
+            else Cst_edit.insert ~at:(b + 1) " " :: acc
+          in
+          collect e acc
+        with Not_found -> List.rev acc
+      in
+      let fix = collect 0 [] in
+      if fix = [] then
+        Some
+          (mk_result ~id:"SPC-018" ~severity:Info
+             ~message:"No space after sentence‑ending period" ~count:cnt)
+      else
+        Some
+          (mk_result_with_fix ~id:"SPC-018" ~severity:Info
+             ~message:"No space after sentence‑ending period" ~count:cnt ~fix)
     else None
   in
   { id = "SPC-018"; run; languages = [] }

--- a/latex-parse/src/validators_l0_typo.ml
+++ b/latex-parse/src/validators_l0_typo.ml
@@ -1050,11 +1050,68 @@ let r_typo_023 : rule =
       if !stripped.[i] = '&' && not (i > 0 && !stripped.[i - 1] = '\\') then
         incr cnt
     done;
-    if !cnt > 0 then
+    if !cnt > 0 then (
+      (* Fix producer (escape_ampersand): insert a backslash before each bare
+         `&` so it renders literally. The COUNT above is unchanged (computed on
+         the tabular-stripped string exactly as before). The fix edits are built
+         independently over the ORIGINAL string [s] at absolute byte offsets,
+         and are filtered so we NEVER escape an `&` that lives inside a
+         tabular/array/align/longtable environment (where `&` is a real column
+         separator) nor inside the shared exempt set (verbatim / \verb /
+         comments / url / math). Purely ADDITIVE single-char `\` insertion, so
+         it cannot corrupt surrounding bytes. Idempotent: after insertion the
+         byte before the `&` is `\`, so the bare-`&` test fails on re-run →
+         --apply-fixes twice is a no-op. *)
+      let slen = String.length s in
+      (* Recompute the tabular/array/align regions in ORIGINAL coordinates (the
+         count's [stripped] copy lost the offsets). Forward, non-overlapping
+         scan mirroring the stripping loop above. *)
+      let removed = ref [] in
+      (try
+         let pos = ref 0 in
+         while true do
+           let _mr, start_pos = Re_compat.search_forward tabular_re s !pos in
+           try
+             let _mr2, end_pos = Re_compat.search_forward end_re s start_pos in
+             let end_pos =
+               try
+                 let _mr3, _ =
+                   Re_compat.search_forward _re_close_brace s end_pos
+                 in
+                 Re_compat.match_end _mr3
+               with Not_found -> end_pos + 10
+             in
+             let end_pos = if end_pos > slen then slen else end_pos in
+             removed := (start_pos, end_pos) :: !removed;
+             pos := end_pos
+           with Not_found ->
+             removed := (start_pos, slen) :: !removed;
+             raise Not_found
+         done
+       with Not_found -> ());
+      let in_removed off =
+        List.exists (fun (a, b) -> off >= a && off < b) !removed
+      in
+      let exempt = find_exempt_ranges s in
+      let edits = ref [] in
+      for i = slen - 1 downto 0 do
+        if
+          s.[i] = '&'
+          && (not (i > 0 && s.[i - 1] = '\\'))
+          && (not (in_removed i))
+          && not (is_in_exempt_range exempt i)
+        then edits := Cst_edit.insert ~at:i "\\" :: !edits
+      done;
       Some
-        (mk_result ~id:"TYPO-023" ~severity:Error
-           ~message:{|ASCII ampersand & outside tabular env; use \&|}
-           ~count:!cnt)
+        (match !edits with
+        | [] ->
+            mk_result ~id:"TYPO-023" ~severity:Error
+              ~message:{|ASCII ampersand & outside tabular env; use \&|}
+              ~count:!cnt
+        | fix ->
+            mk_result_with_fix ~id:"TYPO-023" ~severity:Error
+              ~message:{|ASCII ampersand & outside tabular env; use \&|}
+              ~count:!cnt ~fix))
     else None
   in
   { id = "TYPO-023"; run; languages = [] }

--- a/latex-parse/src/validators_l1.ml
+++ b/latex-parse/src/validators_l1.ml
@@ -701,6 +701,39 @@ let l1_delim_011_rule : rule =
 let l1_script_001_rule : rule =
   (* Match _X where X is 2+ alphanumeric chars not wrapped in braces *)
   let re = Re_compat.regexp {|_\([A-Za-z0-9][A-Za-z0-9]+\)|} in
+  (* Fix edits (catalog token: wrap_in_braces): for each bare multi-char
+     subscript `_XYZ` INSIDE math, wrap the run in braces → `_{XYZ}`. Computed
+     over the ORIGINAL source [s] with absolute byte offsets via
+     [find_math_ranges]/[is_in_math_range] (the rule fires inside math, so math
+     is NOT exempt). A vcu (verbatim/comment/url) filter drops any edit whose
+     `_` lands in a protected span — [find_math_ranges] is context-blind, so a
+     stray `$` in a comment could otherwise yield a spurious in-"math" offset
+     (this is the [mk_result_with_fix_vcu_exempt] semantic: keep in-math, drop
+     verbatim/comment/url). The diagnostic [cnt] below is UNCHANGED (still the
+     original [extract_math_segments] scan); the fix only narrows which
+     occurrences receive an edit. Idempotent: after `_{XYZ}` the byte following
+     `_` is `{`, which the regex (alphanumeric required) no longer matches. *)
+  let mk_fix_edits s =
+    let math = find_math_ranges s in
+    let vcu = find_verbatim_comment_url_ranges s in
+    let len = String.length s in
+    let edits = ref [] in
+    let i = ref 0 in
+    (try
+       while !i <= len do
+         let mr, pos = Re_compat.search_forward re s !i in
+         let e = Re_compat.match_end mr in
+         (if is_in_math_range math pos && not (is_in_exempt_range vcu pos) then
+            let run_str = String.sub s (pos + 1) (e - (pos + 1)) in
+            edits :=
+              Cst_edit.replace ~start_offset:pos ~end_offset:e
+                ("_{" ^ run_str ^ "}")
+              :: !edits);
+         i := if e > !i then e else !i + 1
+       done
+     with Not_found -> ());
+    List.rev !edits
+  in
   let run s =
     let math_segs = extract_math_segments s in
     let cnt = ref 0 in
@@ -718,9 +751,15 @@ let l1_script_001_rule : rule =
         with Not_found -> ())
       math_segs;
     if !cnt > 0 then
-      Some
-        (mk_result ~id:"SCRIPT-001" ~severity:Warning
-           ~message:"Multi‑char subscript without braces" ~count:!cnt)
+      let fix = mk_fix_edits s in
+      if fix = [] then
+        Some
+          (mk_result ~id:"SCRIPT-001" ~severity:Warning
+             ~message:"Multi‑char subscript without braces" ~count:!cnt)
+      else
+        Some
+          (mk_result_with_fix ~id:"SCRIPT-001" ~severity:Warning
+             ~message:"Multi‑char subscript without braces" ~count:!cnt ~fix)
     else None
   in
   { id = "SCRIPT-001"; run; languages = [] }
@@ -1259,6 +1298,42 @@ let l1_script_018_rule : rule =
 
 (* SCRIPT-019: Double prime '' instead of ^{\prime\prime} *)
 let l1_script_019_rule : rule =
+  (* Fix edits (catalog token [replace_with_prime]): each bare double-prime `''`
+     INSIDE math is rewritten to the proper superscript `^{\prime\prime}`. Only
+     a prime-run of EXACTLY length two is rewritten — the same restriction the
+     diagnostic [cnt] below applies (a triple+ run is owned by SCRIPT-012/022
+     and is skipped wholesale). Math membership is the positive filter
+     ([find_math_ranges] + [is_in_math_range], so math is NOT exempt here); the
+     fix is additionally withheld inside verbatim / line-comment / url spans
+     ([find_verbatim_comment_url_ranges] — the manual vcu-exempt for a
+     math-targeting fix) so a literal `''` in a code listing or `%`-comment is
+     never touched.
+
+     Count is preserved byte-identically: the loop below still scans
+     [extract_math_segments] unchanged; the fix is computed separately and only
+     narrows which counted occurrences receive an edit. An edit here is
+     byte-identical to SCRIPT-016's for a `\greek''` occurrence (same range,
+     same replacement), so [Cst_edit.dedup_identical] collapses the pair under
+     --apply-fixes. Idempotent: the output `^{\prime\prime}` contains no `'`, so
+     the rule cannot re-fire on it. *)
+  let mk_fix_edits s =
+    let len = String.length s in
+    let math = find_math_ranges s in
+    let vcu = find_verbatim_comment_url_ranges s in
+    let inside off = is_in_math_range math off in
+    let in_vcu off = is_in_math_range vcu off in
+    Validators_l0_typo.find_all_non_overlapping s "''"
+    |> List.filter (fun off ->
+           inside off
+           && (not (in_vcu off))
+           (* prime-run of EXACTLY two: must be the run start (no `'` before)
+              and not followed by a third `'` *)
+           && (off = 0 || s.[off - 1] <> '\'')
+           && not (off + 2 < len && s.[off + 2] = '\''))
+    |> List.map (fun off ->
+           Cst_edit.replace ~start_offset:off ~end_offset:(off + 2)
+             "^{\\prime\\prime}")
+  in
   let run s =
     let math_segs = extract_math_segments s in
     let cnt = ref 0 in
@@ -1283,9 +1358,16 @@ let l1_script_019_rule : rule =
         done)
       math_segs;
     if !cnt > 0 then
-      Some
-        (mk_result ~id:"SCRIPT-019" ~severity:Info
-           ~message:{|Double prime '' instead of ^{\prime\prime}|} ~count:!cnt)
+      let fix = mk_fix_edits s in
+      if fix = [] then
+        Some
+          (mk_result ~id:"SCRIPT-019" ~severity:Info
+             ~message:{|Double prime '' instead of ^{\prime\prime}|} ~count:!cnt)
+      else
+        Some
+          (mk_result_with_fix ~id:"SCRIPT-019" ~severity:Info
+             ~message:{|Double prime '' instead of ^{\prime\prime}|} ~count:!cnt
+             ~fix)
     else None
   in
   { id = "SCRIPT-019"; run; languages = [] }

--- a/latex-parse/src/validators_l1_math.ml
+++ b/latex-parse/src/validators_l1_math.ml
@@ -644,9 +644,43 @@ let l1_math_028_rule : rule =
   { id = "MATH-028"; run; languages = [] }
 
 (* MATH-029: Use of eqnarray / eqnarray* instead of align / align*. eqnarray is
-   deprecated — spacing around = is wrong. *)
+   deprecated — spacing around = is wrong. auto_replace fix: swap the
+   environment name `eqnarray`/`eqnarray*` → `align`/`align*` on BOTH the
+   `\begin{...}` and the matching `\end{...}` so the document stays well-formed.
+   The diagnostic count (number of `\begin{eqnarray}`/`\begin{eqnarray*}`
+   occurrences) is unchanged. Edits land on the environment delimiters, which
+   sit at the boundary of the math range, so we filter against verbatim /
+   comment / url ranges only (vcu-exempt) and KEEP in-math edits — a stray
+   `\begin{eqnarray}` inside a verbatim block is counted but not rewritten. *)
 let l1_math_029_rule : rule =
   let re = Re_compat.regexp {|\\begin{eqnarray\*?}|} in
+  (* (needle, replacement) pairs. Each exact string is distinct (the `*` and `}`
+     differ at the same offset) so no occurrence is matched twice. *)
+  let pairs =
+    [
+      ("\\begin{eqnarray*}", "\\begin{align*}");
+      ("\\begin{eqnarray}", "\\begin{align}");
+      ("\\end{eqnarray*}", "\\end{align*}");
+      ("\\end{eqnarray}", "\\end{align}");
+    ]
+  in
+  let mk_fix_edits s =
+    let vcu = find_verbatim_comment_url_ranges s in
+    let outside off = not (is_in_exempt_range vcu off) in
+    List.concat_map
+      (fun (needle, replacement) ->
+        let offsets =
+          List.filter outside
+            (Validators_l0_typo.find_all_non_overlapping s needle)
+        in
+        List.map
+          (fun off ->
+            Cst_edit.replace ~start_offset:off
+              ~end_offset:(off + String.length needle)
+              replacement)
+          offsets)
+      pairs
+  in
   let run s =
     let cnt = ref 0 in
     let i = ref 0 in
@@ -658,9 +692,15 @@ let l1_math_029_rule : rule =
        done
      with Not_found -> ());
     if !cnt > 0 then
-      Some
-        (mk_result ~id:"MATH-029" ~severity:Warning
-           ~message:"Use of eqnarray* instead of align*" ~count:!cnt)
+      let fix = mk_fix_edits s in
+      if fix = [] then
+        Some
+          (mk_result ~id:"MATH-029" ~severity:Warning
+             ~message:"Use of eqnarray* instead of align*" ~count:!cnt)
+      else
+        Some
+          (mk_result_with_fix ~id:"MATH-029" ~severity:Warning
+             ~message:"Use of eqnarray* instead of align*" ~count:!cnt ~fix)
     else None
   in
   { id = "MATH-029"; run; languages = [] }
@@ -985,18 +1025,65 @@ let l1_math_043_rule : rule =
   { id = "MATH-043"; run; languages = [] }
 
 (* MATH-044: Binary relation typed as text char — e.g. < for \le, = for \equiv,
-   etc., when text < > appear in math outside of delimiters *)
+   etc., when text < > appear in math outside of delimiters.
+
+   Fix producer (catalog fix: replace_with_symbol): inside math regions, the
+   ASCII relations `<=` / `>=` are replaced by their LaTeX symbols `\le ` / `\ge
+   ` (each 2 bytes → 4 bytes incl. a trailing space). The trailing space is
+   required so the control word does not glue to a following letter (`a<=b`
+   would otherwise become the undefined `\leb`); inside math spaces are ignored
+   by TeX, so the rendering is unaffected and the edit is idempotent (`<=` no
+   longer present after the replace).
+
+   The DIAGNOSE-ONLY count is untouched (same per-segment regex). The fix
+   offsets are computed independently over the ORIGINAL string via
+   `find_all_non_overlapping`, filtered to math ranges (`find_math_ranges`) and
+   to a non-backslash preceding byte (mirroring the regex's `[^\\]` guard), and
+   any edit inside verbatim/comment/url (`find_verbatim_comment_url_ranges`) is
+   dropped while in-math edits are kept. *)
 let l1_math_044_rule : rule =
   let re = Re_compat.regexp {|[^\\]<=\|[^\\]>=|} in
+  let repl_of needle = if needle = "<=" then "\\le " else "\\ge " in
+  let fix_offsets s =
+    let math = find_math_ranges s in
+    let vcu = find_verbatim_comment_url_ranges s in
+    let keep off =
+      off > 0
+      && s.[off - 1] <> '\\'
+      && is_in_math_range math off
+      && not (is_in_math_range vcu off)
+    in
+    let for_needle needle =
+      List.filter_map
+        (fun off -> if keep off then Some (off, needle) else None)
+        (Validators_l0_typo.find_all_non_overlapping s needle)
+    in
+    for_needle "<=" @ for_needle ">="
+  in
+  let mk_fix_edits s =
+    List.map
+      (fun (off, needle) ->
+        Cst_edit.replace ~start_offset:off
+          ~end_offset:(off + String.length needle)
+          (repl_of needle))
+      (fix_offsets s)
+  in
   let run s =
     let math_segs = extract_math_segments s in
     let cnt = ref 0 in
     List.iter (fun seg -> cnt := !cnt + count_re_matches re seg) math_segs;
     if !cnt > 0 then
-      Some
-        (mk_result ~id:"MATH-044" ~severity:Warning
-           ~message:{|Binary relation typed as text char (e.g. < for \le)|}
-           ~count:!cnt)
+      let fix = mk_fix_edits s in
+      if fix = [] then
+        Some
+          (mk_result ~id:"MATH-044" ~severity:Warning
+             ~message:{|Binary relation typed as text char (e.g. < for \le)|}
+             ~count:!cnt)
+      else
+        Some
+          (mk_result_with_fix ~id:"MATH-044" ~severity:Warning
+             ~message:{|Binary relation typed as text char (e.g. < for \le)|}
+             ~count:!cnt ~fix)
     else None
   in
   { id = "MATH-044"; run; languages = [] }

--- a/latex-parse/src/validators_l2.ml
+++ b/latex-parse/src/validators_l2.ml
@@ -5814,27 +5814,71 @@ let rules_user_macro : rule list = [ r_cmd_015; r_cmd_016; r_cmd_017 ]
 
 (* ── TYPO-062: Literal backslash in text ───────────────────────────── *)
 let r_typo_062 : rule =
-  let run s =
-    (* Count \textbackslash suggestions -- look for \\ not followed by a letter
-       (i.e. bare backslash, not a command) outside math *)
-    let s = strip_math_segments s in
+  (* v27.1.x: fix producer (catalog token `escape_backslash`). DETECTION IS
+     UNCHANGED — the count still scans `strip_math_segments s` for `\\` not
+     immediately followed by `[`/`*` (the heuristic linebreak filter). The fix
+     is deliberately CONSERVATIVE: a bare `\\` is almost always a LaTeX
+     linebreak, so we only rewrite an occurrence to `\textbackslash{}` when it
+     is genuinely a literal backslash — i.e. SANDWICHED between two ASCII word
+     characters (e.g. a path `Path\\file`), which a linebreak never is — and not
+     inside an exempt range (verbatim/comment/url/math). Fix offsets are thus a
+     strict subset of the counted occurrences (documented divergence, cf.
+     TYPO-053). Idempotent: after the rewrite the bytes are `\textbackslash{}`,
+     which contain no `\\`, so re-running --apply-fixes is a no-op. *)
+  let is_word c =
+    (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9')
+  in
+  let mk_fix_edits exempt s =
     let n = String.length s in
-    let cnt = ref 0 in
+    let edits = ref [] in
     let i = ref 0 in
     while !i < n - 1 do
       if s.[!i] = '\\' && s.[!i + 1] = '\\' then (
+        if
+          !i > 0
+          && !i + 2 < n
+          && is_word s.[!i - 1]
+          && is_word s.[!i + 2]
+          && not (is_in_exempt_range exempt !i)
+        then
+          edits :=
+            Cst_edit.replace ~start_offset:!i ~end_offset:(!i + 2)
+              "\\textbackslash{}"
+            :: !edits;
+        i := !i + 2)
+      else incr i
+    done;
+    List.rev !edits
+  in
+  let run s =
+    (* Count \textbackslash suggestions -- look for \\ not followed by a letter
+       (i.e. bare backslash, not a command) outside math *)
+    let s_stripped = strip_math_segments s in
+    let n = String.length s_stripped in
+    let cnt = ref 0 in
+    let i = ref 0 in
+    while !i < n - 1 do
+      if s_stripped.[!i] = '\\' && s_stripped.[!i + 1] = '\\' then (
         (* Check it's not a linebreak command like \\[2pt] or \\* *)
         if !i + 2 < n then (
-          let c = s.[!i + 2] in
+          let c = s_stripped.[!i + 2] in
           if c <> '[' && c <> '*' then incr cnt)
         else incr cnt;
         i := !i + 2)
       else incr i
     done;
     if !cnt > 0 then
-      Some
-        (mk_result ~id:"TYPO-062" ~severity:Warning
-           ~message:"Literal backslash in text; use \\textbackslash" ~count:!cnt)
+      let fix = mk_fix_edits (find_exempt_ranges s) s in
+      if fix = [] then
+        Some
+          (mk_result ~id:"TYPO-062" ~severity:Warning
+             ~message:"Literal backslash in text; use \\textbackslash"
+             ~count:!cnt)
+      else
+        Some
+          (mk_result_with_fix ~id:"TYPO-062" ~severity:Warning
+             ~message:"Literal backslash in text; use \\textbackslash"
+             ~count:!cnt ~fix)
     else None
   in
   { id = "TYPO-062"; run; languages = [] }
@@ -5845,14 +5889,32 @@ let r_typo_062 : rule =
    text or $-$ / \textminus in math context. We detect U+2212 (E2 88 92) outside
    of math mode segments. *)
 let r_math_083 : rule =
+  (* Fix (catalog: replace_with_hyphen): each text-mode U+2212 (E2 88 92, 3
+     bytes) → ASCII hyphen-minus `-`. Distinct catalog rule from CHAR-019 (no
+     conflicts_with edge); both fire and emit the same edit, which dedups at
+     apply time. Routed through [mk_result_with_fix_exempt] so the fix is
+     withheld inside verbatim/\verb/comment/url/math; the count is the untouched
+     [strip_math_segments]-based scan (differential 0-diff). Idempotent. *)
+  let mk_fix_edits s =
+    let n = String.length s in
+    let rec loop i acc =
+      if i > n - 3 then List.rev acc
+      else if s.[i] = '\xe2' && s.[i + 1] = '\x88' && s.[i + 2] = '\x92' then
+        loop (i + 3)
+          (Cst_edit.replace ~start_offset:i ~end_offset:(i + 3) "-" :: acc)
+      else loop (i + 1) acc
+    in
+    loop 0 []
+  in
   let run s =
     let s_text = strip_math_segments s in
     (* U+2212 MINUS SIGN = E2 88 92 *)
     let cnt = count_substring s_text "\xe2\x88\x92" in
     if cnt > 0 then
       Some
-        (mk_result ~id:"MATH-083" ~severity:Warning
-           ~message:"Unicode minus inside text mode" ~count:cnt)
+        (mk_result_with_fix_exempt ~id:"MATH-083" ~severity:Warning
+           ~message:"Unicode minus inside text mode" ~count:cnt ~src:s
+           ~fix:(mk_fix_edits s))
     else None
   in
   { id = "MATH-083"; run; languages = [] }

--- a/scripts/tools/generate_fix_producer_ledger.py
+++ b/scripts/tools/generate_fix_producer_ledger.py
@@ -133,6 +133,17 @@ SHIPPED_VERSIONS = {
     "TYPO-052": "v27.1.3",
     "TYPO-054": "v27.1.3",
     "SCRIPT-016": "v27.1.3",
+    "MATH-083": "v27.1.5",
+    "SCRIPT-019": "v27.1.5",
+    "SCRIPT-001": "v27.1.5",
+    "TYPO-023": "v27.1.5",
+    "TYPO-062": "v27.1.5",
+    "SPC-006": "v27.1.5",
+    "SPC-018": "v27.1.5",
+    "SPC-031": "v27.1.5",
+    "SPC-034": "v27.1.5",
+    "MATH-029": "v27.1.5",
+    "MATH-044": "v27.1.5",
 }
 
 # Explicitly NLP-deferred rules (Bucket B, marked "deferred (NLP)" in code).

--- a/specs/README.md
+++ b/specs/README.md
@@ -4,7 +4,7 @@
 
 | Directory / file | Contents |
 |------------------|----------|
-| `v27/` | **Current release** (v27.0.x — currently shipping the Bucket A fix-producer cadence; latest tag `v27.1.4`): master spec (`V27_REPO_EXACT_MASTER_SPEC.{md,yaml}`), cadence + ledger (`V27_FIX_PRODUCER_CADENCE.md`, `FIX_PRODUCER_LEDGER.md`), faithful-semantics / L3-AST / apply-edits / T5 / WS8 plan docs |
+| `v27/` | **Current release** (v27.0.x — currently shipping the Bucket A fix-producer cadence; latest tag `v27.1.5`): master spec (`V27_REPO_EXACT_MASTER_SPEC.{md,yaml}`), cadence + ledger (`V27_FIX_PRODUCER_CADENCE.md`, `FIX_PRODUCER_LEDGER.md`), faithful-semantics / L3-AST / apply-edits / T5 / WS8 plan docs |
 | `v26/` | Prior release (v26.2): master spec (`V26_REPO_EXACT_MASTER_SPEC.{md,yaml}`), `language_contract.{md,yaml}`, `compilation_guarantee_stack.md`, `compilation_profiles.yaml`, `partial_document_semantics.{md,yaml}`, `V26_2_PLAN.md` |
 | `REPO_EXACT_MISSING_ARCHITECTURE_MEMO_V26_V27.md` | Authoritative architecture memo (11 pieces, v26/v27 plan) |
 | `rules/` | `rules_v3.yaml` (660 rules, 644 non-reserved, 16 reserved), `rule_contracts.yaml` / `.json` (per-rule metadata), golden YAML test fixtures |

--- a/specs/rules/README.md
+++ b/specs/rules/README.md
@@ -39,8 +39,8 @@
   - Implemented: 19
   - Impl: 6
   - Reserved: 16 (future families; do not implement yet)
-- Fix producers (`produces_fix: true` in `rule_contracts.yaml`): 104 as of
-  v27.1.4.  See `../v27/V27_FIX_PRODUCER_CADENCE.md` for cadence and
+- Fix producers (`produces_fix: true` in `rule_contracts.yaml`): 115 as of
+  v27.1.5.  See `../v27/V27_FIX_PRODUCER_CADENCE.md` for cadence and
   `../v27/FIX_PRODUCER_LEDGER.md` for the per-rule shipping ledger.
 
 ## Implementation Guidance (When to Start)

--- a/specs/rules/rule_contracts.json
+++ b/specs/rules/rule_contracts.json
@@ -4550,7 +4550,7 @@
       "conflicts_with": [],
       "fix_scope": "local",
       "project_scope": "lp_core_or_extended",
-      "produces_fix": null
+      "produces_fix": true
     },
     {
       "rule_id": "MATH-030",
@@ -4820,7 +4820,7 @@
       "conflicts_with": [],
       "fix_scope": "local",
       "project_scope": "lp_core_or_extended",
-      "produces_fix": null
+      "produces_fix": true
     },
     {
       "rule_id": "MATH-045",
@@ -5522,7 +5522,7 @@
       "conflicts_with": [],
       "fix_scope": "local",
       "project_scope": "lp_core_or_extended",
-      "produces_fix": null
+      "produces_fix": true
     },
     {
       "rule_id": "MATH-084",
@@ -7508,7 +7508,7 @@
       "conflicts_with": [],
       "fix_scope": "local",
       "project_scope": "lp_core_or_extended",
-      "produces_fix": null
+      "produces_fix": true
     },
     {
       "rule_id": "SCRIPT-002",
@@ -7796,7 +7796,7 @@
       "conflicts_with": [],
       "fix_scope": "local",
       "project_scope": "lp_core_or_extended",
-      "produces_fix": null
+      "produces_fix": true
     },
     {
       "rule_id": "SCRIPT-020",
@@ -7940,7 +7940,7 @@
       "conflicts_with": [],
       "fix_scope": "local",
       "project_scope": "lp_core_or_extended",
-      "produces_fix": null
+      "produces_fix": true
     },
     {
       "rule_id": "SPC-007",
@@ -8136,7 +8136,7 @@
       "conflicts_with": [],
       "fix_scope": "local",
       "project_scope": "lp_core_or_extended",
-      "produces_fix": null
+      "produces_fix": true
     },
     {
       "rule_id": "SPC-019",
@@ -8345,7 +8345,7 @@
       "conflicts_with": [],
       "fix_scope": "local",
       "project_scope": "lp_core_or_extended",
-      "produces_fix": null
+      "produces_fix": true
     },
     {
       "rule_id": "SPC-032",
@@ -8393,7 +8393,7 @@
       "conflicts_with": [],
       "fix_scope": "local",
       "project_scope": "lp_core_or_extended",
-      "produces_fix": null
+      "produces_fix": true
     },
     {
       "rule_id": "SPC-035",
@@ -10272,7 +10272,7 @@
       "conflicts_with": [],
       "fix_scope": "document",
       "project_scope": "lp_core_or_extended",
-      "produces_fix": null
+      "produces_fix": true
     },
     {
       "rule_id": "TYPO-024",
@@ -10911,7 +10911,7 @@
       "conflicts_with": [],
       "fix_scope": "local",
       "project_scope": "lp_core_or_extended",
-      "produces_fix": null
+      "produces_fix": true
     },
     {
       "rule_id": "TYPO-063",

--- a/specs/rules/rule_contracts.yaml
+++ b/specs/rules/rule_contracts.yaml
@@ -3754,7 +3754,7 @@ rules:
   conflicts_with: []
   fix_scope: local
   project_scope: lp_core_or_extended
-  produces_fix: null
+  produces_fix: true
 - rule_id: MATH-030
   layer: L1_Expanded
   execution_class: B
@@ -3964,7 +3964,7 @@ rules:
   conflicts_with: []
   fix_scope: local
   project_scope: lp_core_or_extended
-  produces_fix: null
+  produces_fix: true
 - rule_id: MATH-045
   layer: L1_Expanded
   execution_class: B
@@ -4510,7 +4510,7 @@ rules:
   conflicts_with: []
   fix_scope: local
   project_scope: lp_core_or_extended
-  produces_fix: null
+  produces_fix: true
 - rule_id: MATH-084
   layer: L1_Expanded
   execution_class: B
@@ -6115,7 +6115,7 @@ rules:
   conflicts_with: []
   fix_scope: local
   project_scope: lp_core_or_extended
-  produces_fix: null
+  produces_fix: true
 - rule_id: SCRIPT-002
   layer: L1_Expanded
   execution_class: B
@@ -6349,7 +6349,7 @@ rules:
   conflicts_with: []
   fix_scope: local
   project_scope: lp_core_or_extended
-  produces_fix: null
+  produces_fix: true
 - rule_id: SCRIPT-020
   layer: L1_Expanded
   execution_class: B
@@ -6466,7 +6466,7 @@ rules:
   conflicts_with: []
   fix_scope: local
   project_scope: lp_core_or_extended
-  produces_fix: null
+  produces_fix: true
 - rule_id: SPC-007
   layer: L0_Lexer
   execution_class: A
@@ -6634,7 +6634,7 @@ rules:
   conflicts_with: []
   fix_scope: local
   project_scope: lp_core_or_extended
-  produces_fix: null
+  produces_fix: true
 - rule_id: SPC-019
   layer: L0_Lexer
   execution_class: A
@@ -6805,7 +6805,7 @@ rules:
   conflicts_with: []
   fix_scope: local
   project_scope: lp_core_or_extended
-  produces_fix: null
+  produces_fix: true
 - rule_id: SPC-032
   layer: L0_Lexer
   execution_class: A
@@ -6844,7 +6844,7 @@ rules:
   conflicts_with: []
   fix_scope: local
   project_scope: lp_core_or_extended
-  produces_fix: null
+  produces_fix: true
 - rule_id: SPC-035
   layer: L0_Lexer
   execution_class: A
@@ -8324,7 +8324,7 @@ rules:
   conflicts_with: []
   fix_scope: document
   project_scope: lp_core_or_extended
-  produces_fix: null
+  produces_fix: true
 - rule_id: TYPO-024
   layer: L0_Lexer
   execution_class: A
@@ -8840,7 +8840,7 @@ rules:
   conflicts_with: []
   fix_scope: local
   project_scope: lp_core_or_extended
-  produces_fix: null
+  produces_fix: true
 - rule_id: TYPO-063
   layer: L0_Lexer
   execution_class: A

--- a/specs/rules/rules_v3.yaml
+++ b/specs/rules/rules_v3.yaml
@@ -332,7 +332,7 @@
   description: "ASCII ampersand & outside tabular env; use \\&"
   precondition: L0_Lexer
   default_severity: Error
-  maturity: Draft
+  maturity: Implemented
   owner: "@lint-team"
   fix: escape_ampersand
 
@@ -644,7 +644,7 @@
   description: "Literal backslash in text; use \\textbackslash"
   precondition: L0_Lexer
   default_severity: Warning
-  maturity: Draft
+  maturity: Implemented
   owner: "@lint-team"
   fix: escape_backslash
 
@@ -705,7 +705,7 @@
   description: "Indentation mixes spaces and tabs"
   precondition: L0_Lexer
   default_severity: Info
-  maturity: Draft
+  maturity: Implemented
   owner: "@lint-team"
   fix: convert_tabs
 
@@ -801,7 +801,7 @@
   description: "No space after sentence‑ending period"
   precondition: L0_Lexer
   default_severity: Info
-  maturity: Draft
+  maturity: Implemented
   owner: "@style-council"
   fix: insert_space
 
@@ -905,7 +905,7 @@
   description: "Three spaces after period"
   precondition: L0_Lexer
   default_severity: Info
-  maturity: Draft
+  maturity: Implemented
   owner: "@style-council"
   fix: collapse_spaces
 
@@ -929,7 +929,7 @@
   description: "Thin‑space before en‑dash in command‑line flags removed"
   precondition: L0_Lexer
   default_severity: Info
-  maturity: Draft
+  maturity: Implemented
   owner: "@lint-team"
   fix: remove_space
 
@@ -1834,7 +1834,7 @@
   description: "Use of eqnarray* instead of align*"
   precondition: L2_Ast
   default_severity: Warning
-  maturity: Draft
+  maturity: Implemented
   owner: "@math-rules"
   fix: auto_replace
 
@@ -1954,7 +1954,7 @@
   description: "Binary relation typed as text char (e.g. < for \\le)"
   precondition: L1_Expanded
   default_severity: Warning
-  maturity: Draft
+  maturity: Implemented
   owner: "@math-rules"
   fix: replace_with_symbol
 
@@ -2266,7 +2266,7 @@
   description: "Unicode minus inside text mode"
   precondition: L0_Lexer
   default_severity: Warning
-  maturity: Draft
+  maturity: Implemented
   owner: "@math-rules"
   fix: replace_with_hyphen
 
@@ -2583,7 +2583,7 @@
   description: "Multi‑char subscript without braces"
   precondition: L1_Expanded
   default_severity: Warning
-  maturity: Draft
+  maturity: Implemented
   owner: "@math-rules"
   fix: wrap_in_braces
 
@@ -2727,7 +2727,7 @@
   description: "Double prime '' instead of ^{\\prime\\prime}"
   precondition: L1_Expanded
   default_severity: Info
-  maturity: Draft
+  maturity: Implemented
   owner: "@math-rules"
   fix: replace_with_prime
 

--- a/specs/v27/FIX_PRODUCER_LEDGER.md
+++ b/specs/v27/FIX_PRODUCER_LEDGER.md
@@ -12,15 +12,15 @@ The pre-release gate `check_fix_producer_ledger.py` runs the generator with
 ## Summary
 
 - **Total rules**: 660
-- **Shipped**: 104 (~15%)
-- **Pending**: 552
+- **Shipped**: 115 (~17%)
+- **Pending**: 541
 - **Deferred**: 4 (NLP-required)
 
 ### Bucket distribution (tentative — heuristic-assigned for unshipped)
 
 | Bucket | Description | Count | Shipped | Remaining |
 |--------|-------------|-------|---------|-----------|
-| **A**  | Mechanical, safe everywhere       | 458 | 104 | 354 |
+| **A**  | Mechanical, safe everywhere       | 458 | 115 | 343 |
 | **B**  | Sentence-aware (NLP-required)     | 53 | 0 | 53 |
 | **C**  | Context-required (--apply-fixes-with-prompt) | 87 | 0 | 87 |
 | **D**  | Defer indefinitely (compile/runtime) | 62 | 0 | 62 |
@@ -80,7 +80,7 @@ rules + the 4 NLP-deferred rules + CHAR-010/011 (redundant with ENC-020)
 | L3 | 11 | 0 | 11 | 0 | 0 | 0 | 0 | 11 |
 | LANG | 16 | 0 | 16 | 0 | 16 | 0 | 0 | 0 |
 | LAY | 27 | 0 | 27 | 0 | 0 | 0 | 27 | 0 |
-| MATH | 108 | 9 | 99 | 0 | 108 | 0 | 0 | 0 |
+| MATH | 108 | 12 | 96 | 0 | 108 | 0 | 0 | 0 |
 | META | 4 | 0 | 4 | 0 | 0 | 0 | 4 | 0 |
 | MOD | 18 | 0 | 18 | 0 | 0 | 0 | 18 | 0 |
 | NL | 2 | 0 | 2 | 0 | 2 | 0 | 0 | 0 |
@@ -94,8 +94,8 @@ rules + the 4 NLP-deferred rules + CHAR-010/011 (redundant with ENC-020)
 | RO | 1 | 0 | 1 | 0 | 1 | 0 | 0 | 0 |
 | RTL | 5 | 0 | 5 | 0 | 5 | 0 | 0 | 0 |
 | RU | 2 | 0 | 2 | 0 | 2 | 0 | 0 | 0 |
-| SCRIPT | 22 | 1 | 21 | 0 | 22 | 0 | 0 | 0 |
-| SPC | 35 | 18 | 17 | 0 | 35 | 0 | 0 | 0 |
+| SCRIPT | 22 | 3 | 19 | 0 | 22 | 0 | 0 | 0 |
+| SPC | 35 | 22 | 13 | 0 | 35 | 0 | 0 | 0 |
 | STRUCT | 5 | 2 | 3 | 0 | 5 | 0 | 0 | 0 |
 | STYLE | 49 | 0 | 49 | 0 | 0 | 49 | 0 | 0 |
 | SYS | 1 | 0 | 1 | 0 | 0 | 0 | 0 | 1 |
@@ -103,7 +103,7 @@ rules + the 4 NLP-deferred rules + CHAR-010/011 (redundant with ENC-020)
 | TH | 1 | 0 | 1 | 0 | 1 | 0 | 0 | 0 |
 | TIKZ | 10 | 0 | 10 | 0 | 10 | 0 | 0 | 0 |
 | TR | 1 | 0 | 1 | 0 | 1 | 0 | 0 | 0 |
-| TYPO | 63 | 42 | 17 | 4 | 59 | 4 | 0 | 0 |
+| TYPO | 63 | 44 | 15 | 4 | 59 | 4 | 0 | 0 |
 | VERB | 17 | 0 | 17 | 0 | 17 | 0 | 0 | 0 |
 | ZH | 2 | 0 | 2 | 0 | 2 | 0 | 0 | 0 |
 
@@ -377,7 +377,7 @@ rules + the 4 NLP-deferred rules + CHAR-010/011 (redundant with ENC-020)
 | `MATH-026` | MATH | **A** | tentative | pending |
 | `MATH-027` | MATH | **A** | tentative | pending |
 | `MATH-028` | MATH | **A** | tentative | pending |
-| `MATH-029` | MATH | **A** | tentative | pending |
+| `MATH-029` | MATH | **A** | confirmed | shipped in v27.1.5 |
 | `MATH-030` | MATH | **A** | tentative | pending |
 | `MATH-031` | MATH | **A** | tentative | pending |
 | `MATH-032` | MATH | **A** | tentative | pending |
@@ -392,7 +392,7 @@ rules + the 4 NLP-deferred rules + CHAR-010/011 (redundant with ENC-020)
 | `MATH-041` | MATH | **A** | tentative | pending |
 | `MATH-042` | MATH | **A** | tentative | pending |
 | `MATH-043` | MATH | **A** | tentative | pending |
-| `MATH-044` | MATH | **A** | tentative | pending |
+| `MATH-044` | MATH | **A** | confirmed | shipped in v27.1.5 |
 | `MATH-045` | MATH | **A** | tentative | pending |
 | `MATH-046` | MATH | **A** | tentative | pending |
 | `MATH-047` | MATH | **A** | tentative | pending |
@@ -431,7 +431,7 @@ rules + the 4 NLP-deferred rules + CHAR-010/011 (redundant with ENC-020)
 | `MATH-080` | MATH | **A** | tentative | pending |
 | `MATH-081` | MATH | **A** | tentative | pending |
 | `MATH-082` | MATH | **A** | confirmed | shipped in v27.0.46 |
-| `MATH-083` | MATH | **A** | tentative | pending |
+| `MATH-083` | MATH | **A** | confirmed | shipped in v27.1.5 |
 | `MATH-084` | MATH | **A** | tentative | pending |
 | `MATH-085` | MATH | **A** | tentative | pending |
 | `MATH-086` | MATH | **A** | tentative | pending |
@@ -549,7 +549,7 @@ rules + the 4 NLP-deferred rules + CHAR-010/011 (redundant with ENC-020)
 | `RTL-005` | RTL | **A** | tentative | pending |
 | `RU-001` | RU | **A** | tentative | pending |
 | `RU-002` | RU | **A** | tentative | pending |
-| `SCRIPT-001` | SCRIPT | **A** | tentative | pending |
+| `SCRIPT-001` | SCRIPT | **A** | confirmed | shipped in v27.1.5 |
 | `SCRIPT-002` | SCRIPT | **A** | tentative | pending |
 | `SCRIPT-003` | SCRIPT | **A** | tentative | pending |
 | `SCRIPT-004` | SCRIPT | **A** | tentative | pending |
@@ -567,7 +567,7 @@ rules + the 4 NLP-deferred rules + CHAR-010/011 (redundant with ENC-020)
 | `SCRIPT-016` | SCRIPT | **A** | confirmed | shipped in v27.1.3 |
 | `SCRIPT-017` | SCRIPT | **A** | tentative | pending |
 | `SCRIPT-018` | SCRIPT | **A** | tentative | pending |
-| `SCRIPT-019` | SCRIPT | **A** | tentative | pending |
+| `SCRIPT-019` | SCRIPT | **A** | confirmed | shipped in v27.1.5 |
 | `SCRIPT-020` | SCRIPT | **A** | tentative | pending |
 | `SCRIPT-021` | SCRIPT | **A** | tentative | pending |
 | `SCRIPT-022` | SCRIPT | **A** | tentative | pending |
@@ -576,7 +576,7 @@ rules + the 4 NLP-deferred rules + CHAR-010/011 (redundant with ENC-020)
 | `SPC-003` | SPC | **A** | confirmed | shipped in v26.3.1 |
 | `SPC-004` | SPC | **A** | confirmed | shipped in v26.3.1 |
 | `SPC-005` | SPC | **A** | confirmed | shipped in v26.3.1 |
-| `SPC-006` | SPC | **A** | tentative | pending |
+| `SPC-006` | SPC | **A** | confirmed | shipped in v27.1.5 |
 | `SPC-007` | SPC | **A** | tentative | pending |
 | `SPC-008` | SPC | **A** | confirmed | shipped in v26.3.0 |
 | `SPC-009` | SPC | **A** | confirmed | shipped in v26.3.0 |
@@ -588,7 +588,7 @@ rules + the 4 NLP-deferred rules + CHAR-010/011 (redundant with ENC-020)
 | `SPC-015` | SPC | **A** | tentative | pending |
 | `SPC-016` | SPC | **A** | confirmed | shipped in v27.0.60 |
 | `SPC-017` | SPC | **A** | tentative | pending |
-| `SPC-018` | SPC | **A** | tentative | pending |
+| `SPC-018` | SPC | **A** | confirmed | shipped in v27.1.5 |
 | `SPC-019` | SPC | **A** | confirmed | shipped in v27.0.55 |
 | `SPC-020` | SPC | **A** | confirmed | shipped in v27.0.69 |
 | `SPC-021` | SPC | **A** | confirmed | shipped in v27.0.60 |
@@ -601,10 +601,10 @@ rules + the 4 NLP-deferred rules + CHAR-010/011 (redundant with ENC-020)
 | `SPC-028` | SPC | **A** | confirmed | shipped in v27.0.58 |
 | `SPC-029` | SPC | **A** | tentative | pending |
 | `SPC-030` | SPC | **A** | confirmed | shipped in v27.0.56 |
-| `SPC-031` | SPC | **A** | tentative | pending |
+| `SPC-031` | SPC | **A** | confirmed | shipped in v27.1.5 |
 | `SPC-032` | SPC | **A** | tentative | pending |
 | `SPC-033` | SPC | **A** | tentative | pending |
-| `SPC-034` | SPC | **A** | tentative | pending |
+| `SPC-034` | SPC | **A** | confirmed | shipped in v27.1.5 |
 | `SPC-035` | SPC | **A** | confirmed | shipped in v27.0.56 |
 | `STRUCT-001` | STRUCT | **A** | confirmed | shipped in v26.3.0 |
 | `STRUCT-002` | STRUCT | **A** | confirmed | shipped in v26.3.0 |
@@ -711,7 +711,7 @@ rules + the 4 NLP-deferred rules + CHAR-010/011 (redundant with ENC-020)
 | `TYPO-020` | TYPO | **B** | confirmed | deferred (NLP) |
 | `TYPO-021` | TYPO | **A** | confirmed | shipped in v26.3.0 |
 | `TYPO-022` | TYPO | **A** | confirmed | shipped in v26.3.0 |
-| `TYPO-023` | TYPO | **A** | tentative | pending |
+| `TYPO-023` | TYPO | **A** | confirmed | shipped in v27.1.5 |
 | `TYPO-024` | TYPO | **A** | confirmed | shipped in v26.3.0 |
 | `TYPO-025` | TYPO | **A** | confirmed | shipped in v26.3.1 |
 | `TYPO-026` | TYPO | **A** | confirmed | shipped in v26.3.1 |
@@ -750,7 +750,7 @@ rules + the 4 NLP-deferred rules + CHAR-010/011 (redundant with ENC-020)
 | `TYPO-059` | TYPO | **A** | tentative | pending |
 | `TYPO-060` | TYPO | **A** | tentative | pending |
 | `TYPO-061` | TYPO | **A** | confirmed | shipped in v27.0.52 |
-| `TYPO-062` | TYPO | **A** | tentative | pending |
+| `TYPO-062` | TYPO | **A** | confirmed | shipped in v27.1.5 |
 | `TYPO-063` | TYPO | **A** | tentative | pending |
 | `VERB-001` | VERB | **A** | tentative | pending |
 | `VERB-002` | VERB | **A** | tentative | pending |
@@ -791,7 +791,7 @@ Per `V27_FIX_PRODUCER_CADENCE.md` § Acceptance criteria:
   fix producers gated behind `--apply-fixes`).
   **ACHIEVED** every cycle since v27.0.5.
 - [ ] Bucket A shipped fully by v27.2.0 (target).
-  **TRACKING** — 104 of 458 Bucket A
+  **TRACKING** — 115 of 458 Bucket A
   rules shipped. At current 1/cycle pace, full Bucket A completion
   would arrive much later than v27.2.0; cadence target needs review.
 - [ ] Bucket B + C shipped fully by v27.4.0 (target).

--- a/specs/v27/V27_FIX_PRODUCER_CADENCE.md
+++ b/specs/v27/V27_FIX_PRODUCER_CADENCE.md
@@ -1,7 +1,7 @@
 # V27_FIX_PRODUCER_CADENCE — Rolling fix-producer extension to full coverage
 
 **Goal:** Bring the catalogue of 660 lint rules from the 32 fix-producing
-rules at plan authoring (104 shipped as of v27.1.4) to full coverage where
+rules at plan authoring (115 shipped as of v27.1.5) to full coverage where
 mechanically safe, with
 explicit deferral of NLP-required and unsafe-without-context rules.
 
@@ -146,7 +146,7 @@ from `FIX_PRODUCER_LEDGER.md`, ship, update.
   v27.0.5+**; enforced every release cycle via
   `scripts/tools/run_differential_test.py`.
 - [ ] Bucket A shipped fully by v27.2.0 (target).  **IN PROGRESS** —
-  104/458 (~23%) shipped as of v27.1.4.  Original v27.2.0 target
+  115/458 (~25%) shipped as of v27.1.5.  Original v27.2.0 target
   assumed ≥10 producers/release; at the actual cadence pace this
   milestone is on track for a later release.
 - [ ] Bucket B + C shipped fully by v27.4.0 (target).  **NOT


### PR DESCRIPTION
> Stacked on #439 (v27.1.4 verbatim-safety). Base auto-retargets to `main` once #439 merges. The diff here is **only** the 11 new producers + registration.

## Summary

Implements the fix for **11 rules** an earlier pass wrongly dismissed as "redundant." The catalogue is the ground truth: **`conflicts_with` is empty for every one of them** — they are distinct rules intended to coexist (where two producers emit the same edit, it dedups at apply time; it is never a conflict). **104 → 115 producers.**

| Rule | Fix |
|------|-----|
| MATH-083 | text U+2212 → `-` (coexists with CHAR-019, edits dedup) |
| SCRIPT-019 | `''` in math → `^{\prime\prime}` (triple+ left to SCRIPT-012/022) |
| SCRIPT-001 | multi-char subscript `x_12` → `x_{12}` |
| TYPO-023 | bare `&` outside tabular → `\&` |
| TYPO-062 | literal `\` → `\textbackslash{}` — **conservative, never rewrites a `\\` linebreak** |
| SPC-006 | mixed space/tab indentation → spaces |
| SPC-018 | missing space after sentence period |
| SPC-031 | 3+ spaces after period → one |
| SPC-034 | thin-space before en-dash → removed |
| MATH-029 | `eqnarray*`/`eqnarray` → `align*`/`align` |
| MATH-044 | `<=`/`>=` in math → `\le`/`\ge` |

## Method
Implemented via **worktree-isolated** agents (each built + validated in its own worktree — no shared-tree contamination), then applied to the tree and re-validated under the full gate battery here.

## Validation
- **Differential: 0 diffs** vs v27.1.4 across 330 files (each only ADDS a fix; counts untouched).
- **Verbatim-safety gate: PASS** — every producer built on the v27.1.4 exempt/vcu layer; none corrupt verbatim/comment/url/math.
- **Full `dune runtest`: PASS** (typo-fix 424, math 473, golden 355, fix-producer-fuzz, …).
- Registries regenerated (produces_fix:true=115); fix-type-consistency + ledger-sync + version-labels gates pass; maturity Draft→Implemented for all 11.

## Deferred to a careful follow-up (not dropped)
VERB-002 (legitimately edits verbatim — needs gate-allowlisting) and STYLE-015/STYLE-023 (Class-D — need the `--apply-fixes` path extended to Class-D rules). These need real design work, not a mechanical fix.