### PR TITLE
feat(R7-INFRA-4): apply-fixes round-trip gate + adversarial fixer corpus

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,3 +98,22 @@ jobs:
         # the manifest. pdflatex ground truth is baked into the manifest (no TeX
         # needed here); refresh locally via scripts/tools/false_ready_oracle.sh.
         run: python3 scripts/tools/check_known_false_ready.py --repo .
+
+      - name: Apply-fixes round-trip gate (R7-INFRA-4)
+        # The fixer rewrites user documents and nothing re-checked its own output,
+        # so a fix that BREAKS a document was invisible. Measured: 2 of the 65
+        # compile_check docs compile before the fixer and fail after
+        # (good_tikz_simple, good_accents_utf8), and neither is caught by
+        # --compile-check — only real pdflatex sees them.
+        #
+        # This step evaluates the two CLI-only properties, (a) idempotence and
+        # (c) verdict-non-degradation. Property (b), oracle-class preservation,
+        # needs real pdflatex and is NOT covered here; it runs in
+        # pre_release_check.py locally. Wiring (b) into the tex-oracle workflow is
+        # blocked on the pinned TeX image having python3, which is unconfirmed —
+        # the image is deliberately dependency-free. Tracked, not silently skipped.
+        #
+        # Monotone like the false-READY gate: known defects live in
+        # corpora/apply_fixes/manifest.json, so this lands green and fails on a
+        # NEW defect or on an unrecorded improvement.
+        run: python3 scripts/tools/check_apply_fixes_roundtrip.py --repo .

--- a/corpora/apply_fixes/adv--child.tex
+++ b/corpora/apply_fixes/adv--child.tex
@@ -1,0 +1,1 @@
+Child body.

--- a/corpora/apply_fixes/adv_accent_backtick.tex
+++ b/corpora/apply_fixes/adv_accent_backtick.tex
@@ -1,0 +1,8 @@
+% Adversarial fixture: a backtick that IS a LaTeX command, not a quote.
+% The backtick form of the grave-accent command is a COMMAND; rewriting that
+% backtick to U+2018 destroys it.
+% NOT caught by --compile-check: only real pdflatex sees it.
+\documentclass{article}
+\begin{document}
+Accents: \'e \`a \^o \"u \c{c} \~n.
+\end{document}

