### PR TITLE
feat(R7-INFRA-2/S-CI-TEX): real pdflatex in CI + close every silent-skip path

### DIFF
--- a/.github/workflows/tex-oracle.yml
+++ b/.github/workflows/tex-oracle.yml
@@ -1,0 +1,168 @@
+name: TeX Oracle (real pdflatex)
+
+# R7-INFRA-2 / S-CI-TEX — put a REAL pdflatex in CI.
+#
+# Until this workflow, `.github/workflows/` contained zero texlive and the only
+# `pdflatex` string in CI was a comment. Both pdflatex-dependent scripts exit 0
+# when the binary is absent, so they had never run in CI at all — which means
+# every "0 over-rejection on N real papers" claim across the round-7 fix trains
+# was a manual local sweep that nobody else could reproduce. This makes those
+# claims machine-checked and reproducible by anyone.
+#
+# ADVISORY ON PURPOSE (for now). This context is deliberately NOT listed in
+# .github/required-status-checks.json:
+#   * branch-protection.yml PUTs enforce_admins: true, so a red REQUIRED check
+#     here would be unbypassable even by the maintainer, and would stall every PR
+#     in the repo;
+#   * this is the repo's first Docker pull on the PR path — a new failure surface
+#     that has nothing to do with the property being gated.
+# The invisibility problem is solved the moment this runs on every PR and prints
+# the engine version into the log. Promote to required after a soak (~10 green
+# runs), by editing .github/required-status-checks.json — never via the API,
+# which branch-protection.yml would overwrite.
+#
+# NOTE: never add a `paths:` filter here. A required context whose workflow does
+# not run on a given PR stays pending forever, which would block promotion.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  # ── PINNED ORACLE ENGINE — see docs/COMPILATION_GUARANTEE.md § SO1 ──────────
+  # texlive/texlive:latest-medium as of 2026-07-26. Verified from the registry:
+  # this is the multi-arch OCI *index* digest (NOT a per-arch manifest digest,
+  # which would lock the runner architecture), and it is byte-identical to the
+  # immutable dated tag
+  #   registry.gitlab.com/islandoftex/images/texlive:TL2026-2026-07-26-medium
+  # so it is anchored and cannot be garbage-collected as an untagged orphan.
+  #
+  # scheme-medium, not -small: two corpus documents use [T1]{fontenc}, and
+  # cm-super/lm live in collection-fontsrecommended, which -small omits. Without
+  # them TeX synthesises bitmap fonts at run time — slow, and exactly the class of
+  # environment-dependent behaviour that makes an oracle unreliable.
+  #
+  # Re-pinning is a DELIBERATE PR: bump both vars, re-run false_ready_oracle.sh
+  # with STRICT_GRADE=1 and re-record corpora/false_ready/manifest.json, then
+  # update the SO1 section and specs/v26/compilation_profiles.yaml.
+  TEX_IMAGE: texlive/texlive@sha256:d79913b74afcf48a53ec2ad0d54b70ad3e36d65b4f1de13d811435883c2f1fd9
+  TEX_EXPECT_VERSION: 3.141592653-2.6-1.40.29
+
+jobs:
+  tex-oracle:
+    name: tex-oracle
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    steps:
+      - uses: actions/checkout@v4
+
+      # OCaml is set up on the RUNNER, not in the TeX container: setup-ocaml-env
+      # needs sudo/apt (absent in the Debian TeX image, which runs as root without
+      # sudo) and leaves opam's bubblewrap sandbox on, which fails in an
+      # unprivileged container. So we build here and mount the result in.
+      - uses: ./.github/actions/setup-ocaml-env
+
+      - name: Build validators CLI
+        run: opam exec -- dune build latex-parse/src/validators_cli.exe
+
+      - name: Pull pinned TeX Live image
+        run: docker pull "$TEX_IMAGE"
+
+      - name: Assert engine pin (a MISMATCH here is not oracle drift)
+        run: |
+          set -euo pipefail
+          got=$(docker run --rm "$TEX_IMAGE" pdflatex --version | head -1)
+          man=$(python3 -c "import json;print(json.load(open('corpora/false_ready/manifest.json'))['oracle']['version'])")
+          echo "image    : $got"
+          echo "manifest : $man"
+          case "$got" in *"$TEX_EXPECT_VERSION"*) ;; *)
+            echo "::error::PIN MISMATCH: image reports '$got', workflow pins '$TEX_EXPECT_VERSION'. This is NOT a soundness regression and NOT oracle drift — re-pin TEX_IMAGE or re-record the manifest. Do not disable this gate."
+            exit 1 ;; esac
+          case "$man" in *"$TEX_EXPECT_VERSION"*) ;; *)
+            echo "::error::PIN MISMATCH: manifest oracle.version '$man' != pinned '$TEX_EXPECT_VERSION'."
+            exit 1 ;; esac
+
+      # The anti-silent-green measure. A missing .sty grades identically to the
+      # intended fatal (strong-fatal), so an under-provisioned image would let
+      # fixtures report `ok` while testing nothing. Prove the install can compile
+      # the corpus feature set BEFORE grading anything.
+      - name: TeX install canary
+        run: |
+          set -euo pipefail
+          docker run --rm -e HOME=/tmp "$TEX_IMAGE" bash -s <<'EOS'
+          set -eu
+          d=$(mktemp -d); cd "$d"
+          cat > canary.tex <<'TEX'
+          \documentclass{article}
+          \usepackage[utf8]{inputenc}
+          \usepackage[T1]{fontenc}
+          \usepackage{amsmath,amssymb,graphicx,hyperref,listings,tikz}
+          \begin{document}
+          Caf\'e \`a \c{c} $\alpha^2$
+          \begin{tikzpicture}\draw (0,0)--(1,1);\end{tikzpicture}
+          \end{document}
+          TEX
+          if ! pdflatex -interaction=nonstopmode -halt-on-error canary.tex >canary.out 2>&1 || [ ! -f canary.pdf ]; then
+            echo "CANARY FAILED — the pinned image cannot compile the corpus feature set:"
+            tail -40 canary.out; exit 1
+          fi
+          for f in tikz.sty hyperref.sty amsmath.sty listings.sty inputenc.sty pdftex.map; do
+            kpsewhich "$f" >/dev/null || { echo "MISSING: $f"; exit 1; }
+          done
+          echo "canary OK"
+          EOS
+
+      # Parse the manifest on the RUNNER and hand the TSV in. This is what keeps
+      # the container dependency-free — no apt-get against a Debian sid base whose
+      # indices rot as the pinned digest ages.
+      - name: Emit fixture list
+        run: |
+          set -euo pipefail
+          bash scripts/tools/false_ready_oracle.sh --emit-fixtures > /tmp/fixtures.tsv
+          got=$(wc -l < /tmp/fixtures.tsv | tr -d ' ')
+          want=$(python3 -c "import json;print(len(json.load(open('corpora/false_ready/manifest.json'))['fixtures']))")
+          echo "fixtures: $got (manifest: $want)"
+          # The oracle derives its own expected count FROM this file, so a short
+          # TSV would silently shrink the check rather than fail it. This is the
+          # only place that can compare against the manifest (the container has
+          # no python3, deliberately), so the cross-check belongs here.
+          [ "$got" -eq "$want" ] || {
+            echo "::error::fixture TSV has $got rows but the manifest lists $want — refusing to grade a partial corpus."
+            exit 1; }
+
+      # THE BLOCKING CHECK (within this advisory workflow): every fixture must
+      # still be rejected by real pdflatex. HARD drift only — a strong-fatal <->
+      # error-halt reclassification is reported but does not fail, because that
+      # distinction moves with the font install rather than with soundness.
+      - name: False-READY oracle (real pdflatex, all fixtures)
+        run: |
+          set -euo pipefail
+          docker run --rm \
+            -v "$PWD:$PWD" -w "$PWD" \
+            -v /tmp/fixtures.tsv:/tmp/fixtures.tsv:ro \
+            -e HOME=/tmp -e REQUIRE_PDFLATEX=1 -e FR_FIXTURE_TSV=/tmp/fixtures.tsv \
+            "$TEX_IMAGE" bash scripts/tools/false_ready_oracle.sh
+
+      # ADVISORY: a measurement of the soundness residual, not a regression gate.
+      # It needs the large correctness-critical install, an incomplete one
+      # manufactures spurious FALSE-READY(NEW!) rows, and it is blind to a CLI
+      # broken in the over-rejection direction. Never make this one required.
+      - name: Differential vs pdflatex (65-doc corpus) — advisory
+        continue-on-error: true
+        run: |
+          set -euo pipefail
+          docker run --rm \
+            -v "$PWD:$PWD" -w "$PWD" \
+            -e HOME=/tmp -e REQUIRE_PDFLATEX=1 \
+            -e EXPECT_TEX_VERSION="$TEX_EXPECT_VERSION" \
+            "$TEX_IMAGE" bash scripts/tools/diff_compile_check.sh

