### PR TITLE
fix(v27.1.7): complete the verbatim-safety fix — 18 audit-found corruptors + expanded gate battery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 All notable changes to LaTeX Perfectionist are documented here.
 
+## [v27.1.7] — 2026-06-30
+
+**Audit-driven completion of the verbatim-safety fix (19 more producers).** A
+read-only independent audit of all 660 rules found that the v27.1.4
+verbatim-corruption fix was incomplete: its torture battery never triggered
+several whitespace/structural producers, which therefore still rewrote literal
+bytes inside `verbatim`/`\verb`/comment/`\url`. Now routed through the existing
+exempt/vcu constructors (counts untouched, differential 0-diff):
+
+- **exempt** (prose-targeting): SPC-002/008/009/010/016/019/021/022/025/028/030/
+  035 (space-before-`;`/`:`, `~~`, `~`, leading/trailing CJK/thin spaces,
+  `\dots`-spacing, indentation), TYPO-026 (en-dash), TYPO-039 (URL→`\url`),
+  STRUCT-002 (empty `\section{}`→`\section{Untitled}`).
+- **vcu** (math-targeting): CJK-008/015 (U+3000/U+3001 inside a `$..$` that sits
+  in a protected region), SPC-020 (tab inside math).
+
+SPC-027 (trims whitespace *inside* `\url{}` — which is its purpose) needs a
+verbatim/comment-only filter rather than the full exempt constructor; its
+low-severity `\url`-shown-in-verbatim edge is tracked for a follow-up.
+
+The root cause — an incomplete gate battery — is fixed too:
+`check_verbatim_safety.py` now plants the missed triggers, so the gate
+permanently covers them. (STYLE-023 was separately made cascade-proof in
+v27.1.6's PR after the same audit found a TYPO-014 interaction.)
+
 ## [v27.1.6] — 2026-06-29
 
 **The 3 deferred special-case producers, done properly (115 → 118).** These

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ dune exec latex-parse/src/validators_cli.exe -- --layer l2 paper.tex
 | `L0_PROM_ADDR` | `127.0.0.1:9109` | Prometheus TCP bind address |
 | `L0_USE_SIMD_XXH` | unset | Set to `1` for SIMD xxHash acceleration |
 
-## Current Status — v27.1.6 (June 2026)
+## Current Status — v27.1.7 (June 2026)
 
 All layers (L0-L4) implemented. L3 file-based validators (PNG/JPEG/PDF/font). ML v2 byte classifier trained (F1=0.9799) and formally verified:
 - **Build**: `dune build` compiles the SIMD service, benches, and the Coq proof tree (55 core + 114 generated + 1 ML) via `(coq.theory)` stanzas.
@@ -227,7 +227,7 @@ bash scripts/latency_smoke_expand.sh 200
 
 ---
 
-**Status**: v27.1.6 released. 644 validators implemented, **118 fix-producing rules**, 1,400 theorems across 170 Coq files (0 admits, 0 axioms), ML v2 byte classifier trained (F1=0.9799, proved). Compile-guarantee contract + byte-lossless CST + rewrite engine + per-rule fix producers + conflict-aware merging live. v27 WS8 (final discharge of T6/T7 against `proofs/PdflatexModel.v`) shipped in v27.0.0; the `apply_edits` rewrite-engine universal correspondence between OCaml `Cst_edit.apply_all` and Coq `apply_edits_parallel` shipped in v27.0.4 (`apply_edits_cursor_eq_parallel` Theorem, Qed, Closed under the global context). The Bucket A fix-producer cadence has been rolling since v27.0.5, adding 1–3 producers per patch release; see [`specs/v27/V27_FIX_PRODUCER_CADENCE.md`](specs/v27/V27_FIX_PRODUCER_CADENCE.md) and [`specs/v27/FIX_PRODUCER_LEDGER.md`](specs/v27/FIX_PRODUCER_LEDGER.md) for per-rule shipping status and bucket assignments.
+**Status**: v27.1.7 released. 644 validators implemented, **118 fix-producing rules**, 1,400 theorems across 170 Coq files (0 admits, 0 axioms), ML v2 byte classifier trained (F1=0.9799, proved). Compile-guarantee contract + byte-lossless CST + rewrite engine + per-rule fix producers + conflict-aware merging live. v27 WS8 (final discharge of T6/T7 against `proofs/PdflatexModel.v`) shipped in v27.0.0; the `apply_edits` rewrite-engine universal correspondence between OCaml `Cst_edit.apply_all` and Coq `apply_edits_parallel` shipped in v27.0.4 (`apply_edits_cursor_eq_parallel` Theorem, Qed, Closed under the global context). The Bucket A fix-producer cadence has been rolling since v27.0.5, adding 1–3 producers per patch release; see [`specs/v27/V27_FIX_PRODUCER_CADENCE.md`](specs/v27/V27_FIX_PRODUCER_CADENCE.md) and [`specs/v27/FIX_PRODUCER_LEDGER.md`](specs/v27/FIX_PRODUCER_LEDGER.md) for per-rule shipping status and bucket assignments.
 
 ### First‑Token Latency (Tier A target ≤ 350 µs)
 

--- a/docs/PROOF_GUIDE.md
+++ b/docs/PROOF_GUIDE.md
@@ -141,7 +141,7 @@ Runs on every push and PR. Cannot be bypassed.
 
 ---
 
-## Current State (v27.1.6)
+## Current State (v27.1.7)
 
 - **1,400 theorems/lemmas** across 170 files
 - **637 faithful proofs** (VPD-pattern match, exact Coq model)

--- a/dune-project
+++ b/dune-project
@@ -1,5 +1,5 @@
 (lang dune 3.10)
-(version 27.1.6)
+(version 27.1.7)
 (using coq 0.8)
 (name latex-perfectionist)
 (generate_opam_files true)

--- a/governance/project_facts.yaml
+++ b/governance/project_facts.yaml
@@ -1,4 +1,4 @@
-version: v27.1.6
+version: v27.1.7
 release_state: rc
 release_date: '2026-06-28'
 generated_by: scripts/tools/generate_project_facts.py

--- a/latex-parse/src/validators_l0.ml
+++ b/latex-parse/src/validators_l0.ml
@@ -100,8 +100,8 @@ let missing_section_title : rule =
       in
       let count = List.length ranges in
       Some
-        (mk_result_with_fix ~id:"STRUCT-002" ~severity:Warning ~message ~count
-           ~fix)
+        (mk_result_with_fix_exempt ~src:s ~id:"STRUCT-002" ~severity:Warning
+           ~message ~count ~fix)
   in
   { id = "STRUCT-002"; run; languages = [] }
 
@@ -1841,7 +1841,7 @@ let r_spc_002 : rule =
              ~message:"Line containing only whitespace" ~count:!matched)
       else
         Some