--- a/corpora/apply_fixes/adv_input_filename.tex
+++ b/corpora/apply_fixes/adv_input_filename.tex
@@ -1,0 +1,11 @@
+% Adversarial fixture: a double hyphen inside an include FILENAME.
+% TYPO-002 rewrites the double hyphen to an en dash. In a filename that is not
+% typography, it is an identifier: the rewritten document asks TeX for a file
+% that does not exist.
+% NOTE: this comment deliberately avoids writing the include command itself,
+% because T2's include extraction is comment-blind and would treat the mention
+% as a real edge (see the note in this fixture's manifest entry).
+\documentclass{article}
+\begin{document}
+\input{adv--child}
+\end{document}

--- a/corpora/apply_fixes/adv_tikz_path.tex
+++ b/corpora/apply_fixes/adv_tikz_path.tex
@@ -1,0 +1,11 @@
+% Adversarial fixture: `--` inside a TikZ path.
+% The double hyphen is pgf's line-to PATH OPERATOR, not punctuation. Rewriting it
+% dash yields "! Package tikz Error: Giving up on this path." and no PDF.
+% NOT caught by --compile-check: only real pdflatex sees it.
+\documentclass{article}
+\usepackage{tikz}
+\begin{document}
+\begin{tikzpicture}
+  \draw (0,0) -- (2,0) -- (2,2) -- cycle;
+\end{tikzpicture}
+\end{document}

--- a/corpora/apply_fixes/manifest.json
+++ b/corpora/apply_fixes/manifest.json
@@ -9,80 +9,203 @@
   "known_broken": [
     {
       "doc": "corpora/apply_fixes/adv_accent_backtick.tex",
-      "mode": "--apply-fixes",
+      "mode": "default:--apply-fixes",
       "breaks_compile": true,
       "degrades_verdict": false,
-      "not_idempotent": false
+      "not_idempotent": false,
+      "manufactured_false_ready": true
     },
     {
       "doc": "corpora/apply_fixes/adv_accent_backtick.tex",
-      "mode": "--apply-fixes-best-effort",
+      "mode": "default:--apply-fixes-best-effort",
       "breaks_compile": true,
       "degrades_verdict": false,
-      "not_idempotent": false
+      "not_idempotent": false,
+      "manufactured_false_ready": true
+    },
+    {
+      "doc": "corpora/apply_fixes/adv_accent_backtick.tex",
+      "mode": "pilot:--apply-fixes",
+      "breaks_compile": true,
+      "degrades_verdict": false,
+      "not_idempotent": false,
+      "manufactured_false_ready": true
+    },
+    {
+      "doc": "corpora/apply_fixes/adv_accent_backtick.tex",
+      "mode": "pilot:--apply-fixes-best-effort",
+      "breaks_compile": true,
+      "degrades_verdict": false,
+      "not_idempotent": false,
+      "manufactured_false_ready": true
     },
     {
       "doc": "corpora/apply_fixes/adv_input_filename.tex",
-      "mode": "--apply-fixes",
+      "mode": "default:--apply-fixes",
       "breaks_compile": true,
       "degrades_verdict": true,
-      "not_idempotent": false
+      "not_idempotent": false,
+      "manufactured_false_ready": false
     },
     {
       "doc": "corpora/apply_fixes/adv_input_filename.tex",
-      "mode": "--apply-fixes-best-effort",
+      "mode": "default:--apply-fixes-best-effort",
       "breaks_compile": true,
       "degrades_verdict": true,
-      "not_idempotent": false
+      "not_idempotent": false,
+      "manufactured_false_ready": false
+    },
+    {
+      "doc": "corpora/apply_fixes/adv_input_filename.tex",
+      "mode": "pilot:--apply-fixes",
+      "breaks_compile": true,
+      "degrades_verdict": true,
+      "not_idempotent": false,
+      "manufactured_false_ready": false
+    },
+    {
+      "doc": "corpora/apply_fixes/adv_input_filename.tex",
+      "mode": "pilot:--apply-fixes-best-effort",
+      "breaks_compile": true,
+      "degrades_verdict": true,
+      "not_idempotent": true,
+      "manufactured_false_ready": false
     },
     {
       "doc": "corpora/apply_fixes/adv_tikz_path.tex",
-      "mode": "--apply-fixes",
+      "mode": "default:--apply-fixes",
       "breaks_compile": true,
       "degrades_verdict": false,
-      "not_idempotent": false
+      "not_idempotent": false,
+      "manufactured_false_ready": true
     },
     {
       "doc": "corpora/apply_fixes/adv_tikz_path.tex",
-      "mode": "--apply-fixes-best-effort",
+      "mode": "default:--apply-fixes-best-effort",
       "breaks_compile": true,
       "degrades_verdict": false,
-      "not_idempotent": false
+      "not_idempotent": false,
+      "manufactured_false_ready": true
+    },
+    {
+      "doc": "corpora/apply_fixes/adv_tikz_path.tex",
+      "mode": "pilot:--apply-fixes",
+      "breaks_compile": true,
+      "degrades_verdict": false,
+      "not_idempotent": false,
+      "manufactured_false_ready": true
+    },
+    {
+      "doc": "corpora/apply_fixes/adv_tikz_path.tex",
+      "mode": "pilot:--apply-fixes-best-effort",
+      "breaks_compile": true,
+      "degrades_verdict": false,
+      "not_idempotent": false,
+      "manufactured_false_ready": true
     },
     {
       "doc": "corpora/compile_check/good_accents_utf8.tex",
-      "mode": "--apply-fixes",
+      "mode": "default:--apply-fixes",
       "breaks_compile": true,
       "degrades_verdict": false,
-      "not_idempotent": false
+      "not_idempotent": false,
+      "manufactured_false_ready": true
     },
     {
       "doc": "corpora/compile_check/good_accents_utf8.tex",
-      "mode": "--apply-fixes-best-effort",
+      "mode": "default:--apply-fixes-best-effort",
       "breaks_compile": true,
       "degrades_verdict": false,
-      "not_idempotent": false
+      "not_idempotent": false,
+      "manufactured_false_ready": true
+    },
+    {
+      "doc": "corpora/compile_check/good_accents_utf8.tex",
+      "mode": "pilot:--apply-fixes",
+      "breaks_compile": true,
+      "degrades_verdict": false,
+      "not_idempotent": false,
+      "manufactured_false_ready": true
+    },
+    {
+      "doc": "corpora/compile_check/good_accents_utf8.tex",
+      "mode": "pilot:--apply-fixes-best-effort",
+      "breaks_compile": true,
+      "degrades_verdict": false,
+      "not_idempotent": false,
+      "manufactured_false_ready": true
+    },
+    {
+      "doc": "corpora/compile_check/good_longtable_free.tex",
+      "mode": "pilot:--apply-fixes",
+      "breaks_compile": true,
+      "degrades_verdict": false,
+      "not_idempotent": false,
+      "manufactured_false_ready": true
+    },
+    {
+      "doc": "corpora/compile_check/good_longtable_free.tex",
+      "mode": "pilot:--apply-fixes-best-effort",
+      "breaks_compile": true,
+      "degrades_verdict": false,
+      "not_idempotent": false,
+      "manufactured_false_ready": true
     },
     {
       "doc": "corpora/compile_check/good_quotes_dashes.tex",
-      "mode": "--apply-fixes-best-effort",
+      "mode": "default:--apply-fixes-best-effort",
       "breaks_compile": false,
       "degrades_verdict": false,
-      "not_idempotent": true
+      "not_idempotent": true,
+      "manufactured_false_ready": false
+    },
+    {
+      "doc": "corpora/compile_check/good_quotes_dashes.tex",
+      "mode": "pilot:--apply-fixes-best-effort",
+      "breaks_compile": false,
+      "degrades_verdict": false,
+      "not_idempotent": true,
+      "manufactured_false_ready": false
     },
     {
       "doc": "corpora/compile_check/good_tikz_simple.tex",
-      "mode": "--apply-fixes",
+      "mode": "default:--apply-fixes",
       "breaks_compile": true,
       "degrades_verdict": false,
-      "not_idempotent": false
+      "not_idempotent": false,
+      "manufactured_false_ready": true
     },
     {
       "doc": "corpora/compile_check/good_tikz_simple.tex",
-      "mode": "--apply-fixes-best-effort",
+      "mode": "default:--apply-fixes-best-effort",
       "breaks_compile": true,
       "degrades_verdict": false,
-      "not_idempotent": false
+      "not_idempotent": false,
+      "manufactured_false_ready": true
+    },
+    {
+      "doc": "corpora/compile_check/good_tikz_simple.tex",
+      "mode": "pilot:--apply-fixes",
+      "breaks_compile": true,
+      "degrades_verdict": false,
+      "not_idempotent": false,
+      "manufactured_false_ready": true
+    },
+    {
+      "doc": "corpora/compile_check/good_tikz_simple.tex",
+      "mode": "pilot:--apply-fixes-best-effort",
+      "breaks_compile": true,
+      "degrades_verdict": false,
+      "not_idempotent": false,
+      "manufactured_false_ready": true
+    },
+    {
+      "doc": "corpora/compile_check/tolerated_trailing_whitespace.tex",
+      "mode": "pilot:--apply-fixes-best-effort",
+      "breaks_compile": false,
+      "degrades_verdict": false,
+      "not_idempotent": true,
+      "manufactured_false_ready": false
     }
   ]
 }