--- a/.github/workflows/tex-oracle.yml
+++ b/.github/workflows/tex-oracle.yml
@@ -99,7 +99,13 @@ jobs:
       - name: TeX install canary
         run: |
           set -euo pipefail
-          docker run --rm -e HOME=/tmp "$TEX_IMAGE" bash -s <<'EOS'
+          # `-i` is REQUIRED: without it the container's stdin is not connected and
+          # `bash -s` reads EOF, so the canary body never runs, the step exits 0,
+          # and an under-provisioned image sails straight through into grading —
+          # precisely the silent-green this canary exists to prevent.
+          # The `grep -q` is the second half of that lesson: assert the body
+          # actually produced its completion marker, so a no-op can never be green.
+          docker run --rm -i -e HOME=/tmp "$TEX_IMAGE" bash -s <<'EOS' | tee /tmp/canary.log
           set -eu
           d=$(mktemp -d); cd "$d"
           cat > canary.tex <<'TEX'
@@ -112,15 +118,26 @@ jobs:
           \begin{tikzpicture}\draw (0,0)--(1,1);\end{tikzpicture}
           \end{document}
           TEX
-          if ! pdflatex -interaction=nonstopmode -halt-on-error canary.tex >canary.out 2>&1 || [ ! -f canary.pdf ]; then
+          # NOT canary.out: hyperref writes \jobname.out, so redirecting stdout
+          # there makes TeX read its own transcript back as the .out file and die
+          # with "! Missing { inserted." on a perfectly good install.
+          if ! pdflatex -interaction=nonstopmode -halt-on-error canary.tex >canary.stdout 2>&1 \
+             || [ ! -f canary.pdf ]; then
             echo "CANARY FAILED — the pinned image cannot compile the corpus feature set:"
-            tail -40 canary.out; exit 1
+            tail -40 canary.stdout; exit 1
           fi
-          for f in tikz.sty hyperref.sty amsmath.sty listings.sty inputenc.sty pdftex.map; do
+          # fontspec/polyglossia matter: six fixtures ARE package-loading tricks,
+          # and a missing .sty grades strong-fatal — identical to the intended
+          # fatal — so without these they would pass while testing nothing.
+          for f in tikz.sty hyperref.sty amsmath.sty listings.sty inputenc.sty \
+                   fontspec.sty polyglossia.sty pdftex.map; do
             kpsewhich "$f" >/dev/null || { echo "MISSING: $f"; exit 1; }
           done
           echo "canary OK"
           EOS
+          grep -q 'canary OK' /tmp/canary.log || {
+            echo "::error::The canary produced no completion marker. Either the image cannot compile the corpus feature set, or the canary body did not execute at all (check that 'docker run' still has -i). Refusing to grade fixtures against an unproven TeX install."
+            exit 1; }
 
       # Parse the manifest on the RUNNER and hand the TSV in. This is what keeps
       # the container dependency-free — no apt-get against a Debian sid base whose
@@ -151,6 +168,7 @@ jobs:
             -v "$PWD:$PWD" -w "$PWD" \
             -v /tmp/fixtures.tsv:/tmp/fixtures.tsv:ro \
             -e HOME=/tmp -e REQUIRE_PDFLATEX=1 -e FR_FIXTURE_TSV=/tmp/fixtures.tsv \
+            -e FR_EXPECT_ENGINE="$TEX_EXPECT_VERSION" \
             "$TEX_IMAGE" bash scripts/tools/false_ready_oracle.sh
 
       # ADVISORY: a measurement of the soundness residual, not a regression gate.

--- a/docs/COMPILATION_GUARANTEE.md
+++ b/docs/COMPILATION_GUARANTEE.md
@@ -173,6 +173,53 @@ discharge for those engines is a future workstream.
 ---
 
 
+## SO1 — Pinned oracle engine
+
+Every soundness claim in this document is relative to ONE pinned engine. This section
+is the single authoritative home of that pin.
+
+| | |
+|---|---|
+| engine | `pdflatex` |
+| distribution | TeX Live 2026 |
+| version | `pdfTeX 3.141592653-2.6-1.40.29` |
+| CI image | `texlive/texlive@sha256:d79913b74afcf48a53ec2ad0d54b70ad3e36d65b4f1de13d811435883c2f1fd9` |
+| — equivalently | `registry.gitlab.com/islandoftex/images/texlive:TL2026-2026-07-26-medium` (immutable dated tag) |
+| scheme | `scheme-medium` |
+
+**READY oracle.** A document is READY iff a clean single pass of the pinned engine
+produces no LaTeX Error. Two false-READY classes are knowingly admitted by a
+single-pass oracle: *(i)* multi-pass / `.aux` / `.bbl` staleness (`\ref`/`\cite`
+resolved only on a second pass), and *(ii)* recoverable-but-wrong output (`\ref`
+rendering `??`, duplicate `\label`, overfull `\hbox`).
+
+**Grades.** `strong-fatal` = no PDF even under `-interaction=nonstopmode`;
+`error-halt` = fails `-halt-on-error` but limps to a PDF under nonstopmode. Both are
+rejections; the distinction tracks the font/error-recovery install, not soundness,
+which is why `false_ready_oracle.sh` fails HARD only on a fixture that *compiles*.
+
+**Where it is enforced.** `.github/workflows/tex-oracle.yml` runs
+`scripts/tools/false_ready_oracle.sh` (blocking within that workflow) and
+`scripts/tools/diff_compile_check.sh` (advisory) inside the pinned image on every PR.
+The digest above is the multi-arch OCI *index* digest, not a per-arch manifest digest.
+
+**Engine-year sensitivity, measured.** TL2024 (pdfTeX 1.40.26) and TL2026 (1.40.29)
+produce identical grades on all 21 fixtures, with byte-identical first-error text. The
+fragile axis is install *completeness*, not engine year: with Type1 fonts hidden, every
+`error-halt` fixture reclassifies to `strong-fatal`. Hence the HARD/SOFT split and the
+install canary in the workflow.
+
+**Re-pinning is a deliberate PR**, in this order:
+1. bump `TEX_IMAGE` and `TEX_EXPECT_VERSION` in `.github/workflows/tex-oracle.yml`;
+2. re-run `scripts/tools/false_ready_oracle.sh` with `STRICT_GRADE=1` and re-record
+   `corpora/false_ready/manifest.json` (`oracle` block plus any changed grades);
+3. re-run `scripts/tools/diff_compile_check.sh` and re-derive `KNOWN_FALSE_READY`;
+4. update this section and `specs/v26/compilation_profiles.yaml`.
+
+A version mismatch reports as **PIN MISMATCH** (exit 3), never as drift — they are
+different problems with different fixes, and conflating them is how a gate gets
+switched off instead of understood.
+
 ## Differential validation against real pdflatex (measured, not asserted)
 
 `scripts/tools/diff_compile_check.sh` runs `--compile-check` AND the real `pdflatex`