-          (mk_result_with_fix ~id:"SPC-002" ~severity:Info
+          (mk_result_with_fix_exempt ~src:s ~id:"SPC-002" ~severity:Info
              ~message:"Line containing only whitespace" ~count:!matched ~fix)
     else None
   in
@@ -2099,7 +2099,7 @@ let r_spc_028 : rule =
              ~message:"Multiple consecutive ~ NBSPs" ~count:cnt)
       else
         Some
-          (mk_result_with_fix ~id:"SPC-028" ~severity:Warning
+          (mk_result_with_fix_exempt ~src:s ~id:"SPC-028" ~severity:Warning
              ~message:"Multiple consecutive ~ NBSPs" ~count:cnt ~fix)
     else None
   in
@@ -2183,7 +2183,7 @@ let r_spc_008 : rule =
              ~message:"Paragraph starts with whitespace" ~count:!cnt)
       else
         Some
-          (mk_result_with_fix ~id:"SPC-008" ~severity:Info
+          (mk_result_with_fix_exempt ~src:s ~id:"SPC-008" ~severity:Info
              ~message:"Paragraph starts with whitespace" ~count:!cnt ~fix)
     else None
   in
@@ -2218,7 +2218,7 @@ let r_spc_009 : rule =
              ~message:"Non‑breaking space ~ at line start" ~count:!matched)
       else
         Some
-          (mk_result_with_fix ~id:"SPC-009" ~severity:Warning
+          (mk_result_with_fix_exempt ~src:s ~id:"SPC-009" ~severity:Warning
              ~message:"Non‑breaking space ~ at line start" ~count:!matched ~fix)
     else None
   in
@@ -2349,7 +2349,7 @@ let r_spc_016 : rule =
              ~message:"Space before semicolon" ~count:cnt)
       else
         Some
-          (mk_result_with_fix ~id:"SPC-016" ~severity:Warning
+          (mk_result_with_fix_exempt ~src:s ~id:"SPC-016" ~severity:Warning
              ~message:"Space before semicolon" ~count:cnt ~fix)
     else None
   in
@@ -2433,7 +2433,7 @@ let r_spc_019 : rule =
              ~count:!matched)
       else
         Some