--- a/corpora/apply_fixes/manifest.json
+++ b/corpora/apply_fixes/manifest.json
@@ -1,0 +1,88 @@
+{
+  "description": "R7-INFRA-4 baseline: documents that --apply-fixes damages. Each entry is a KNOWN defect awaiting the R7-3 fixer guard. The gate fails on a NEW breakage and on an unrecorded improvement, so this list can only shrink.",
+  "properties": {
+    "a_idempotent": "applying twice == applying once",
+    "c_verdict_non_degrading": "a READY document must not become NOT-READY",
+    "b_oracle_class_preserving": "a document that compiled must still compile"
+  },
+  "pdflatex_graded": true,
+  "known_broken": [
+    {
+      "doc": "corpora/apply_fixes/adv_accent_backtick.tex",
+      "mode": "--apply-fixes",
+      "breaks_compile": true,
+      "degrades_verdict": false,
+      "not_idempotent": false
+    },
+    {
+      "doc": "corpora/apply_fixes/adv_accent_backtick.tex",
+      "mode": "--apply-fixes-best-effort",
+      "breaks_compile": true,
+      "degrades_verdict": false,
+      "not_idempotent": false
+    },
+    {
+      "doc": "corpora/apply_fixes/adv_input_filename.tex",
+      "mode": "--apply-fixes",
+      "breaks_compile": true,
+      "degrades_verdict": true,
+      "not_idempotent": false
+    },
+    {
+      "doc": "corpora/apply_fixes/adv_input_filename.tex",
+      "mode": "--apply-fixes-best-effort",
+      "breaks_compile": true,
+      "degrades_verdict": true,
+      "not_idempotent": false
+    },
+    {
+      "doc": "corpora/apply_fixes/adv_tikz_path.tex",
+      "mode": "--apply-fixes",
+      "breaks_compile": true,
+      "degrades_verdict": false,
+      "not_idempotent": false
+    },
+    {
+      "doc": "corpora/apply_fixes/adv_tikz_path.tex",
+      "mode": "--apply-fixes-best-effort",
+      "breaks_compile": true,
+      "degrades_verdict": false,
+      "not_idempotent": false
+    },
+    {
+      "doc": "corpora/compile_check/good_accents_utf8.tex",
+      "mode": "--apply-fixes",
+      "breaks_compile": true,
+      "degrades_verdict": false,
+      "not_idempotent": false
+    },
+    {
+      "doc": "corpora/compile_check/good_accents_utf8.tex",
+      "mode": "--apply-fixes-best-effort",
+      "breaks_compile": true,
+      "degrades_verdict": false,
+      "not_idempotent": false
+    },
+    {
+      "doc": "corpora/compile_check/good_quotes_dashes.tex",
+      "mode": "--apply-fixes-best-effort",
+      "breaks_compile": false,
+      "degrades_verdict": false,
+      "not_idempotent": true
+    },
+    {
+      "doc": "corpora/compile_check/good_tikz_simple.tex",
+      "mode": "--apply-fixes",
+      "breaks_compile": true,
+      "degrades_verdict": false,
+      "not_idempotent": false
+    },
+    {
+      "doc": "corpora/compile_check/good_tikz_simple.tex",
+      "mode": "--apply-fixes-best-effort",
+      "breaks_compile": true,
+      "degrades_verdict": false,
+      "not_idempotent": false
+    }
+  ]
+}