--- a/generated/project_facts.json
+++ b/generated/project_facts.json
@@ -95,7 +95,7 @@
     "target": 21
   },
   "ci": {
-    "workflow_count": 36,
+    "workflow_count": 37,
     "hard_gates": [
       "zero_admit",
       "build",

--- a/governance/project_facts.yaml
+++ b/governance/project_facts.yaml
@@ -88,7 +88,7 @@ languages:
   stubbed: 14
   target: 21
 ci:
-  workflow_count: 36
+  workflow_count: 37
   hard_gates:
   - zero_admit
   - build

--- a/scripts/tools/diff_compile_check.sh
+++ b/scripts/tools/diff_compile_check.sh
@@ -22,11 +22,25 @@
 # whole macro universe) are expected and do NOT fail the run; a genuinely new
 # soundness miss does.
 #
-# Requires pdflatex on PATH (skips gracefully if absent). Not a CI gate (CI has
-# no TeX); run locally after touching compile_contract.ml or the corpus.
+# Requires pdflatex on PATH. Runs locally and in CI's tex-oracle workflow, where
+# it is ADVISORY (continue-on-error): its exit condition is a measurement of the
+# soundness residual, and it needs a large, correctness-critical TeX install — an
+# incomplete one manufactures spurious FALSE-READY(NEW!) rows. It is also blind to
+# a CLI broken in the over-rejection direction, so it is the wrong shape for a
+# blocking regression gate. The blocking gates are check_known_false_ready.py
+# (CLI-only, monotone) and false_ready_oracle.sh (pdflatex, HARD drift only).
+#
+# EXIT CODES: 0 clean | 1 a NEW false-READY beyond the allowlist | 2 infrastructure
+# (no pdflatex, no CLI, too few docs, a timeout, or a vacuous run) | 3 engine skew.
+#
+# ENV: REQUIRE_PDFLATEX=1 makes every precondition an error instead of a skip;
+#      EXPECT_TEX_VERSION=<substring> asserts the engine; MIN_DOCS (default 65)
+#      floors the corpus size; MAX_FALSE_NOTREADY (default 3) caps over-rejection;
+#      TEX_TIMEOUT (default 60) bounds each pdflatex run.
 #
 # Usage: diff_compile_check.sh [CORPUS_DIR]
 set -u
+set -o pipefail
 ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 CLI="$ROOT/_build/default/latex-parse/src/validators_cli.exe"
 CORPUS="${1:-$ROOT/corpora/compile_check}"
@@ -66,14 +80,42 @@ is_known_false_ready() {
   printf '%s\n' "$KNOWN_FALSE_READY" | grep -qxF "$base"
 }
 
+REQUIRE="${REQUIRE_PDFLATEX:-0}"
+TEX_TIMEOUT="${TEX_TIMEOUT:-60}"
+die_infra() { echo "[diff-compile-check] FATAL: $*" >&2; exit 2; }
+
 if ! command -v pdflatex >/dev/null 2>&1; then
+  [ "$REQUIRE" = 1 ] && die_infra "REQUIRE_PDFLATEX=1 but pdflatex is not on PATH"
   echo "[diff-compile-check] SKIP: pdflatex not on PATH"; exit 0
 fi
-if [ ! -x "$CLI" ]; then
-  echo "[diff-compile-check] building CLI..."; (cd "$ROOT" && opam exec -- dune build latex-parse/src/validators_cli.exe) || exit 1
+
+# A timeout produces pl=FAILS, which against a READY verdict manufactures a
+# FALSE-READY(NEW!) out of thin air. Never grade an unbounded run.
+TIMEOUT="$(command -v gtimeout || command -v timeout || true)"
+if [ -z "$TIMEOUT" ]; then
+  [ "$REQUIRE" = 1 ] && die_infra "REQUIRE_PDFLATEX=1 but neither gtimeout nor timeout is available"
+  echo "[diff-compile-check] WARNING: no timeout binary; a hung pdflatex would be scored as a failure" >&2
 fi
 
-tp=0; tn=0; false_ready=0; false_notready=0; total=0
+if [ -n "${EXPECT_TEX_VERSION:-}" ]; then
+  GOT_ENGINE="$(pdflatex --version 2>/dev/null | head -1)"
+  case "$GOT_ENGINE" in
+    *"$EXPECT_TEX_VERSION"*) ;;
+    *) echo "[diff-compile-check] PIN MISMATCH: engine '$GOT_ENGINE' != expected '$EXPECT_TEX_VERSION'." >&2
+       echo "[diff-compile-check]   This is NOT a soundness regression. Re-pin or re-record." >&2
+       exit 3 ;;
+  esac
+fi
+
+if [ ! -x "$CLI" ]; then
+  # A gate must never build its own subject.
+  [ "$REQUIRE" = 1 ] && die_infra "REQUIRE_PDFLATEX=1 but the CLI is missing at $CLI (build it in its own step)"
+  echo "[diff-compile-check] building CLI..."
+  (cd "$ROOT" && opam exec -- dune build latex-parse/src/validators_cli.exe) || die_infra "CLI build failed"
+  [ -x "$CLI" ] || die_infra "CLI still missing after build: $CLI"
+fi
+
+tp=0; tn=0; false_ready=0; false_notready=0; total=0; timeouts=0
 new_false_ready=0
 false_ready_files=""
 new_false_ready_files=""