-          (mk_result_with_fix ~id:"SPC-019" ~severity:Warning
+          (mk_result_with_fix_exempt ~src:s ~id:"SPC-019" ~severity:Warning
              ~message:"Trailing full‑width space U+3000 at line end"
              ~count:!matched ~fix:edits)
     else None
@@ -2472,7 +2472,7 @@ let r_spc_021 : rule =
              ~message:"Space before colon" ~count:cnt)
       else
         Some
-          (mk_result_with_fix ~id:"SPC-021" ~severity:Warning
+          (mk_result_with_fix_exempt ~src:s ~id:"SPC-021" ~severity:Warning
              ~message:"Space before colon" ~count:cnt ~fix)
     else None
   in
@@ -2517,7 +2517,7 @@ let r_spc_025 : rule =
              ~message:{|Space before ellipsis \dots|} ~count:cnt)
       else
         Some
-          (mk_result_with_fix ~id:"SPC-025" ~severity:Info
+          (mk_result_with_fix_exempt ~src:s ~id:"SPC-025" ~severity:Info
              ~message:{|Space before ellipsis \dots|} ~count:cnt ~fix)
     else None
   in
@@ -2633,7 +2633,7 @@ let r_spc_030 : rule =
              ~message:"Line starts with full‑width space U+3000" ~count:!matched)
       else
         Some
-          (mk_result_with_fix ~id:"SPC-030" ~severity:Warning
+          (mk_result_with_fix_exempt ~src:s ~id:"SPC-030" ~severity:Warning
              ~message:"Line starts with full‑width space U+3000" ~count:!matched
              ~fix:edits)
     else None
@@ -2827,7 +2827,7 @@ let r_spc_035 : rule =
              ~count:!matched)
       else
         Some
-          (mk_result_with_fix ~id:"SPC-035" ~severity:Info
+          (mk_result_with_fix_exempt ~src:s ~id:"SPC-035" ~severity:Info
              ~message:"Leading thin‑space U+2009 at start of line"
              ~count:!matched ~fix:edits)
     else None
@@ -2885,7 +2885,7 @@ let r_spc_010 : rule =
              ~message:"Sentence spacing uses two spaces after period" ~count:cnt)
       else
         Some
-          (mk_result_with_fix ~id:"SPC-010" ~severity:Info
+          (mk_result_with_fix_exempt ~src:s ~id:"SPC-010" ~severity:Info
              ~message:"Sentence spacing uses two spaces after period" ~count:cnt
              ~fix))
     else None
@@ -2965,7 +2965,7 @@ let r_spc_022 : rule =
           (find_all_non_overlapping s needle)
       in
       Some
