### PR TITLE
test(hardening): permanent UTF-8/offset-misalignment regression corpus (120-producer audit clean)

### DIFF
--- a/corpora/lint/adversarial_utf8/README.md
+++ b/corpora/lint/adversarial_utf8/README.md
@@ -1,0 +1,27 @@
+# Adversarial UTF-8 / offset-misalignment regression corpus
+
+`cjk_offset_torture.tex` is a **permanent regression fixture** for the fix-output
+corruption class first found in STYLE-033 (v27.1.8): a fix producer that derives
+its `Cst_edit` byte offsets from a **length-changing** transform of the source
+(`strip_comments`, `strip_math_segments`) and emits them against the *original*
+string — landing edits mid-multibyte-character once an earlier comment/math span
+has shrunk the text, producing invalid UTF-8.
+
+The file deliberately interleaves multibyte CJK glyphs with:
+- `%`-comment lines that contain CJK *after* the `%` (shifts `strip_comments` offsets),
+- inline and display `$…$` math containing CJK (shifts `strip_math_segments` offsets),
+- a wide spread of common producer triggers (mid-text `%`, double space after
+  period, space before `\cite`/`;`/`:`, `~~`, bare `&`, straight quotes, en/em
+  dashes, fullwidth punctuation, `=>`/`\times`/`\div`, …),
+
+so that any producer using the unsafe offset pattern lands an edit inside a CJK
+character. `scripts/tools/check_apply_fixes_safety.py` scans `corpora/lint/**`,
+iterates `--apply-fixes` to a fixpoint, and fails if the output is not valid
+UTF-8 — so this fixture turns that gate into a standing guard for the whole
+producer set. (Verified: simulating the pre-fix STYLE-033 logic against this file
+yields invalid UTF-8 at byte 312.)
+
+All 120 producers were audited clean for this class in v27.1.8/v27.1.9; the safe
+patterns are: match the **original** source for edit offsets, filter via
+`find_math_ranges`/`find_exempt_ranges`, and skip multibyte sequences in byte
+scans. See the `fix_output_safety` memory note.

--- a/corpora/lint/adversarial_utf8/cjk_offset_torture.tex
+++ b/corpora/lint/adversarial_utf8/cjk_offset_torture.tex
@@ -1,0 +1,18 @@
+\documentclass{article}
+\usepackage{xeCJK}
+\begin{document}
+% 验和测试数据注释行，包含中文标点，。and a trailing comment with 50% literal
+通过实验验证，准确率达到 50\% 的提升 and R\&D notes here 和后续分析。
+我们测试了 50% off 的折扣 and the Smith & Jones method 在数据集上的表现。
+第一句结束。  第二句开始 with a double space after the period 和中文。
+如图所示 \cite{zhang2024} 的方法 and another result \cite{li2025} 很有效。
+参数设置为 a ; b 以及 c : d 还有 e~~f 的非断行空格 在中文语境中。
+使用 "straight quotes" 和 \'apostrophes\' 在 ASCII context 验和测试。
+范围是 5 -- 7 以及 spaced 5 – 3 的减号用法 验和数据 2020–2025。
+内联公式 $x = 验 + 和$ 以及 $a \times b \div c => d$ 的数学表达式。
+\begin{equation} 验和 = \alpha , \beta . \end{equation}
+全角标点测试，。：；！？ in ASCII context 验和 with fullwidth punctuation。
+省略号用法 ... 以及 trailing spaces below 验和   
+% 第二条注释 with CJK 验和 and a mid-comment 75% value 不应被转义
+末尾段落 验和测试 final paragraph with mixed 中英文 content and 100% coverage.
+\end{document}


### PR DESCRIPTION
## What

Following the STYLE-033 UTF-8-corruption fix in v27.1.8, I ran a comprehensive adversarial audit of **all 120 fix producers** for the same bug class — a producer that derives `Cst_edit` byte offsets from a **length-changing** transform (`strip_comments`, `strip_math_segments`) and emits them against the original string, landing edits mid-multibyte-character.

**Result: 0 bugs.** Offset-derivation census across all 120 producers:
- **65** ranges-filtered (`find_math_ranges`/`find_exempt_ranges`)
- **33** original-source (match `s` directly)
- **22** byte-scan-utf8-aware (skip multibyte sequences)

The 16 producers that use `strip_*` use it **only for the diagnostic count** (a number); their fix offsets all come from the original source. STYLE-033 was the lone anomaly (already fixed).

## Permanent guard

Adds `corpora/lint/adversarial_utf8/cjk_offset_torture.tex` — a dense fixture interleaving multibyte CJK with `%`-comments (CJK after `%`), `$…$` math (CJK inside), and a wide spread of producer triggers (mid-text `%`, double space after period, space before `\cite`/`;`/`:`, `~~`, bare `&`, straight quotes, en/em dashes, fullwidth punctuation, `=>`/`\times`/`\div`).

`check_apply_fixes_safety.py` already scans `corpora/lint/**`, iterates `--apply-fixes` to a fixpoint, and fails on non-UTF-8 output — so this fixture turns that gate into a standing guard for the whole producer set against future regressions of this class.

**Proven to have teeth:** simulating the pre-fix STYLE-033 logic against this fixture yields invalid UTF-8 at byte 312 (the `%`-comments shrink the string by 255 bytes, shifting a delete mid-CJK-char).

## Verification

- Fixture converges to valid UTF-8 (no oscillation, no apply-abort)
- Full convergence gate: 332/332 corpus files converge to valid UTF-8
- verbatim-safety, catalogue, full `dune runtest` all green
- No rule/producer/version change (test-infrastructure only)