--- a/scripts/tools/check_apply_fixes_roundtrip.py
+++ b/scripts/tools/check_apply_fixes_roundtrip.py
@@ -79,7 +79,17 @@ from pathlib import Path
 
 CORPORA = ["corpora/compile_check", "corpora/apply_fixes"]
 MANIFEST = "corpora/apply_fixes/manifest.json"
-MODES = ["--apply-fixes", "--apply-fixes-best-effort"]
+# TWO ORTHOGONAL AXES, and both matter:
+#   flag    --apply-fixes converges internally; --apply-fixes-best-effort is one pass
+#   profile default vs L0_VALIDATORS=pilot — pilot is a REAL shipping profile
+#           (scripts/tools/diff_compile_check.sh:48 exports it) and is strictly
+#           MORE destructive. Measured: good_longtable_free.tex is corrupted only
+#           under pilot (`>{\bfseries}` -> `\textgreater{}{\bfseries}`, an illegal
+#           pream-token, pdflatex 0 -> 1). Varying only the flag misses that class
+#           entirely, which is exactly what my first version of this gate did.
+FLAGS = ["--apply-fixes", "--apply-fixes-best-effort"]
+PROFILES = [("default", {}), ("pilot", {"L0_VALIDATORS": "pilot"})]
+CELLS = [(pname, penv, flag) for pname, penv in PROFILES for flag in FLAGS]
 MIN_DOCS = 60  # compile_check alone is 65 standalone docs; a smaller sweep is a bug
 
 
@@ -169,7 +179,9 @@ def main() -> int:
                 [str(cli), "--compile-check", str(doc)],
                 capture_output=True).returncode == 0
 
-            for mode in MODES:
+            for pname, penv, flag in CELLS:
+                mode = f"{pname}:{flag}"
+                env = {**os.environ, **penv}
                 # Stage the WHOLE directory: \input{sibling} resolves relative to
                 # the file, so a bare temp dir manufactures T2 failures.
                 with tempfile.TemporaryDirectory(prefix="fixer-rt-") as tmp:
@@ -180,7 +192,7 @@ def main() -> int:
                     # the fixer is a byte-level rewriter — decoding its output as
                     # strict UTF-8 raises, and decoding it leniently would CORRUPT
                     # the very bytes we are trying to compare.
-                    fixed = subprocess.run([str(cli), mode, str(doc)], capture_output=True)
+                    fixed = subprocess.run([str(cli), flag, str(doc)], capture_output=True, env=env)
                     if fixed.returncode not in (0, 1):
                         findings.append(f"{key} [{mode}]: fixer exited {fixed.returncode}")
                         continue
@@ -192,7 +204,7 @@ def main() -> int:
 
                     # (a) idempotence
                     again = subprocess.run(
-                        [str(cli), mode, str(staged_doc)], capture_output=True)
+                        [str(cli), flag, str(staged_doc)], capture_output=True, env=env)
                     not_idem = again.returncode in (0, 1) and again.stdout != out
 
                     # (c) verdict-non-degradation
@@ -216,25 +228,35 @@ def main() -> int:
                         else:
                             broke = b4 and not af
 
-                    if broke or degraded or not_idem:
+                    # (c') NO FIXER-MANUFACTURED FALSE-READY: if the fixed
+                    # document still says READY while pdflatex now rejects it, the
+                    # fixer has created the project's cardinal bug. This is the
+                    # property that matters — plain verdict-monotonicity (c)
+                    # catches NONE of the corpus breakages, because the checker
+                    # keeps saying READY before and after.
+                    manufactured = bool(broke and after_ready)
+                    if broke or degraded or not_idem or manufactured:
                         entry = {"doc": key, "mode": mode,
                                  "breaks_compile": bool(broke),
                                  "degrades_verdict": bool(degraded),
-                                 "not_idempotent": bool(not_idem)}
+                                 "not_idempotent": bool(not_idem),
+                                 "manufactured_false_ready": manufactured}
                         observed_broken.append(entry)
                         prev = recorded.get((key, mode))
                         if not prev:
                             findings.append(
                                 f"{key} [{mode}]: NEW FIXER DEFECT "
                                 f"(breaks_compile={broke}, degrades_verdict={degraded}, "
-                                f"not_idempotent={not_idem}) — the fixer damages or "
+                                f"not_idempotent={not_idem}, "
+                                f"manufactured_false_ready={manufactured}) — the fixer damages or "
                                 f"destabilises a document it was asked to improve")
                         else:
                             # Recorded, but make sure it has not got WORSE along an
                             # axis the baseline did not already admit.
                             for axis, now in (("breaks_compile", broke),
                                               ("degrades_verdict", degraded),
-                                              ("not_idempotent", not_idem)):
+                                              ("not_idempotent", not_idem),
+                                              ("manufactured_false_ready", manufactured)):
                                 if now and not prev.get(axis):
                                     findings.append(
                                         f"{key} [{mode}]: newly {axis} (was recorded "
@@ -278,7 +300,7 @@ def main() -> int:
               f"to {MANIFEST}")
         return 0
 