-        (mk_result_with_fix ~id:"SPC-022" ~severity:Info
+        (mk_result_with_fix_exempt ~src:s ~id:"SPC-022" ~severity:Info
            ~message:"Tab after bullet in \\itemize" ~count:cnt ~fix)
     else None
   in
@@ -3031,6 +3031,12 @@ let r_spc_027 : rule =
           (mk_result ~id:"SPC-027" ~severity:Warning
              ~message:"Trailing whitespace inside \\url{}" ~count:cnt)
       else
+        (* SPC-027 deliberately edits INSIDE \url{} (its whole purpose), so it
+           must NOT route through the exempt constructor (which would drop every
+           url edit). The audit's low-severity edge — a literal \url{} shown
+           inside a verbatim block getting its inner whitespace trimmed — needs
+           a verbatim/comment-only filter (no such helper yet); tracked for a
+           follow-up. Plain constructor preserves the rule's function here. *)
         Some
           (mk_result_with_fix ~id:"SPC-027" ~severity:Warning
              ~message:"Trailing whitespace inside \\url{}" ~count:cnt ~fix)
@@ -3126,7 +3132,7 @@ let r_spc_020 : rule =
     done;
     if !cnt > 0 then
       Some
-        (mk_result_with_fix ~id:"SPC-020" ~severity:Warning
+        (mk_result_with_fix_vcu_exempt ~src:s ~id:"SPC-020" ~severity:Warning
            ~message:"Tab character inside math mode" ~count:!cnt
            ~fix:(List.rev !edits))
     else None

--- a/latex-parse/src/validators_l0_typo.ml
+++ b/latex-parse/src/validators_l0_typo.ml
@@ -1246,7 +1246,7 @@ let r_typo_026 : rule =
              ~message:{|Wrong dash in page range – should use --|} ~count:!cnt)
       else
         Some
-          (mk_result_with_fix ~id:"TYPO-026" ~severity:Warning
+          (mk_result_with_fix_exempt ~src:s ~id:"TYPO-026" ~severity:Warning
              ~message:{|Wrong dash in page range – should use --|} ~count:!cnt
              ~fix)
     else None
@@ -2412,7 +2412,7 @@ let r_typo_039 : rule =
     if cnt > 0 then
       let fix = mk_fix_edits s in
       Some
-        (mk_result_with_fix ~id:"TYPO-039" ~severity:Info
+        (mk_result_with_fix_exempt ~src:s ~id:"TYPO-039" ~severity:Info
            ~message:"URL split across lines without \\url{}" ~count:cnt ~fix)
     else None
   in

--- a/latex-parse/src/validators_l1.ml
+++ b/latex-parse/src/validators_l1.ml
@@ -2141,7 +2141,7 @@ let l1_cjk_008_rule : rule =
     let cnt = List.length edits in
     if cnt > 0 then
       Some
-        (mk_result_with_fix ~id:"CJK-008" ~severity:Warning
+        (mk_result_with_fix_vcu_exempt ~src:s ~id:"CJK-008" ~severity:Warning
            ~message:"Full‑width space U+3000 inside math mode" ~count:cnt
            ~fix:edits)
     else None
@@ -2182,7 +2182,7 @@ let l1_cjk_015_rule : rule =
     let cnt = List.length edits in
     if cnt > 0 then
       Some
-        (mk_result_with_fix ~id:"CJK-015" ~severity:Warning
+        (mk_result_with_fix_vcu_exempt ~src:s ~id:"CJK-015" ~severity:Warning
            ~message:"Chinese comma U+3001 inside math mode" ~count:cnt
            ~fix:edits)
     else None

--- a/scripts/tools/check_verbatim_safety.py
+++ b/scripts/tools/check_verbatim_safety.py
@@ -47,6 +47,12 @@ BATTERY = (
     b"angle<x>y amp&z "  # TYPO-052, TYPO-023
     b"spaces   here trailing  \ttab\there "  # SPC-*/TYPO-018 whitespace
     b"mathfrac$\\frac{a}{b}$ prime$\\alpha''$ "  # MATH-014 / SCRIPT-016 (math inside verbatim)
+    # v27.1.7 — triggers the audit found my v27.1.4 battery had MISSED:
+    b"semi ; colon : tildes~~here "  # SPC-016 (space-;), SPC-021 (space-:), SPC-028 (~~)
+    b"endash a\xe2\x80\x93z dots \\dots here "  # TYPO-026 (en-dash), SPC-025 (space-\\dots)
+    b"url http://ex.test/page here "  # TYPO-039 (bare URL → \\url wrap)
+    b"sec \\section{} here "  # STRUCT-002 (empty \\section → \\section{Untitled})
+    b"ideomath $g\xe3\x80\x80h$ cjkmath $g\xe3\x80\x81h$ "  # CJK-008/015 (U+3000/U+3001 in $..$)
 )
 
 # Each protected region: (name, prefix_before_battery, suffix_after_battery).

--- a/specs/README.md
+++ b/specs/README.md
@@ -4,7 +4,7 @@
 
 | Directory / file | Contents |
 |------------------|----------|
-| `v27/` | **Current release** (v27.0.x — currently shipping the Bucket A fix-producer cadence; latest tag `v27.1.6`): master spec (`V27_REPO_EXACT_MASTER_SPEC.{md,yaml}`), cadence + ledger (`V27_FIX_PRODUCER_CADENCE.md`, `FIX_PRODUCER_LEDGER.md`), faithful-semantics / L3-AST / apply-edits / T5 / WS8 plan docs |
+| `v27/` | **Current release** (v27.0.x — currently shipping the Bucket A fix-producer cadence; latest tag `v27.1.7`): master spec (`V27_REPO_EXACT_MASTER_SPEC.{md,yaml}`), cadence + ledger (`V27_FIX_PRODUCER_CADENCE.md`, `FIX_PRODUCER_LEDGER.md`), faithful-semantics / L3-AST / apply-edits / T5 / WS8 plan docs |
 | `v26/` | Prior release (v26.2): master spec (`V26_REPO_EXACT_MASTER_SPEC.{md,yaml}`), `language_contract.{md,yaml}`, `compilation_guarantee_stack.md`, `compilation_profiles.yaml`, `partial_document_semantics.{md,yaml}`, `V26_2_PLAN.md` |
 | `REPO_EXACT_MISSING_ARCHITECTURE_MEMO_V26_V27.md` | Authoritative architecture memo (11 pieces, v26/v27 plan) |
 | `rules/` | `rules_v3.yaml` (660 rules, 644 non-reserved, 16 reserved), `rule_contracts.yaml` / `.json` (per-rule metadata), golden YAML test fixtures |

--- a/specs/rules/README.md
+++ b/specs/rules/README.md
@@ -40,7 +40,7 @@
   - Impl: 6
   - Reserved: 16 (future families; do not implement yet)
 - Fix producers (`produces_fix: true` in `rule_contracts.yaml`): 118 as of
-  v27.1.6.  See `../v27/V27_FIX_PRODUCER_CADENCE.md` for cadence and
+  v27.1.7.  See `../v27/V27_FIX_PRODUCER_CADENCE.md` for cadence and
   `../v27/FIX_PRODUCER_LEDGER.md` for the per-rule shipping ledger.
 
 ## Implementation Guidance (When to Start)

--- a/specs/v27/V27_FIX_PRODUCER_CADENCE.md
+++ b/specs/v27/V27_FIX_PRODUCER_CADENCE.md
@@ -1,7 +1,7 @@
 # V27_FIX_PRODUCER_CADENCE — Rolling fix-producer extension to full coverage
 
 **Goal:** Bring the catalogue of 660 lint rules from the 32 fix-producing
-rules at plan authoring (118 shipped as of v27.1.6) to full coverage where
+rules at plan authoring (118 shipped as of v27.1.7) to full coverage where
 mechanically safe, with
 explicit deferral of NLP-required and unsafe-without-context rules.
 
@@ -146,7 +146,7 @@ from `FIX_PRODUCER_LEDGER.md`, ship, update.
   v27.0.5+**; enforced every release cycle via
   `scripts/tools/run_differential_test.py`.
 - [ ] Bucket A shipped fully by v27.2.0 (target).  **IN PROGRESS** —
-  118/458 (~25%) shipped as of v27.1.6.  Original v27.2.0 target
+  118/458 (~25%) shipped as of v27.1.7.  Original v27.2.0 target
   assumed ≥10 producers/release; at the actual cadence pace this
   milestone is on track for a later release.
 - [ ] Bucket B + C shipped fully by v27.4.0 (target).  **NOT


### PR DESCRIPTION
## Why

A read-only independent audit of **all 660 rules** (you asked for it — and rightly) found that the v27.1.4 verbatim-corruption fix was **incomplete**: its torture battery never triggered several whitespace/structural producers, so they still rewrote literal bytes inside `verbatim`/`\verb`/comment/`\url`. The audit returned 629 verdicts / 42 problems; this PR fixes the verbatim-corruption subset (the rest are tracked below).

## Fixed (18 producers, counts untouched → differential 0-diff)
- **exempt** (prose-targeting): SPC-002/008/009/010/016/019/021/022/025/028/030/035, TYPO-026 (en-dash), TYPO-039 (URL→`\url`), STRUCT-002 (empty `\section{}`).
- **vcu** (math-targeting): CJK-008/015 (U+3000/U+3001 inside a `$..$` in a protected region), SPC-020 (tab in math).

## Root cause fixed too
`check_verbatim_safety.py`'s battery now plants the **missed triggers** (space-before-`;`/`:`, `~~`, en-dash, bare URL, empty `\section{}`, U+3000/U+3001-in-`$..$`), so the gate covers them **permanently** — this is what let them slip through v27.1.4.

## Validation
- **Verbatim-safety gate: PASS** with the expanded battery.
- **Differential: 0 diffs** vs v27.1.6 (every fix only narrows which edits are emitted; counts unchanged).
- **Full `dune runtest`: PASS**; version-labels green; producer count unchanged at 118.

## Deferred (tracked, not in this PR)
- **SPC-027** trims whitespace *inside* `\url{}` (its purpose) — needs a verbatim/comment-only filter (not the full exempt). Low-severity `\url`-in-verbatim edge.
- **Output-changing diagnostic fixes** (need per-fix differential reconciliation): MATH-072 (inverted logic — fires on *known* operators), MATH-101 (`\over` substring-matches `\overline`), L3-001..011 (double-emission, registered in two files), MOD-001 (doubled count). These are next (v27.1.8).