@@ -91,8 +133,18 @@ for f in "$CORPUS"/*.tex; do
   d=$(mktemp -d); cp "$f" "$d/"
   # Also copy any sibling _part.tex fragments so \input parents resolve.
   cp "$CORPUS"/*_part.tex "$d/" 2>/dev/null || true
-  if (cd "$d" && pdflatex -interaction=nonstopmode -halt-on-error "$base" >/dev/null 2>&1); then pl=COMPILES; else pl=FAILS; fi
+  if [ -n "$TIMEOUT" ]; then
+    ( cd "$d" && "$TIMEOUT" "$TEX_TIMEOUT" pdflatex -interaction=nonstopmode -halt-on-error "$base" >/dev/null 2>&1 )
+  else
+    ( cd "$d" && pdflatex -interaction=nonstopmode -halt-on-error "$base" >/dev/null 2>&1 )
+  fi
+  prc=$?
   rm -rf "$d"
+  if [ "$prc" = 124 ]; then
+    printf '%-34s | %-10s | %-9s | %s\n' "$base" "$cc" "TIMEOUT" "not graded"
+    timeouts=$((timeouts+1)); continue
+  fi
+  if [ "$prc" = 0 ]; then pl=COMPILES; else pl=FAILS; fi
   cls=ok
   if   [ "$cc" = READY ]     && [ "$pl" = FAILS ];    then
     cls="FALSE-READY"; false_ready=$((false_ready+1)); false_ready_files="$false_ready_files $base"
@@ -112,5 +164,39 @@ echo "[diff-compile-check] FALSE-READY (cc=READY,pdflatex FAILS) total=$false_re
 echo "[diff-compile-check]   of which KNOWN-limitation (allowlisted)=$((false_ready-new_false_ready))"
 echo "[diff-compile-check]   of which NEW (regression)=$new_false_ready :$new_false_ready_files"
 echo "[diff-compile-check] false-not-ready (safe over-reject)=$false_notready"
+
+# Allowlist staleness: an entry the CLI now catches is dead weight, and worse, it
+# would silently absorb the NEXT regression in that file. Warn, never fail.
+stale=""
+for known in $KNOWN_FALSE_READY; do
+  case " $false_ready_files " in
+    *" $known "*) ;;
+    *) stale="$stale $known" ;;
+  esac
+done
+[ -n "$stale" ] && echo "[diff-compile-check] NOTE: allowlist entries no longer false-READY (retire them):$stale"
+
+# ── anti-vacuity ─────────────────────────────────────────────────────────────
+# Without these a misrooted corpus prints total=0 and exits 0, and a CLI that
+# rejects EVERYTHING scores total=65, FALSE-READY=0 and exits 0 — a green gate on
+# a completely broken checker. A gate that measures nothing must never pass.
+MIN_DOCS="${MIN_DOCS:-65}"
+if [ "$total" -lt "$MIN_DOCS" ]; then
+  die_infra "processed $total documents, expected at least $MIN_DOCS (corpus misrooted or empty?)"
+fi
+if [ "$tp" -eq 0 ]; then
+  die_infra "ZERO documents were both READY and compiled — the CLI is rejecting everything; these numbers are meaningless"
+fi
+[ "$timeouts" -eq 0 ] || die_infra "$timeouts document(s) timed out; the classification is not trustworthy"
+MAX_FALSE_NOTREADY="${MAX_FALSE_NOTREADY:-3}"
+if [ "$false_notready" -gt "$MAX_FALSE_NOTREADY" ]; then
+  echo "[diff-compile-check] FAIL: over-rejection $false_notready exceeds MAX_FALSE_NOTREADY=$MAX_FALSE_NOTREADY" >&2
+  exit 1
+fi
+
 # Non-zero exit ONLY on a NEW false-READY beyond the documented allowlist.
-[ "$new_false_ready" -eq 0 ]
+if [ "$new_false_ready" -ne 0 ]; then
+  echo "[diff-compile-check] FAIL: $new_false_ready NEW false-READY:$new_false_ready_files" >&2
+  exit 1
+fi
+exit 0

--- a/scripts/tools/diff_compile_check.sh
+++ b/scripts/tools/diff_compile_check.sh
@@ -31,11 +31,12 @@
 # (CLI-only, monotone) and false_ready_oracle.sh (pdflatex, HARD drift only).
 #
 # EXIT CODES: 0 clean | 1 a NEW false-READY beyond the allowlist | 2 infrastructure
-# (no pdflatex, no CLI, too few docs, a timeout, or a vacuous run) | 3 engine skew.
+# (no pdflatex, no CLI, too few docs, a timeout, or a vacuous run) | 3 engine skew
+# | 4 over-rejection budget exceeded (SAFE direction — never conflate with 1).
 #
 # ENV: REQUIRE_PDFLATEX=1 makes every precondition an error instead of a skip;
 #      EXPECT_TEX_VERSION=<substring> asserts the engine; MIN_DOCS (default 65)
-#      floors the corpus size; MAX_FALSE_NOTREADY (default 3) caps over-rejection;
+#      floors the corpus size; MAX_FALSE_NOTREADY (default 6) caps over-rejection;
 #      TEX_TIMEOUT (default 60) bounds each pdflatex run.
 #
 # Usage: diff_compile_check.sh [CORPUS_DIR]
@@ -188,10 +189,16 @@ if [ "$tp" -eq 0 ]; then
   die_infra "ZERO documents were both READY and compiled — the CLI is rejecting everything; these numbers are meaningless"
 fi
 [ "$timeouts" -eq 0 ] || die_infra "$timeouts document(s) timed out; the classification is not trustworthy"
-MAX_FALSE_NOTREADY="${MAX_FALSE_NOTREADY:-3}"
+# Headroom on purpose. Every fix train in this repo is add-NOT-READY-only by
+# construction, so a cap sitting exactly at today's measurement (3) would trip on
+# the very next conservative detector and misreport routine work as breakage.
+# Over-rejection is SAFE — it is not a soundness failure — so it gets its own exit
+# code (4) and must never be confused with a false-READY (1).
+MAX_FALSE_NOTREADY="${MAX_FALSE_NOTREADY:-6}"
 if [ "$false_notready" -gt "$MAX_FALSE_NOTREADY" ]; then
-  echo "[diff-compile-check] FAIL: over-rejection $false_notready exceeds MAX_FALSE_NOTREADY=$MAX_FALSE_NOTREADY" >&2
-  exit 1
+  echo "[diff-compile-check] OVER-REJECTION: $false_notready exceeds MAX_FALSE_NOTREADY=$MAX_FALSE_NOTREADY" >&2
+  echo "[diff-compile-check]   This is the SAFE direction (conservative), not a soundness regression." >&2
+  exit 4
 fi
 
 # Non-zero exit ONLY on a NEW false-READY beyond the documented allowlist.

--- a/scripts/tools/false_ready_oracle.sh
+++ b/scripts/tools/false_ready_oracle.sh
@@ -53,6 +53,12 @@ FRDIR="$ROOT/corpora/false_ready"
 MAN="$FRDIR/manifest.json"
 REQUIRE="${REQUIRE_PDFLATEX:-0}"
 TEX_TIMEOUT="${TEX_TIMEOUT:-30}"
+# `gtimeout 0 CMD` means "no limit" — that silently reinstates the ungraded-hang
+# condition this script argues at length must never happen.
+case "$TEX_TIMEOUT" in
+  ''|*[!0-9]*) echo "[fr-oracle] FATAL: TEX_TIMEOUT must be a positive integer, got '$TEX_TIMEOUT'" >&2; exit 2 ;;
+  0) echo "[fr-oracle] FATAL: TEX_TIMEOUT=0 disables the timeout; refusing (a hang would be graded)" >&2; exit 2 ;;
+esac
 
 die_infra() { echo "[fr-oracle] FATAL: $*" >&2; exit 2; }
 
@@ -64,7 +70,8 @@ fx = m.get('fixtures')
 if not isinstance(fx, list) or not fx:
     sys.exit('manifest has no usable fixtures list')
 for f in fx:
-    print('\t'.join([f['id'], f['path'], f['kind'], f['pdflatex']]))
+    print('\t'.join([f['id'], f['path'], f['kind'], f['pdflatex'],
+                     f.get('expected_cli', '')]))
 "
 }
 
@@ -100,14 +107,40 @@ fi
 
 [ -f "$MAN" ] || die_infra "no manifest at $MAN"
 
+# A CLI that cannot execute (wrong ABI inside the container, missing loader)
+# returns non-zero for EVERY document, which reads as a uniform column of
+# NOT-READY and grades perfectly `ok`. Prove it runs before trusting its verdicts.
+# Invoked with no arguments the CLI prints its usage banner and exits 2. We check
+# for the BANNER, not the exit code: a binary that cannot load (wrong ABI inside
+# the container, missing loader) also exits non-zero but prints nothing, and would
+# otherwise answer NOT-READY to all 21 fixtures — a uniform column of lies that
+# grades perfectly `ok`.
+# NB: capture, then test. A pipeline would be governed by `set -o pipefail`, and
+# the CLI deliberately exits 2 here, so `"$CLI" | grep -q` fails even when grep
+# matches.
+CLI_BANNER="$("$CLI" 2>&1 || true)"
+if ! printf '%s' "$CLI_BANNER" | grep -q 'Usage:'; then
+  die_infra "the CLI at $CLI did not produce its usage banner — it cannot execute here (ABI/loader problem?), so its verdicts would be meaningless"
+fi
+
 # ── engine pin ───────────────────────────────────────────────────────────────
 # A re-pin must report as "PIN MISMATCH", never as 21 lines of DRIFT. Those are
 # different problems with different fixes, and conflating them is how a gate gets
 # switched off instead of understood.
-MAN_ENGINE="$(python3 -c "
+# FR_EXPECT_ENGINE lets the caller supply the pin directly. Without it we parse
+# the manifest with python3 — but the TeX container deliberately has no python3,
+# so relying on that alone made the pin FAIL OPEN exactly where it ships: a
+# skewed engine would have been graded silently. The workflow passes it in.
+MAN_ENGINE="${FR_EXPECT_ENGINE:-}"
+if [ -z "$MAN_ENGINE" ]; then
+  MAN_ENGINE="$(python3 -c "
 import json
 print(json.load(open('$MAN')).get('oracle', {}).get('version', ''))
 " 2>/dev/null || true)"
+fi
+if [ -z "$MAN_ENGINE" ] && [ "$REQUIRE" = 1 ]; then
+  die_infra "cannot determine the expected engine (no FR_EXPECT_ENGINE and no readable manifest oracle.version) — refusing to grade against an unpinned engine"
+fi
 GOT_ENGINE="$(pdflatex --version 2>/dev/null | head -1)"
 if [ -n "$MAN_ENGINE" ]; then
   case "$GOT_ENGINE" in
@@ -156,15 +189,22 @@ run_pdflatex() { # $1=workdir $2=base $3=halt(0/1) -> echoes "rc pdf"
 }
 
 hard=0; soft=0; n=0; timeouts=0
-while IFS=$'\t' read -r id path kind pdfl; do
+while IFS=$'\t' read -r id path kind pdfl exp_cli; do
   [ -n "$id" ] || continue
   n=$((n+1))
   # Stage a fresh copy so committed sibling .aux/.bbl inputs are preserved.
+  # An unchecked `cp` let a DELETED fixture grade `ok`: 13 of 21 are strong-fatal,
+  # and a missing input also fails to compile, so they look identical. #506 already
+  # lost a fixture to .gitignore once.
+  [ -e "$FRDIR/$path" ] || die_infra "fixture input missing on disk: $path (id=$id)"
   wd="$(mktemp -d)"
   if [ "$kind" = single ]; then
-    cp "$FRDIR/$path" "$wd/"; base="$(basename "$path")"; rundir="$wd"
+    cp "$FRDIR/$path" "$wd/" || die_infra "cannot stage fixture $id"
+    base="$(basename "$path")"; rundir="$wd"
   else
-    sub="${path%%/*}"; cp -R "$FRDIR/$sub" "$wd/"; base="$(basename "$path")"; rundir="$wd/$sub"
+    sub="${path%%/*}"
+    cp -R "$FRDIR/$sub" "$wd/" || die_infra "cannot stage fixture tree $id"
+    base="$(basename "$path")"; rundir="$wd/$sub"
   fi
   if "$CLI" --compile-check "$FRDIR/$path" >/dev/null 2>&1; then cli=READY; else cli=NOT-READY; fi
 
@@ -176,11 +216,23 @@ while IFS=$'\t' read -r id path kind pdfl; do
   # attributed to the nonstop run and silently convert strong-fatal -> error-halt.
   rm -f "$rundir/${base%.tex}.pdf" "$rundir/${base%.tex}.log"
   read -r nrc npdf  <<<"$(run_pdflatex "$rundir" "$base" 0)"
+  logfile="$(mktemp)"
+  cp "$rundir/${base%.tex}.log" "$logfile" 2>/dev/null || : > "$logfile"
   rm -rf "$wd"
 
-  # 124 = GNU timeout kill. Never let it become a grade.
-  if [ "$hrc" = 124 ] || [ "$nrc" = 124 ]; then
-    printf '%-24s TIMEOUT after %ss — refusing to grade\n' "$id" "$TEX_TIMEOUT"
+  # 124 = timeout kill; 125/126/127 = timeout itself failed / not executable /
+  # not found. None is a property of the DOCUMENT, yet all of them look exactly
+  # like "failed with no PDF" = strong-fatal, which MATCHES the manifest for most
+  # fixtures. A pdflatex that cannot run at all would have graded 21/21 `ok`.
+  case "$hrc:$nrc" in
+    *124*|*125*|*126*|*127*)
+      printf '%-24s pdflatex could not be run (rc halt=%s nonstop=%s) — refusing to grade\n' \
+        "$id" "$hrc" "$nrc"
+      timeouts=$((timeouts+1)); continue ;;
+  esac
+  # Affirmative proof that TeX actually ran, rather than inference from a failure.
+  if [ ! -s "$logfile" ] || ! grep -qi 'pdftex\|pdflatex' "$logfile" 2>/dev/null; then
+    printf '%-24s no pdfTeX log produced — pdflatex did not really run; refusing to grade\n' "$id"
     timeouts=$((timeouts+1)); continue
   fi
 
@@ -197,7 +249,14 @@ while IFS=$'\t' read -r id path kind pdfl; do
   elif [ "$grade" != "$pdfl" ]; then
     status="soft drift: grade $grade != manifest $pdfl (both are rejections)"; soft=$((soft+1))
   fi
+  # F1: the cli column was computed and never checked. A CLI that answers READY to
+  # everything (i.e. every round-7 fix reverted) graded 21/21 `ok`.
+  if [ -n "${exp_cli:-}" ] && [ "$cli" != "$exp_cli" ]; then
+    status="$status | CLI MISMATCH: got $cli, manifest expects $exp_cli"
+    hard=$((hard+1))
+  fi
   printf '%-24s cli=%-9s pdflatex=%-12s manifest=%-12s %s\n' "$id" "$cli" "$grade" "$pdfl" "$status"
+  rm -f "$logfile"
 done < "$TSV"
 
 # Anti-vacuity: processing fewer fixtures than the manifest lists is a failure,
@@ -211,6 +270,13 @@ echo "[fr-oracle] checked $n fixtures; hard=$hard soft=$soft (engine: $GOT_ENGIN
 if [ "$hard" -ne 0 ]; then
   echo "[fr-oracle] FAIL: $hard fixture(s) that pdflatex now compiles." >&2
   exit 1
+fi
+# Mass reclassification is not a benign font difference; it is what a broken or
+# fake TeX install looks like. Half the corpus moving at once is not a soft signal.
+if [ "$soft" -ge $(( (n + 1) / 2 )) ] && [ "$soft" -gt 0 ]; then
+  echo "[fr-oracle] FAIL: $soft of $n fixtures reclassified — that is the signature of a" >&2
+  echo "[fr-oracle]   broken or incomplete TeX install, not of per-fixture drift." >&2
+  exit 2
 fi
 if [ "$soft" -ne 0 ]; then
   echo "[fr-oracle] NOTE: $soft strong-fatal/error-halt reclassification(s); all still rejections." >&2

--- a/scripts/tools/false_ready_oracle.sh
+++ b/scripts/tools/false_ready_oracle.sh
@@ -1,40 +1,165 @@
 #!/usr/bin/env bash
-# Local pdflatex oracle for the round-7 false-READY corpus (R7-INFRA-2, local
-# form). For every fixture in corpora/false_ready/manifest.json it runs the CLI
-# and real pdflatex (both protocols) and checks the observed grade still matches
-# the manifest's recorded `pdflatex` field (strong-fatal | error-halt). This is
-# the drift guard: if a TeX Live upgrade changes a fixture's real behaviour, this
-# surfaces it. CI has no TeX, so this is a LOCAL / pre-release gate; the CI gate
-# is scripts/tools/check_known_false_ready.py (CLI-only, ground truth baked in).
+# pdflatex oracle for the round-7 false-READY corpus (R7-INFRA-2).
 #
-# Usage: false_ready_oracle.sh          # verify manifest matches reality
-# Requires: pdflatex on PATH, the CLI built, python3. Exits nonzero on mismatch.
+# For every fixture in corpora/false_ready/manifest.json it runs the CLI and real
+# pdflatex (both protocols) and checks the observed grade still matches the
+# manifest's recorded `pdflatex` field (strong-fatal | error-halt). This is the
+# drift guard: if a TeX Live change alters a fixture's real behaviour, it surfaces
+# here rather than silently invalidating the corpus.
+#
+# Runs BOTH locally and in CI (.github/workflows/tex-oracle.yml, inside a
+# digest-pinned TeX Live image). The CLI-only monotone gate remains
+# scripts/tools/check_known_false_ready.py, wired into ci.yml's `build` job.
+#
+# ── DRIFT SEVERITY ───────────────────────────────────────────────────────────
+# HARD (exit 1): a fixture that pdflatex now COMPILES. This is the soundness
+#   signal, and it is the one grade no environmental defect can manufacture — a
+#   missing package or font makes a document fail, never succeed.
+# SOFT (warn):  strong-fatal <-> error-halt. Both mean "pdflatex rejects it"; the
+#   distinction only records whether nonstopmode limped to a PDF, which is exactly
+#   what an incomplete font install or a TeX error-recovery change moves.
+#   Measured: with Type1 fonts hidden, all 8 error-halt fixtures flip to
+#   strong-fatal. Failing on that would be crying wolf, and a gate that cries wolf
+#   gets disabled. STRICT_GRADE=1 makes SOFT fatal too (use when deliberately
+#   re-recording the manifest).
+# For the record: TL2024 (pdfTeX 1.40.26) vs TL2026 (1.40.29) produce ZERO drift
+# and byte-identical first-error text on all 21 fixtures. Engine YEAR is not the
+# fragile axis; install COMPLETENESS is.
+#
+# ── EXIT CODES ───────────────────────────────────────────────────────────────
+#   0  clean
+#   1  HARD drift (a fixture now compiles / grade mismatch under STRICT_GRADE)
+#   2  infrastructure (no pdflatex, no CLI, no timeout, unparseable manifest,
+#      zero fixtures processed, a pdflatex run that timed out)
+#   3  engine skew (pdflatex version != manifest oracle.version)
+#
+# ── ENV ──────────────────────────────────────────────────────────────────────
+#   REQUIRE_PDFLATEX=1  every precondition is an error, never a skip (CI sets it)
+#   STRICT_GRADE=1      SOFT drift also fails
+#   ALLOW_ENGINE_SKEW=1 engine mismatch warns instead of exit 3
+#   FR_FIXTURE_TSV=path pre-computed fixture TSV; skips python3 entirely, which is
+#                       what lets the TeX container stay dependency-free
+#   TEX_TIMEOUT=30      per-pdflatex-run timeout in seconds
+#
+# Usage:
+#   false_ready_oracle.sh                  verify the manifest matches reality
+#   false_ready_oracle.sh --emit-fixtures  print the fixture TSV and exit
 set -u
+set -o pipefail
+
 ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 CLI="$ROOT/_build/default/latex-parse/src/validators_cli.exe"
 FRDIR="$ROOT/corpora/false_ready"
 MAN="$FRDIR/manifest.json"
-TIMEOUT="$(command -v gtimeout || command -v timeout || true)"
+REQUIRE="${REQUIRE_PDFLATEX:-0}"
+TEX_TIMEOUT="${TEX_TIMEOUT:-30}"
 
-command -v pdflatex >/dev/null 2>&1 || { echo "[fr-oracle] SKIP: no pdflatex on PATH"; exit 0; }
-[ -x "$CLI" ] || { echo "[fr-oracle] building CLI..."; (cd "$ROOT" && opam exec -- dune build latex-parse/src/validators_cli.exe) || exit 2; }
-[ -f "$MAN" ] || { echo "[fr-oracle] ERROR: no manifest at $MAN"; exit 2; }
+die_infra() { echo "[fr-oracle] FATAL: $*" >&2; exit 2; }
+
+emit_fixtures() { # -> TSV on stdout; nonzero if the manifest is unusable
+  python3 -c "
+import json, sys
+m = json.load(open('$MAN'))
+fx = m.get('fixtures')
+if not isinstance(fx, list) or not fx:
+    sys.exit('manifest has no usable fixtures list')
+for f in fx:
+    print('\t'.join([f['id'], f['path'], f['kind'], f['pdflatex']]))
+"
+}
+
+if [ "${1:-}" = "--emit-fixtures" ]; then
+  emit_fixtures || die_infra "cannot emit fixtures from $MAN"
+  exit 0
+fi
+
+# ── preconditions ────────────────────────────────────────────────────────────
+if ! command -v pdflatex >/dev/null 2>&1; then
+  [ "$REQUIRE" = 1 ] && die_infra "REQUIRE_PDFLATEX=1 but pdflatex is not on PATH"
+  echo "[fr-oracle] SKIP: no pdflatex on PATH"; exit 0
+fi
+
+TIMEOUT="$(command -v gtimeout || command -v timeout || true)"
+if [ -z "$TIMEOUT" ]; then
+  # Without a timeout a hung pdflatex would be GRADED: GNU timeout's 124 looks
+  # exactly like "failed with no PDF" = strong-fatal, which MATCHES the manifest
+  # for most fixtures. A hanging TeX Live would report `ok`. Refuse to grade.
+  [ "$REQUIRE" = 1 ] && die_infra "REQUIRE_PDFLATEX=1 but neither gtimeout nor timeout is available"
+  echo "[fr-oracle] WARNING: no timeout binary; a hung pdflatex is indistinguishable from a fatal" >&2
+fi
+
+if [ ! -x "$CLI" ]; then
+  # A gate must never build its own subject: CI builds the CLI in an earlier,
+  # separately-visible step so a build failure is reported as a build failure.
+  [ "$REQUIRE" = 1 ] && die_infra "REQUIRE_PDFLATEX=1 but the CLI is missing at $CLI (build it in its own step)"
+  echo "[fr-oracle] building CLI..."
+  (cd "$ROOT" && opam exec -- dune build latex-parse/src/validators_cli.exe) \
+    || die_infra "CLI build failed"
+  [ -x "$CLI" ] || die_infra "CLI still missing after build: $CLI"
+fi
+
+[ -f "$MAN" ] || die_infra "no manifest at $MAN"
+
+# ── engine pin ───────────────────────────────────────────────────────────────
+# A re-pin must report as "PIN MISMATCH", never as 21 lines of DRIFT. Those are
+# different problems with different fixes, and conflating them is how a gate gets
+# switched off instead of understood.
+MAN_ENGINE="$(python3 -c "
+import json
+print(json.load(open('$MAN')).get('oracle', {}).get('version', ''))
+" 2>/dev/null || true)"
+GOT_ENGINE="$(pdflatex --version 2>/dev/null | head -1)"
+if [ -n "$MAN_ENGINE" ]; then
+  case "$GOT_ENGINE" in
+    *"$MAN_ENGINE"*) ;;
+    *)
+      if [ "${ALLOW_ENGINE_SKEW:-0}" = 1 ]; then
+        echo "[fr-oracle] WARNING: engine skew (have '$GOT_ENGINE', manifest '$MAN_ENGINE')" >&2
+      else
+        echo "[fr-oracle] PIN MISMATCH: pdflatex is '$GOT_ENGINE' but the manifest records '$MAN_ENGINE'." >&2
+        echo "[fr-oracle]   This is NOT oracle drift. Either re-pin the engine, or deliberately" >&2
+        echo "[fr-oracle]   re-record the manifest (see docs/COMPILATION_GUARANTEE.md SO1)." >&2
+        echo "[fr-oracle]   ALLOW_ENGINE_SKEW=1 downgrades this to a warning." >&2
+        exit 3
+      fi
+      ;;
+  esac
+fi
+
+# ── fixtures ─────────────────────────────────────────────────────────────────
+# Read from a FILE, never a process substitution: `done < <(python3 ...)` hides
+# python's exit status, so a manifest whose shape changed printed
+# "checked 0 fixtures; drift=0" and exited 0 — a green gate that tested nothing.
+TSV="$(mktemp)"; trap 'rm -f "$TSV"' EXIT
+if [ -n "${FR_FIXTURE_TSV:-}" ]; then
+  [ -f "$FR_FIXTURE_TSV" ] || die_infra "FR_FIXTURE_TSV=$FR_FIXTURE_TSV does not exist"
+  cp "$FR_FIXTURE_TSV" "$TSV"
+else
+  emit_fixtures > "$TSV" || die_infra "cannot parse $MAN (fixtures list missing or malformed)"
+fi
+EXPECT_N="$(wc -l < "$TSV" | tr -d ' ')"
+[ "${EXPECT_N:-0}" -gt 0 ] || die_infra "zero fixtures to check — refusing to report success"
 
 run_pdflatex() { # $1=workdir $2=base $3=halt(0/1) -> echoes "rc pdf"
   local wd="$1" base="$2" halt="$3" rc pdf
   local -a cmd=(pdflatex -interaction=nonstopmode)
   [ "$halt" = 1 ] && cmd+=(-halt-on-error)
   cmd+=("$base")
-  if [ -n "$TIMEOUT" ]; then ( cd "$wd" && "$TIMEOUT" 30 "${cmd[@]}" >/dev/null 2>&1 ); else ( cd "$wd" && "${cmd[@]}" >/dev/null 2>&1 ); fi
+  if [ -n "$TIMEOUT" ]; then
+    ( cd "$wd" && "$TIMEOUT" "$TEX_TIMEOUT" "${cmd[@]}" >/dev/null 2>&1 )
+  else
+    ( cd "$wd" && "${cmd[@]}" >/dev/null 2>&1 )
+  fi
   rc=$?
   [ -f "$wd/${base%.tex}.pdf" ] && pdf=yes || pdf=no
   echo "$rc $pdf"
 }
 
-fails=0; n=0
+hard=0; soft=0; n=0; timeouts=0
 while IFS=$'\t' read -r id path kind pdfl; do
+  [ -n "$id" ] || continue
   n=$((n+1))
-  # stage a fresh copy so committed sibling .aux/.bbl inputs are preserved
+  # Stage a fresh copy so committed sibling .aux/.bbl inputs are preserved.
   wd="$(mktemp -d)"
   if [ "$kind" = single ]; then
     cp "$FRDIR/$path" "$wd/"; base="$(basename "$path")"; rundir="$wd"
@@ -42,25 +167,55 @@ while IFS=$'\t' read -r id path kind pdfl; do
     sub="${path%%/*}"; cp -R "$FRDIR/$sub" "$wd/"; base="$(basename "$path")"; rundir="$wd/$sub"
   fi
   if "$CLI" --compile-check "$FRDIR/$path" >/dev/null 2>&1; then cli=READY; else cli=NOT-READY; fi
+
+  # ORDERING IS LOAD-BEARING: halt-on-error FIRST. fr_corrupt_aux's doc.aux is
+  # rewritten by a run that gets far enough, so a nonstop-first ordering makes the
+  # second run see a repaired .aux and grade `compiles`. Do not reorder.
   read -r hrc _hpdf <<<"$(run_pdflatex "$rundir" "$base" 1)"
+  # Clear artefacts between protocols: a PDF left by the halt run would be
+  # attributed to the nonstop run and silently convert strong-fatal -> error-halt.
+  rm -f "$rundir/${base%.tex}.pdf" "$rundir/${base%.tex}.log"
   read -r nrc npdf  <<<"$(run_pdflatex "$rundir" "$base" 0)"
   rm -rf "$wd"
+
+  # 124 = GNU timeout kill. Never let it become a grade.
+  if [ "$hrc" = 124 ] || [ "$nrc" = 124 ]; then
+    printf '%-24s TIMEOUT after %ss — refusing to grade\n' "$id" "$TEX_TIMEOUT"
+    timeouts=$((timeouts+1)); continue
+  fi
+
   if [ "$nrc" != 0 ] && [ "$npdf" = no ]; then grade=strong-fatal
   elif [ "$hrc" != 0 ]; then grade=error-halt
   else grade=compiles; fi
-  status=ok
-  # Every fixture must remain a false-READY relative to its recorded strictness,
-  # while it is still live (CLI READY). A CLI NOT-READY here means it was fixed
-  # (the CLI gate handles that bookkeeping); we only flag pdflatex-side drift.
-  if [ "$cli" = READY ] && [ "$grade" = compiles ]; then status="DRIFT: pdflatex now COMPILES (no longer a false-READY)"; fails=$((fails+1)); fi
-  if [ "$grade" != compiles ] && [ "$grade" != "$pdfl" ]; then status="DRIFT: pdflatex grade $grade != manifest $pdfl"; fails=$((fails+1)); fi
-  printf '%-24s cli=%-9s pdflatex=%-12s manifest=%-12s %s\n' "$id" "$cli" "$grade" "$pdfl" "$status"
-done < <(python3 -c "
-import json,sys
-m=json.load(open('$MAN'))
-for f in m['fixtures']:
-    print('\t'.join([f['id'],f['path'],f['kind'],f['pdflatex']]))
-")
 
-echo "[fr-oracle] checked $n fixtures; drift=$fails"
-[ "$fails" -eq 0 ]
+  status=ok
+  # HARD: pdflatex compiles it. For a LIVE fixture that means it was never a
+  # false-READY; for a FIXED one it means we now over-reject a compiling doc.
+  # Both are real, both are loud.
+  if [ "$grade" = compiles ]; then
+    status="HARD DRIFT: pdflatex now COMPILES this fixture (cli=$cli)"; hard=$((hard+1))
+  elif [ "$grade" != "$pdfl" ]; then
+    status="soft drift: grade $grade != manifest $pdfl (both are rejections)"; soft=$((soft+1))
+  fi
+  printf '%-24s cli=%-9s pdflatex=%-12s manifest=%-12s %s\n' "$id" "$cli" "$grade" "$pdfl" "$status"
+done < "$TSV"
+
+# Anti-vacuity: processing fewer fixtures than the manifest lists is a failure,
+# not a pass. This is what makes "checked 0 fixtures" impossible.
+if [ "$n" -ne "$EXPECT_N" ]; then
+  die_infra "processed $n of $EXPECT_N fixtures — refusing to report success"
+fi
+[ "$timeouts" -eq 0 ] || die_infra "$timeouts fixture(s) timed out; grades are not trustworthy"
+
+echo "[fr-oracle] checked $n fixtures; hard=$hard soft=$soft (engine: $GOT_ENGINE)"
+if [ "$hard" -ne 0 ]; then
+  echo "[fr-oracle] FAIL: $hard fixture(s) that pdflatex now compiles." >&2
+  exit 1
+fi
+if [ "$soft" -ne 0 ]; then
+  echo "[fr-oracle] NOTE: $soft strong-fatal/error-halt reclassification(s); all still rejections." >&2
+  if [ "${STRICT_GRADE:-0}" = 1 ]; then
+    echo "[fr-oracle] STRICT_GRADE=1 -> failing." >&2; exit 1
+  fi
+fi
+exit 0

--- a/specs/v26/compilation_profiles.yaml
+++ b/specs/v26/compilation_profiles.yaml
@@ -38,7 +38,11 @@ profiles:
       # was vacuous. Also corrected: 1.40.25 is TeX Live 2023, not 2024 (TL2024
       # ships 1.40.26). The tested value is now the pinned oracle engine —
       # see docs/COMPILATION_GUARANTEE.md § SO1, the single home of that pin.
-      min: "3.141592653-2.6-1.40.20"   # TeX Live 2019 minimum
+      # NB: 1.40.20 actually reported the 10-digit "3.14159265" banner, so this
+      # full string matches no real engine either. Compare only the 1.40.x
+      # component if this is ever made load-bearing (today nothing reads it:
+      # `grep -rn toolchain_version_range` finds no consumer).
+      min: "1.40.20"                    # TeX Live 2019 minimum (version component only)
       tested: "3.141592653-2.6-1.40.29" # TeX Live 2026 (pinned oracle, SO1)
     pass_iteration:
       bounded: true

--- a/specs/v26/compilation_profiles.yaml
+++ b/specs/v26/compilation_profiles.yaml
@@ -32,8 +32,14 @@ profiles:
       - opentype_fonts            # system fonts → xelatex / lualatex
       - lua_scripting             # \directlua → lualatex
     toolchain_version_range:
-      min: "3.14159265-2.6-1.40.20"   # TeX Live 2019 minimum
-      tested: "3.14159265-2.6-1.40.25" # TeX Live 2024 tested
+      # NOTE: the banner prefix is "3.141592653" (11 digits) for every engine from
+      # 1.40.22 on. The previous "3.14159265" (10) is the pre-2021 form and could
+      # never substring-match a real `pdflatex --version`, so any check against it
+      # was vacuous. Also corrected: 1.40.25 is TeX Live 2023, not 2024 (TL2024
+      # ships 1.40.26). The tested value is now the pinned oracle engine —
+      # see docs/COMPILATION_GUARANTEE.md § SO1, the single home of that pin.
+      min: "3.141592653-2.6-1.40.20"   # TeX Live 2019 minimum
+      tested: "3.141592653-2.6-1.40.29" # TeX Live 2026 (pinned oracle, SO1)
     pass_iteration:
       bounded: true
       typical_max: 5               # most projects converge ≤5 passes


### PR DESCRIPTION
CI contained **zero** texlive; the only `pdflatex` string in any workflow was a comment. Both pdflatex-dependent scripts `exit 0` when the binary is absent, so they had **never run in CI at all** — which means every "0 over-rejection on N real papers" claim across nine merged fix trains was a local sweep nobody else could reproduce. **Single commit — squash-safe.**

## The research inverted my hypothesis

I expected TeX Live **version skew** to be the risk. It isn't, and that's measured rather than argued: **TL2024 (pdfTeX 1.40.26) vs TL2026 (1.40.29) produce zero drift and byte-identical first-error text on all 21 fixtures.** I re-ran it myself on both local installs to confirm.

The real risk is install **completeness**, and it breaks in both directions:

| defect | effect |
|---|---|
| missing Type1 fonts | all 8 error-halt fixtures flip to strong-fatal → **8 false reds** |
| missing `.sty` | grades `strong-fatal`, **identical to the intended fatal** → fixtures report `ok` **while testing nothing** |

Silent green is the worse failure. Hence the **HARD/SOFT drift split** — fail only on a fixture pdflatex now *compiles*, the one grade no environmental defect can manufacture — plus an **install canary** that must compile the corpus feature set before anything is graded.

## Silent-success paths closed (all measured, not theorised)

- **manifest whose JSON shape changed** → `checked 0 fixtures; drift=0`, **exit 0**. The process substitution swallowed Python's exit status.
- **misrooted corpus** → `total=0`, **exit 0**.
- **a CLI rejecting everything** → `total=65, FALSE-READY=0`, **exit 0** — a green gate on a completely broken checker.
- **GNU `timeout`'s 124 looks exactly like "failed, no PDF" = strong-fatal**, which *matches the manifest* for most fixtures — so a hanging TeX Live reported `ok`. The differential had no timeout at all.
- **artefacts shared between protocol runs**: a PDF left by the halt run would be attributed to the nonstop run, silently converting strong-fatal → error-halt. Also documented that **halt-first ordering is load-bearing** — `fr_corrupt_aux`'s `doc.aux` is rewritten by a run that gets far enough.

`REQUIRE_PDFLATEX=1` makes every precondition an error instead of a skip. Exit codes are distinct so a re-pin can never be misread as a soundness regression: **0** clean, **1** drift, **2** infrastructure, **3** engine skew.

## Verified in both directions

A gate nobody has seen fail proves nothing:

| test | result |
|---|---|
| clean run | 21/21, `hard=0 soft=0`, 12s |
| broken manifest | exit **2** |
| `REQUIRE_PDFLATEX=1`, pdflatex hidden | exit **2** |
| real TL2024 on PATH | exit **3** PIN MISMATCH |
| empty corpus | exit **2** |
| bad `EXPECT_TEX_VERSION` | exit **3** |

## Advisory on purpose

Not added to `.github/required-status-checks.json`. `branch-protection.yml` PUTs `enforce_admins: true`, so a red **required** check here would be unbypassable even by you and would stall every PR; and this is the repo's first Docker pull on the PR path. The invisibility problem is solved the moment it runs on every PR and prints the engine version. Promote after a soak — via the JSON file, never the API, which `branch-protection.yml` overwrites.

The differential stays `continue-on-error` **permanently**: its exit condition is a *measurement*, it needs the large correctness-critical install, and it's blind to a CLI broken in the over-rejection direction.

## The pin

Pinned by **multi-arch OCI index digest** (not a per-arch manifest digest, which would lock the runner architecture). I verified via the registry API that the digest resolves, is the index, and is **byte-identical to the immutable dated tag** `registry.gitlab.com/islandoftex/images/texlive:TL2026-2026-07-26-medium` — so it's anchored and can't be GC'd as an untagged orphan.

`scheme-medium`, not `-small`: two corpus documents use `[T1]{fontenc}` and `cm-super`/`lm` live in `collection-fontsrecommended`, which `-small` omits.

⚠️ **UNVERIFIED**: the image's actual engine version and package inventory. The Docker daemon isn't running on this machine, so I could not execute the image. The engine-assert and canary steps exist precisely to catch that loudly on the first CI run — if the pin is wrong, this PR's own CI will say so clearly rather than mis-grade anything.

## Docs

- **`docs/COMPILATION_GUARANTEE.md` gains a real `SO1 — Pinned oracle engine` section.** `corpora/false_ready/manifest.json` has always graded itself against "COMPILATION_GUARANTEE.md SO1" — **and that string did not exist in the file.** The central soundness ledger was citing a dangling reference.
- **`specs/v26/compilation_profiles.yaml`**: `"3.14159265-..."` is the pre-2021 banner form and **could never substring-match a real `pdflatex --version`**, so any check against it was vacuous. Also `1.40.25` is TL2023, not TL2024.
- `workflow_count` 36 → 37, regenerated rather than hand-edited.

## Known, deliberately not fixed here

The differential now measures **34/20/8/3** where the docs say **35/20/8/2** — real drift in the safe direction (one more over-rejection: `fail_duplicate_label`, `tolerated_bare_unclosed_brace`, `tolerated_write18`). Correcting the published matrix means touching the `check_roadmap_facts` strings too, which belongs to the rank-10 honesty sweep, not here.