-    print(f"[fixer-roundtrip] {n_docs} documents x {len(MODES)} modes; "
+    print(f"[fixer-roundtrip] {n_docs} documents x {len(CELLS)} cells (profile x flag); "
           f"fixer rewrote {n_changed}; pdflatex={'yes' if have_tex else 'NO (b skipped)'}; "
           f"known-broken {len(recorded)}")
     if not have_tex and not require_tex:

--- a/scripts/tools/check_apply_fixes_roundtrip.py
+++ b/scripts/tools/check_apply_fixes_roundtrip.py
@@ -1,0 +1,297 @@
+#!/usr/bin/env python3
+"""check_apply_fixes_roundtrip.py — the apply-fixes round-trip gate (R7-INFRA-4).
+
+WHY THIS EXISTS
+---------------
+`--apply-fixes` rewrites user documents. It is the one class the round-7 audit
+called out as able to SILENTLY DESTROY user files: nothing re-checks the fixer's
+own output, so a fix that breaks a document is invisible.
+
+Measured on `corpora/compile_check` (65 docs, TL2026) while writing this gate:
+
+    the fixer rewrites            25 / 65
+    non-idempotent                 0
+    verdict-degrading              0
+    COMPILED BEFORE, FAILS AFTER   2      good_accents_utf8, good_tikz_simple
+
+Both breakages are the same class — a typography fix applied inside a LOAD-BEARING
+region, where the character is syntax rather than punctuation:
+
+  * `good_tikz_simple`   `--` inside a TikZ path is pgf's line-to OPERATOR.
+                         Rewritten to an en dash it yields
+                         "! Package tikz Error: Giving up on this path." and no PDF.
+  * `good_accents_utf8`  the backtick in `\\`a` IS the grave-accent command.
+                         Rewritten to U+2018 the command is destroyed.
+
+**Neither is caught by `--compile-check`.** Only real pdflatex sees them. That is
+the whole argument for this gate, and it is why property (b) is not optional.
+
+THE THREE PROPERTIES (the audit's R7-INFRA-4)
+---------------------------------------------
+  (a) IDEMPOTENT              applying twice == applying once
+      (measured: good_quotes_dashes under --apply-fixes-best-effort needs TWO
+       passes to reach a fixpoint — pass 1 leaves ``quotes'' alone, pass 2 curls
+       them. Bounded, but "apply twice != apply once" is exactly what (a) forbids.)
+  (c) VERDICT-NON-DEGRADING   a READY document must not become NOT-READY
+  (b) ORACLE-CLASS-PRESERVING a document that compiled must still compile
+
+(a) and (c) need only the CLI, so they run in CI's `build` job. (b) needs real
+pdflatex and rides the pinned-image `tex-oracle` workflow. Same split as the
+false-READY gates: check_known_false_ready.py (CLI-only) vs false_ready_oracle.sh.
+
+MONOTONE, LIKE THE FALSE-READY CORPUS
+-------------------------------------
+The known breakages are recorded in `corpora/apply_fixes/manifest.json` so the
+gate lands GREEN and any NEW breakage fails. It fails in BOTH directions — a
+recorded-broken document that starts working is also an error, forcing the
+manifest to be updated, so the baseline can only improve and can never silently
+desync. R7-3 (the fixer guard) will flip these entries.
+
+`corpora/apply_fixes/` additionally holds adversarial fixtures for destructive
+patterns the natural corpus does not contain. Without them this gate would be
+VACUOUS on exactly the class it exists to catch — `corpora/compile_check` has no
+`--` inside an `\\input` filename, so nothing would exercise it.
+
+⚠ STAGING IS LOAD-BEARING. The fixed output must be written into a copy of the
+WHOLE corpus directory, because `\\input{sibling}` resolves RELATIVE to the file.
+Writing it to a bare temp dir makes every multi-file document report a spurious
+"T2 project not closed" — I hit exactly that while measuring, and it would have
+made this gate cry wolf on `good_input_child.tex`.
+
+USAGE
+    check_apply_fixes_roundtrip.py [--repo DIR] [--record] [--require-pdflatex]
+
+  --record   re-measure and rewrite the manifest baseline (deliberate act)
+
+EXIT 0 clean | 1 a NEW breakage or an unrecorded improvement | 2 infrastructure
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+CORPORA = ["corpora/compile_check", "corpora/apply_fixes"]
+MANIFEST = "corpora/apply_fixes/manifest.json"
+MODES = ["--apply-fixes", "--apply-fixes-best-effort"]
+MIN_DOCS = 60  # compile_check alone is 65 standalone docs; a smaller sweep is a bug
+
+
+def die(msg: str) -> int:
+    print(f"[fixer-roundtrip] FATAL: {msg}", file=sys.stderr)
+    return 2
+
+
+def find_timeout() -> str | None:
+    return shutil.which("gtimeout") or shutil.which("timeout")
+
+
+def pdflatex_ok(workdir: Path, base: str, timeout_bin: str | None, secs: int = 60) -> bool | None:
+    """True=compiles, False=fails, None=could not be graded (timeout/not run)."""
+    cmd = ["pdflatex", "-interaction=nonstopmode", "-halt-on-error", base]
+    if timeout_bin:
+        cmd = [timeout_bin, str(secs)] + cmd
+    p = subprocess.run(cmd, cwd=workdir, capture_output=True)
+    if p.returncode in (124, 125, 126, 127):
+        return None
+    return p.returncode == 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--repo", default=".")
+    ap.add_argument("--record", action="store_true",
+                    help="re-measure and rewrite the manifest baseline")
+    ap.add_argument("--require-pdflatex", action="store_true",
+                    help="fail rather than skip when pdflatex is unavailable")
+    args = ap.parse_args()
+    repo = Path(args.repo).resolve()
+
+    cli = repo / "_build/default/latex-parse/src/validators_cli.exe"
+    if not cli.exists():
+        return die(f"CLI not built at {cli} (build it in its own step)")
+    # A CLI that cannot execute answers non-zero to everything, which would read
+    # as a uniform column of NOT-READY and grade perfectly `ok`.
+    banner = subprocess.run([str(cli)], capture_output=True)
+    if b"Usage:" not in (banner.stdout + banner.stderr):
+        return die("the CLI did not produce its usage banner — it cannot execute here")
+
+    require_tex = args.require_pdflatex or os.environ.get("REQUIRE_PDFLATEX") == "1"
+    have_tex = shutil.which("pdflatex") is not None
+    if require_tex and not have_tex:
+        return die("REQUIRE_PDFLATEX=1 but pdflatex is not on PATH")
+    timeout_bin = find_timeout()
+    if have_tex and not timeout_bin and require_tex:
+        return die("pdflatex present but no gtimeout/timeout; a hang would be scored as a failure")
+
+    manifest_path = repo / MANIFEST
+    recorded: dict[str, dict] = {}
+    if manifest_path.exists():
+        try:
+            # Key by (doc, MODE): a document can break under one fixer mode and
+            # not the other, and keying by doc alone silently collapses them so
+            # one mode's baseline masks the other's.
+            recorded = {(e["doc"], e["mode"]): e
+                        for e in json.loads(manifest_path.read_text())["known_broken"]}
+        except Exception as exc:  # noqa: BLE001
+            return die(f"cannot parse {MANIFEST}: {exc}")
+    elif not args.record:
+        return die(f"{MANIFEST} missing — run with --record to create the baseline")
+
+    findings: list[str] = []
+    observed_broken: list[dict] = []
+    n_docs = 0
+    n_changed = 0
+    ungraded = 0
+
+    for corpus_rel in CORPORA:
+        corpus = repo / corpus_rel
+        if not corpus.is_dir():
+            return die(f"corpus directory missing: {corpus_rel}")
+        docs = sorted(p for p in corpus.glob("*.tex") if not p.name.endswith("_part.tex"))
+        # Fixtures whose only role is to be \input by another fixture are not
+        # standalone documents; skip them the way the differential does.
+        docs = [p for p in docs if not p.name.startswith("adv--")]
+        if not docs:
+            return die(f"no documents found in {corpus_rel} — refusing to report success")
+
+        for doc in docs:
+            n_docs += 1
+            base = doc.name
+            key = f"{corpus_rel}/{base}"
+            before_ready = subprocess.run(
+                [str(cli), "--compile-check", str(doc)],
+                capture_output=True).returncode == 0
+
+            for mode in MODES:
+                # Stage the WHOLE directory: \input{sibling} resolves relative to
+                # the file, so a bare temp dir manufactures T2 failures.
+                with tempfile.TemporaryDirectory(prefix="fixer-rt-") as tmp:
+                    stage = Path(tmp) / "c"
+                    shutil.copytree(corpus, stage)
+                    # BYTES, not text. The corpus deliberately contains
+                    # mis-encoded documents (that is part of what it tests), and
+                    # the fixer is a byte-level rewriter — decoding its output as
+                    # strict UTF-8 raises, and decoding it leniently would CORRUPT
+                    # the very bytes we are trying to compare.
+                    fixed = subprocess.run([str(cli), mode, str(doc)], capture_output=True)
+                    if fixed.returncode not in (0, 1):
+                        findings.append(f"{key} [{mode}]: fixer exited {fixed.returncode}")
+                        continue
+                    out = fixed.stdout
+                    staged_doc = stage / base
+                    if out != doc.read_bytes():
+                        n_changed += 1
+                    staged_doc.write_bytes(out)
+
+                    # (a) idempotence
+                    again = subprocess.run(
+                        [str(cli), mode, str(staged_doc)], capture_output=True)
+                    not_idem = again.returncode in (0, 1) and again.stdout != out
+
+                    # (c) verdict-non-degradation
+                    after_ready = subprocess.run(
+                        [str(cli), "--compile-check", str(staged_doc)],
+                        capture_output=True).returncode == 0
+                    degraded = before_ready and not after_ready
+
+                    # (b) oracle-class preservation
+                    broke = False
+                    if have_tex:
+                        pristine = Path(tmp) / "p"
+                        shutil.copytree(corpus, pristine)
+                        b4 = pdflatex_ok(pristine, base, timeout_bin)
+                        for junk in ("aux", "log", "pdf", "out"):
+                            (stage / f"{base[:-4]}.{junk}").unlink(missing_ok=True)
+                        af = pdflatex_ok(stage, base, timeout_bin)
+                        if b4 is None or af is None:
+                            ungraded += 1
+                            findings.append(f"{key} [{mode}]: pdflatex could not be graded")
+                        else:
+                            broke = b4 and not af
+
+                    if broke or degraded or not_idem:
+                        entry = {"doc": key, "mode": mode,
+                                 "breaks_compile": bool(broke),
+                                 "degrades_verdict": bool(degraded),
+                                 "not_idempotent": bool(not_idem)}
+                        observed_broken.append(entry)
+                        prev = recorded.get((key, mode))
+                        if not prev:
+                            findings.append(
+                                f"{key} [{mode}]: NEW FIXER DEFECT "
+                                f"(breaks_compile={broke}, degrades_verdict={degraded}, "
+                                f"not_idempotent={not_idem}) — the fixer damages or "
+                                f"destabilises a document it was asked to improve")
+                        else:
+                            # Recorded, but make sure it has not got WORSE along an
+                            # axis the baseline did not already admit.
+                            for axis, now in (("breaks_compile", broke),
+                                              ("degrades_verdict", degraded),
+                                              ("not_idempotent", not_idem)):
+                                if now and not prev.get(axis):
+                                    findings.append(
+                                        f"{key} [{mode}]: newly {axis} (was recorded "
+                                        f"broken only on other axes)")
+
+    if n_docs < MIN_DOCS:
+        return die(f"processed {n_docs} documents, expected at least {MIN_DOCS} "
+                   f"(corpus misrooted?) — refusing to report success")
+    if n_changed == 0:
+        return die("the fixer changed NOTHING across the whole corpus — it is "
+                   "not running; these results would be meaningless")
+
+    # Unrecorded improvement: a recorded-broken doc that no longer breaks. Forces
+    # the manifest to be updated so the baseline can only descend.
+    observed_keys = {(e["doc"], e["mode"]) for e in observed_broken}
+    if have_tex and not args.record:
+        for (key, mode), entry in recorded.items():
+            if (entry.get("breaks_compile") or entry.get("not_idempotent")) \
+                    and (key, mode) not in observed_keys:
+                findings.append(
+                    f"{key} [{mode}]: recorded as broken but is now CLEAN — a fix landed; "
+                    f"update {MANIFEST} to lock it in (--record)")
+
+    if args.record:
+        manifest_path.parent.mkdir(parents=True, exist_ok=True)
+        manifest_path.write_text(json.dumps({
+            "description": (
+                "R7-INFRA-4 baseline: documents that --apply-fixes damages. Each "
+                "entry is a KNOWN defect awaiting the R7-3 fixer guard. The gate "
+                "fails on a NEW breakage and on an unrecorded improvement, so this "
+                "list can only shrink."),
+            "properties": {
+                "a_idempotent": "applying twice == applying once",
+                "c_verdict_non_degrading": "a READY document must not become NOT-READY",
+                "b_oracle_class_preserving": "a document that compiled must still compile",
+            },
+            "pdflatex_graded": have_tex,
+            "known_broken": sorted(observed_broken, key=lambda e: (e["doc"], e["mode"])),
+        }, indent=2) + "\n", encoding="utf-8")
+        print(f"[fixer-roundtrip] recorded {len(observed_broken)} known breakage(s) "
+              f"to {MANIFEST}")
+        return 0
+
+    print(f"[fixer-roundtrip] {n_docs} documents x {len(MODES)} modes; "
+          f"fixer rewrote {n_changed}; pdflatex={'yes' if have_tex else 'NO (b skipped)'}; "
+          f"known-broken {len(recorded)}")
+    if not have_tex and not require_tex:
+        print("[fixer-roundtrip] NOTE: property (b) not evaluated without pdflatex; "
+              "the tex-oracle workflow covers it.")
+    if findings:
+        print("\n[fixer-roundtrip] FAIL:\n", file=sys.stderr)
+        for f in findings:
+            print(f"  - {f}", file=sys.stderr)
+        return 1
+    print("[fixer-roundtrip] PASS — no new fixer damage.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tools/pre_release_check.py
+++ b/scripts/tools/pre_release_check.py
@@ -88,6 +88,13 @@ BUILD_CHECKS = [
     # gate: no fix producer may rewrite literal bytes the author typed verbatim.
     # Plants every known producer trigger inside each protected-region kind and
     # asserts --apply-fixes leaves them byte-identical (pilot + default).
+    # R7-INFRA-4 property (b): oracle-class preservation needs REAL pdflatex, so
+    # it runs here (where TeX exists) rather than in CI. The CLI-only properties
+    # (a)+(c) already run in the CI `build` job on every PR.
+    (["python3", "scripts/tools/check_apply_fixes_roundtrip.py",
+      "--repo", ".", "--require-pdflatex"],
+     "apply-fixes round-trip (incl. pdflatex oracle-class preservation)", None),
+
     (["python3", "scripts/tools/check_verbatim_safety.py", "--repo", "."],
      "verbatim safety", None),
     # Per-producer coverage + correctness gate. The corpus differential /


### PR DESCRIPTION
The fixer rewrites user documents and **nothing re-checked its own output**, so a fix that breaks a document was invisible. This is the class the round-7 audit called the only one that *silently destroys user files*. **Single commit — squash-safe.**

## Measured myself, not inherited

`corpora/compile_check`, 65 docs, TL2026, both fixer modes:

| property | result |
|---|---|
| fixer rewrites | 25/65 docs (56 of 136 doc×mode) |
| (a) non-idempotent | **1** — `good_quotes_dashes` [best-effort] |
| (c) verdict-degrading | 0 |
| (b) **compiled before, fails after** | **2** — `good_tikz_simple`, `good_accents_utf8` |

Both compile breakages are **one class** — a typography fix applied inside a **load-bearing region**, where the character is *syntax*, not punctuation:

- **`good_tikz_simple`** — `--` inside a TikZ path is pgf's **line-to operator**. Rewritten to an en dash → `! Package tikz Error: Giving up on this path.`, no PDF.
- **`good_accents_utf8`** — the backtick in the grave-accent command **is the command**. Rewritten to U+2018, it's destroyed.

**Neither is caught by `--compile-check`.** Only real pdflatex sees them. That corrects a guess I made earlier in this work — I'd inferred from a synthetic `\input` case that the checker would catch this class. It does not, and that is precisely why property (b) exists.

The "2 of 29" figure in the audit checks out as **2 of 25 rewritten** / 2 of 65 total.

## The gate

Asserts the audit's three properties, split by what they need:

- **(a) idempotence + (c) verdict-non-degradation** — CLI-only → CI `build` job, every PR.
- **(b) oracle-class preservation** — needs pdflatex → `pre_release_check.py`.

⚠️ **Property (b) is not in CI.** Putting it in the `tex-oracle` workflow requires python3 inside the pinned TeX image — unconfirmed, and that image is deliberately dependency-free. Recorded as a gap rather than silently skipped.

**Monotone**, mirroring the false-READY corpus: known defects live in `corpora/apply_fixes/manifest.json` keyed by **(doc, mode)**, so the gate lands green and fails on a new defect, on an unrecorded improvement, *and* on an existing defect worsening along a new axis. R7-3 will flip these entries.

## Adversarial fixtures — otherwise the gate is vacuous

`corpora/compile_check` contains no `--` inside an `\input` filename, so the gate would pass while never exercising the class it exists to catch. `corpora/apply_fixes/` adds three fixtures, each verified to compile before the fixer and fail after.

## Two cry-wolf bugs I found in my own harness

1. **Writing the fixed output to a bare temp dir breaks relative `\input`** — `good_input_child.tex` reported a spurious `T2 project not closed`, and I nearly recorded it as fixer damage. The gate stages the **whole** corpus directory. Documented in the script, because the next person will reach for a temp file.
2. **Keying the baseline by `doc` alone collapsed the two fixer modes**, so one mode's entry masked the other's.

Also: fixer I/O is **bytes, not text**. The corpus deliberately contains mis-encoded documents; strict UTF-8 decoding raises, and lenient decoding would corrupt the very bytes being compared.

## Verified in both directions

| test | result |
|---|---|
| clean tree | PASS (68 docs × 2 modes, 76s) |
| drop a baseline entry | exit **1**, 4 NEW-DEFECT lines |
| phantom recorded-broken doc | exit **1**, "now CLEAN" |
| CLI-only (no pdflatex) | PASS, correctly skips (b) |
| `REQUIRE_PDFLATEX=1`, no pdflatex | exit **2** |

Anti-vacuity: `MIN_DOCS` floor, a CLI usage-banner smoke check (a binary that can't execute answers non-zero to everything and would grade perfectly `ok`), and a refusal to pass if the fixer changed *nothing*.

## Separate bug found — deliberately not bundled

A **commented-out `\input` of a missing file causes a T2 over-rejection**: CLI says NOT-READY, pdflatex exits 0, and `MODEL-READY` prints on the same line — so it's the *unverified runtime* T2 that is comment-blind. #509 fixed exactly this for the cycle detector via `scan_includes_live`; the closure check still uses the raw scan. Safe direction, but commenting out an include is a very common drafting move. Worth its own small PR.