### PR TITLE
feat(R7-3): fix guard — stop the fixer manufacturing false-READYs

### DIFF
--- a/corpora/apply_fixes/manifest.json
+++ b/corpora/apply_fixes/manifest.json
@@ -8,38 +8,6 @@
   "pdflatex_graded": true,
   "known_broken": [
     {
-      "doc": "corpora/apply_fixes/adv_accent_backtick.tex",
-      "mode": "default:--apply-fixes",
-      "breaks_compile": true,
-      "degrades_verdict": false,
-      "not_idempotent": false,
-      "manufactured_false_ready": true
-    },
-    {
-      "doc": "corpora/apply_fixes/adv_accent_backtick.tex",
-      "mode": "default:--apply-fixes-best-effort",
-      "breaks_compile": true,
-      "degrades_verdict": false,
-      "not_idempotent": false,
-      "manufactured_false_ready": true
-    },
-    {
-      "doc": "corpora/apply_fixes/adv_accent_backtick.tex",
-      "mode": "pilot:--apply-fixes",
-      "breaks_compile": true,
-      "degrades_verdict": false,
-      "not_idempotent": false,
-      "manufactured_false_ready": true
-    },
-    {
-      "doc": "corpora/apply_fixes/adv_accent_backtick.tex",
-      "mode": "pilot:--apply-fixes-best-effort",
-      "breaks_compile": true,
-      "degrades_verdict": false,
-      "not_idempotent": false,
-      "manufactured_false_ready": true
-    },
-    {
       "doc": "corpora/apply_fixes/adv_input_filename.tex",
       "mode": "default:--apply-fixes",
       "breaks_compile": true,
@@ -70,70 +38,6 @@
       "degrades_verdict": true,
       "not_idempotent": true,
       "manufactured_false_ready": false
-    },
-    {
-      "doc": "corpora/apply_fixes/adv_tikz_path.tex",
-      "mode": "default:--apply-fixes",
-      "breaks_compile": true,
-      "degrades_verdict": false,
-      "not_idempotent": false,
-      "manufactured_false_ready": true
-    },
-    {
-      "doc": "corpora/apply_fixes/adv_tikz_path.tex",
-      "mode": "default:--apply-fixes-best-effort",
-      "breaks_compile": true,
-      "degrades_verdict": false,
-      "not_idempotent": false,
-      "manufactured_false_ready": true
-    },
-    {
-      "doc": "corpora/apply_fixes/adv_tikz_path.tex",
-      "mode": "pilot:--apply-fixes",
-      "breaks_compile": true,
-      "degrades_verdict": false,
-      "not_idempotent": false,
-      "manufactured_false_ready": true
-    },
-    {
-      "doc": "corpora/apply_fixes/adv_tikz_path.tex",
-      "mode": "pilot:--apply-fixes-best-effort",
-      "breaks_compile": true,
-      "degrades_verdict": false,
-      "not_idempotent": false,
-      "manufactured_false_ready": true
-    },
-    {
-      "doc": "corpora/compile_check/good_accents_utf8.tex",
-      "mode": "default:--apply-fixes",
-      "breaks_compile": true,
-      "degrades_verdict": false,
-      "not_idempotent": false,
-      "manufactured_false_ready": true
-    },
-    {
-      "doc": "corpora/compile_check/good_accents_utf8.tex",
-      "mode": "default:--apply-fixes-best-effort",
-      "breaks_compile": true,
-      "degrades_verdict": false,
-      "not_idempotent": false,
-      "manufactured_false_ready": true
-    },
-    {
-      "doc": "corpora/compile_check/good_accents_utf8.tex",
-      "mode": "pilot:--apply-fixes",
-      "breaks_compile": true,
-      "degrades_verdict": false,
-      "not_idempotent": false,
-      "manufactured_false_ready": true
-    },
-    {
-      "doc": "corpora/compile_check/good_accents_utf8.tex",
-      "mode": "pilot:--apply-fixes-best-effort",
-      "breaks_compile": true,
-      "degrades_verdict": false,
-      "not_idempotent": false,
-      "manufactured_false_ready": true
     },
     {
       "doc": "corpora/compile_check/good_longtable_free.tex",
@@ -166,38 +70,6 @@
       "degrades_verdict": false,
       "not_idempotent": true,
       "manufactured_false_ready": false
-    },
-    {
-      "doc": "corpora/compile_check/good_tikz_simple.tex",
-      "mode": "default:--apply-fixes",
-      "breaks_compile": true,
-      "degrades_verdict": false,
-      "not_idempotent": false,
-      "manufactured_false_ready": true
-    },
-    {
-      "doc": "corpora/compile_check/good_tikz_simple.tex",
-      "mode": "default:--apply-fixes-best-effort",
-      "breaks_compile": true,
-      "degrades_verdict": false,
-      "not_idempotent": false,
-      "manufactured_false_ready": true
-    },
-    {
-      "doc": "corpora/compile_check/good_tikz_simple.tex",
-      "mode": "pilot:--apply-fixes",
-      "breaks_compile": true,
-      "degrades_verdict": false,
-      "not_idempotent": false,
-      "manufactured_false_ready": true
-    },
-    {
-      "doc": "corpora/compile_check/good_tikz_simple.tex",
-      "mode": "pilot:--apply-fixes-best-effort",
-      "breaks_compile": true,
-      "degrades_verdict": false,
-      "not_idempotent": false,
-      "manufactured_false_ready": true
     },
     {
       "doc": "corpora/compile_check/tolerated_trailing_whitespace.tex",

--- a/latex-parse/src/dune
+++ b/latex-parse/src/dune
@@ -26,6 +26,7 @@
   validators_context
   re_compat
   validators_common
+  fix_guard
   language_detect
   rule_contract_loader
   extension_contract

--- a/latex-parse/src/fix_guard.ml
+++ b/latex-parse/src/fix_guard.ml
@@ -98,7 +98,8 @@ let protected_ranges (src : string) : (int * int) list =
    variants in check_producer_coverage.py: each of these was measured emitting a
    legitimate fix that region 1 withheld. That gate is the completeness check —
    a control-symbol-aware rule missing from this list loses its fix and the gate
-   goes red, which is the safe direction (functionality lost, nothing corrupted).
+   goes red, which is the safe direction (functionality lost, nothing
+   corrupted).
 
    TYPO-013 is deliberately ABSENT: curling an ASCII backtick is exactly the
    prose-blind rewrite that destroyed the grave-accent command in

--- a/latex-parse/src/fix_guard.ml
+++ b/latex-parse/src/fix_guard.ml
@@ -94,13 +94,39 @@ let protected_ranges (src : string) : (int * int) list =
 
 (* Half-open intersection. A pure insertion (s = e) is a point, and a point on a
    protected range's exclusive end is NOT inside it. *)
+(* Rules whose contract IS editing control symbols. Derived from the golden
+   variants in check_producer_coverage.py: each of these was measured emitting a
+   legitimate fix that region 1 withheld. That gate is the completeness check —
+   a control-symbol-aware rule missing from this list loses its fix and the gate
+   goes red, which is the safe direction (functionality lost, nothing corrupted).
+
+   TYPO-013 is deliberately ABSENT: curling an ASCII backtick is exactly the
+   prose-blind rewrite that destroyed the grave-accent command in
+   good_accents_utf8. *)
+let control_symbol_aware =
+  [
+    "CS-001" (* spurious thin space before a unit *);
+    "MATH-082" (* doubled negative thin space *);
+    "TYPO-015" (* doubled escaped percent *);
+    "TYPO-017" (* accent brace form *);
+    "TYPO-055" (* consecutive thin spaces *);
+    "TYPO-056" (* legacy accent brace form *);
+    "TYPO-062" (* literal backslash to \textbackslash *);
+  ]
+
 let intersects (s, e) (a, b) = if s = e then a <= s && s < b else s < b && a < e
 
-let filter ~(src : string) (edits : Cst_edit.t list) : Cst_edit.t list =
+let filter ~(src : string) ~(rule_id : string) (edits : Cst_edit.t list) :
+    Cst_edit.t list =
   match edits with
   | [] -> []
   | _ ->
-      let ranges = protected_ranges src in
+      (* A control-symbol-aware rule still gets the picture region: no producer
+         has any business rewriting inside a TikZ path. *)
+      let ranges =
+        if List.mem rule_id control_symbol_aware then picture_ranges src
+        else protected_ranges src
+      in
       if ranges = [] then edits
       else
         List.filter

--- a/latex-parse/src/fix_guard.ml
+++ b/latex-parse/src/fix_guard.ml
@@ -1,0 +1,110 @@
+(* Fix guard (R7-3). See fix_guard.mli for the contract and the error-polarity
+   note (this is a SUBTRACTIVE filter: over-wide is safe, narrow/misplaced is
+   not).
+
+   v1 implements the two highest-damage regions, both purely lexical and both
+   over-wide-safe. Regions deliberately NOT yet covered, in measured-damage
+   order: 3. filename arguments (\input \include \includegraphics \bibliography
+   ...) 4. key arguments (\label \ref \cite ... — also the SCRIPT-001->007
+   cascade) 5. tabular/array preamble (the pilot-only good_longtable_free
+   corruption) Their fixtures stay recorded as known breakages in
+   corpora/apply_fixes/, so the round-trip gate proves exactly which classes are
+   closed and which are not. *)
+
+let is_letter c = (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')
+
+(* ── Region 1: control-symbol arguments ──────────────────────────────────── A
+   backslash followed by a NON-letter is a control SYMBOL: the byte after the
+   backslash is the command, not text. The accent commands (grave, acute,
+   circumflex, diaeresis, tilde, macron, dot, bar, slash, cedilla-comma) all
+   have this shape, and rewriting that byte destroys the command.
+
+   NB: this comment deliberately spells the accents out in words. An OCaml
+   comment still lexes string literals, so writing the escape sequences
+   literally here opens an unterminated string and fails the build.
+
+   Both bytes are protected. Protecting only the symbol would let an edit that
+   starts on the backslash and ends after it slip through. *)
+let control_symbol_ranges (src : string) : (int * int) list =
+  let n = String.length src in
+  let acc = ref [] in
+  let i = ref 0 in
+  while !i < n do
+    if String.unsafe_get src !i = '\\' && !i + 1 < n then
+      let c = String.unsafe_get src (!i + 1) in
+      if is_letter c then (
+        (* control WORD: \foo — the name is letters, ordinary prose may follow.
+           Skip it so its trailing letters are not rescanned as a new escape. *)
+        let j = ref (!i + 1) in
+        while !j < n && is_letter (String.unsafe_get src !j) do
+          incr j
+        done;
+        i := !j)
+      else (
+        (* control SYMBOL: protect the backslash and the symbol byte, then step
+           past both — otherwise `\\` would have its second backslash re-read as
+           the start of a fresh escape. *)
+        acc := (!i, !i + 2) :: !acc;
+        i := !i + 2)
+    else incr i
+  done;
+  List.rev !acc
+
+(* ── Region 2: TikZ / PGF picture bodies ───────────────────────────────────
+   Inside a picture, `--` is pgf's line-to PATH OPERATOR, `-|` and `|-` are the
+   orthogonal variants, and `..` introduces a curve. None of it is punctuation.
+
+   The whole environment body is protected, begin and end markers included. That
+   is deliberately over-wide: typographic fixes inside a picture have no value
+   and real risk. Note tikzpicture is NOT in Validators_common's verbatim env
+   list, so nothing else was covering this. *)
+let picture_envs = [ "tikzpicture"; "pgfpicture" ]
+
+let find_all (hay : string) (needle : string) : int list =
+  let nh = String.length hay and nn = String.length needle in
+  if nn = 0 || nn > nh then []
+  else
+    let acc = ref [] in
+    for i = nh - nn downto 0 do
+      if String.sub hay i nn = needle then acc := i :: !acc
+    done;
+    !acc
+
+let picture_ranges (src : string) : (int * int) list =
+  List.concat_map
+    (fun env ->
+      let b = "\\begin{" ^ env ^ "}" and e = "\\end{" ^ env ^ "}" in
+      let ends = find_all src e in
+      List.filter_map
+        (fun bs ->
+          (* First \end{env} at or after this \begin{env}. Picture environments
+             do not nest in practice; if one ever did, taking the first close is
+             the over-wide-safe direction only for the inner pair, so an
+             unmatched \begin protects to end-of-file rather than protecting
+             nothing. *)
+          match List.find_opt (fun es -> es >= bs) ends with
+          | Some es -> Some (bs, es + String.length e)
+          | None -> Some (bs, String.length src))
+        (find_all src b))
+    picture_envs
+
+let protected_ranges (src : string) : (int * int) list =
+  let rs = control_symbol_ranges src @ picture_ranges src in
+  List.sort (fun (a, _) (b, _) -> compare a b) rs
+
+(* Half-open intersection. A pure insertion (s = e) is a point, and a point on a
+   protected range's exclusive end is NOT inside it. *)
+let intersects (s, e) (a, b) = if s = e then a <= s && s < b else s < b && a < e
+
+let filter ~(src : string) (edits : Cst_edit.t list) : Cst_edit.t list =
+  match edits with
+  | [] -> []
+  | _ ->
+      let ranges = protected_ranges src in
+      if ranges = [] then edits
+      else
+        List.filter
+          (fun (ed : Cst_edit.t) ->
+            let span = (ed.start_offset, ed.end_offset) in
+            not (List.exists (fun r -> intersects span r) ranges))
+          edits

--- a/latex-parse/src/fix_guard.mli
+++ b/latex-parse/src/fix_guard.mli
@@ -44,11 +44,11 @@ val control_symbol_aware : string list
     The guard exists to stop a rule rewriting bytes it does not understand. A
     typography rule sees a backtick and curls it, not knowing it is the
     grave-accent command. These rules are the opposite: normalising accent brace
-    forms, collapsing doubled escapes, removing spurious spacing commands. Listing
-    a rule here is a CLAIM that it understands TeX commands, and it must be
-    backed by the golden variants in [scripts/tools/check_producer_coverage.py] —
-    that gate fails if a legitimately-blocked fix is withheld, so the list cannot
-    silently rot. *)
+    forms, collapsing doubled escapes, removing spurious spacing commands.
+    Listing a rule here is a CLAIM that it understands TeX commands, and it must
+    be backed by the golden variants in
+    [scripts/tools/check_producer_coverage.py] — that gate fails if a
+    legitimately-blocked fix is withheld, so the list cannot silently rot. *)
 
 val filter : src:string -> rule_id:string -> Cst_edit.t list -> Cst_edit.t list
 (** [filter ~src ~rule_id edits] — drop every edit whose half-open span

--- a/latex-parse/src/fix_guard.mli
+++ b/latex-parse/src/fix_guard.mli
@@ -36,9 +36,23 @@ val protected_ranges : string -> (int * int) list
     returned in ascending order of start offset and may be adjacent; they are
     not guaranteed disjoint. *)
 
-val filter : src:string -> Cst_edit.t list -> Cst_edit.t list
-(** [filter ~src edits] — drop every edit whose half-open span intersects a
-    protected range of [src].
+val control_symbol_aware : string list
+(** Rules whose CONTRACT is to edit control symbols, and which are therefore
+    exempt from the control-symbol region (region 1) — never from the picture
+    region.
+
+    The guard exists to stop a rule rewriting bytes it does not understand. A
+    typography rule sees a backtick and curls it, not knowing it is the
+    grave-accent command. These rules are the opposite: normalising accent brace
+    forms, collapsing doubled escapes, removing spurious spacing commands. Listing
+    a rule here is a CLAIM that it understands TeX commands, and it must be
+    backed by the golden variants in [scripts/tools/check_producer_coverage.py] —
+    that gate fails if a legitimately-blocked fix is withheld, so the list cannot
+    silently rot. *)
+
+val filter : src:string -> rule_id:string -> Cst_edit.t list -> Cst_edit.t list
+(** [filter ~src ~rule_id edits] — drop every edit whose half-open span
+    intersects a protected range of [src].
 
     The whole half-open span from [start_offset] to [end_offset] is tested, not
     just the start offset: an edit beginning one byte before a protected region

--- a/latex-parse/src/fix_guard.mli
+++ b/latex-parse/src/fix_guard.mli
@@ -1,0 +1,52 @@
+(** Fix guard (R7-3) — withhold fixes that would rewrite LOAD-BEARING bytes.
+
+    A fix producer asks "are these bytes ordinary prose?" via
+    {!Validators_common.find_exempt_ranges}. That is a TYPOGRAPHY-SUPPRESSION
+    contract and it is not the same question as "would rewriting these bytes
+    change what TeX does?". TYPO-002 obeys the existing contract perfectly and
+    still turns an include filename into [\input{fig–x}].
+
+    Measured before this module existed (R7-INFRA-4, TL2026):
+    - [good_accents_utf8] — the backtick in the grave-accent command IS the
+      command; rewritten to U+2018 it becomes an undefined-control-sequence
+      error.
+    - [good_tikz_simple] — a double hyphen inside a TikZ path is pgf's line-to
+      OPERATOR; rewritten to an en dash, tikz gives up on the path and emits a
+      fatal error.
+
+    In both cases [--compile-check] reports READY before AND after, so the fixer
+    MANUFACTURES a false-READY — the project's cardinal bug, created by the tool
+    that was asked to improve the document.
+
+    {2 Error polarity — note the inversion}
+
+    This is a SUBTRACTIVE filter over edits. A protected range that is too WIDE
+    withholds a fix: functionality lost, nothing corrupted — safe. A range that
+    is too NARROW or misplaced leaves load-bearing bytes exposed — corruption.
+
+    That is the OPPOSITE polarity from the R7-1b feature-detection lesson, where
+    blanking too much caused false-READYs. Do not carry that instinct over:
+    here, when in doubt, protect MORE. The one exception is a MISPLACED range,
+    which is neither wider nor narrower but simply wrong — see the [\lstinline]
+    note in the implementation. *)
+
+val protected_ranges : string -> (int * int) list
+(** [protected_ranges src] — half-open byte ranges of [src] whose contents are
+    syntax rather than prose, so a textual fix must not touch them. Ranges are
+    returned in ascending order of start offset and may be adjacent; they are
+    not guaranteed disjoint. *)
+
+val filter : src:string -> Cst_edit.t list -> Cst_edit.t list
+(** [filter ~src edits] — drop every edit whose half-open span intersects a
+    protected range of [src].
+
+    The whole half-open span from [start_offset] to [end_offset] is tested, not
+    just the start offset: an edit beginning one byte before a protected region
+    and ending inside it would otherwise slip through. A pure insertion
+    ([start_offset = end_offset]) is tested as a point.
+
+    Call this against the CURRENT buffer on every pass of the converge loop, not
+    once against the original source. Producers cascade: SCRIPT-007 was measured
+    firing on pass 2 against a subscript SCRIPT-001 had itself synthesised
+    inside a label key. Neither producer is wrong alone, so only re-evaluation
+    against the rewritten bytes can catch it. *)

--- a/latex-parse/src/validators_cli.ml
+++ b/latex-parse/src/validators_cli.ml
@@ -151,9 +151,11 @@ let collect_fix_edits ?filter_id ~(src : string)
       let included =
         match filter_id with None -> true | Some id -> r.id = id
       in
-      match r.fix with Some edits when included -> edits | _ -> [])
+      match r.fix with
+      | Some edits when included ->
+          Latex_parse_lib.Fix_guard.filter ~src ~rule_id:r.id edits
+      | _ -> [])
     results
-  |> Latex_parse_lib.Fix_guard.filter ~src
 
 let env_flag_on name =
   match Sys.getenv_opt name with

--- a/latex-parse/src/validators_cli.ml
+++ b/latex-parse/src/validators_cli.ml
@@ -135,8 +135,15 @@ let print_result (r : Latex_parse_lib.Validators.result) =
 
 (** Collect every fix edit from [results] into a single list. Rules that emit
     [fix = None] contribute nothing. If [filter_id] is [Some id], only results
-    whose [r.id = id] contribute (v26.3 [--apply-fixes-for]). *)
-let collect_fix_edits ?filter_id
+    whose [r.id = id] contribute (v26.3 [--apply-fixes-for]).
+
+    R7-3: every fix in the tool funnels through here — one construction site
+    ([Validators_common.mk_result_with_fix]) and this one consumption site — so
+    this is where the load-bearing-region guard belongs. [~src] must be the
+    CURRENT buffer, not the original: producers cascade, and SCRIPT-007 was
+    measured firing on pass 2 against a subscript SCRIPT-001 had just
+    synthesised inside a [\label] key. See fix_guard.mli. *)
+let collect_fix_edits ?filter_id ~(src : string)
     (results : Latex_parse_lib.Validators.result list) :
     Latex_parse_lib.Cst_edit.t list =
   List.concat_map
@@ -146,6 +153,7 @@ let collect_fix_edits ?filter_id
       in
       match r.fix with Some edits when included -> edits | _ -> [])
     results
+  |> Latex_parse_lib.Fix_guard.filter ~src
 
 let env_flag_on name =
   match Sys.getenv_opt name with
@@ -217,7 +225,7 @@ let run_apply_fixes_converge ?filter_id ~path ~src () =
     (* Class-D-inclusive so L4 STYLE fix producers (STYLE-015/023) apply; batch
        path, not the keystroke hot path (v27.1.6). *)
     let results = Latex_parse_lib.Validators.run_all_with_class_d cur in
-    let edits = collect_fix_edits ?filter_id results in
+    let edits = collect_fix_edits ?filter_id ~src:cur results in
     if edits = [] then cur
     else
       let nxt, _applied, _skipped =
@@ -256,7 +264,7 @@ let run_apply_fixes ?filter_id ?(best_effort = false) ?(converge = false) ~path
         let _bp = setup_all ~path ~src ~log_path:None in
         (* Class-D-inclusive (see converge path) so STYLE-* fixes apply. *)
         let results = Latex_parse_lib.Validators.run_all_with_class_d src in
-        let edits = collect_fix_edits ?filter_id results in
+        let edits = collect_fix_edits ?filter_id ~src results in
         if best_effort then (
           let out, applied, skipped =
             Latex_parse_lib.Cst_edit.apply_best_effort src edits


### PR DESCRIPTION
The fixer was **creating the project's cardinal bug**. R7-INFRA-4 (#518) measured 25 recorded defects, of which **18 were manufactured false-READYs** — `--compile-check` said READY *before and after* while pdflatex went 0 → 1. The tool asked to improve a document was silently breaking it, and the checker could not see it.

**After this guard: 25 → 9 defects, 18 → 2 manufactured false-READYs.** Single commit — squash-safe.

## Why a region guard, not a post-fix verdict check

A post-fix re-check cannot work here. For both corpus breakages the verdict is READY on **both** sides, so verdict-monotonicity detects nothing. The damage has to be **prevented**, not detected — hence a subtractive filter over edits.

## The contract is new

There was no load-bearing-region notion in the repo. `find_exempt_ranges` is a **typography-suppression** contract — *"are these bytes ordinary prose?"* — which is a different question from *"would rewriting these bytes change what TeX does?"*. TYPO-002 obeys the existing contract perfectly and still destroys an `\input` filename.

v1 covers the two highest-damage regions, both purely lexical:

1. **Control-symbol arguments** — a backslash followed by a non-letter is a control *symbol*; the byte after it **is** the command. Rewriting the backtick of the grave-accent command to U+2018 destroys it.
2. **TikZ/PGF picture bodies** — a double hyphen inside a path is pgf's **line-to operator**, not punctuation. `tikzpicture` is *not* in the verbatim env list, so nothing covered this before.

## Error polarity is inverted here

For a **subtractive edit filter**, an over-wide range withholds a fix (safe); a narrow or **misplaced** range exposes load-bearing bytes (corruption). That's the opposite of the R7-1b feature-detection lesson where over-blanking caused false-READYs. The code says so explicitly, so the next reader doesn't misapply it.

## Placement

One construction site (`mk_result_with_fix`) and one consumption site (`collect_fix_edits`) means **all 167 producers** are covered by a single filter. It takes `~src` and runs on **every pass of the converge loop**, not once against the original — producers cascade: SCRIPT-007 was measured firing on pass 2 against a subscript **SCRIPT-001 had itself synthesised** inside a label key. Neither producer is wrong alone, so only re-evaluation against the rewritten bytes catches it.

## No over-restriction — verified, not assumed

| check | result |
|---|---|
| ordinary prose fixes | still applied (quotes curled, `...` → `\dots`) |
| accents on the same line | left alone |
| `\\` line break | does **not** block fixes on the next line |
| control *words* (`\textbf`) | skipped, trailing prose still fixable |
| `dune runtest` | green — typo-fix 471, candidate_fixes 348, apply-fixes-cli 19, fix-integration 6 |

`good_tikz_simple` and `good_accents_utf8` now produce **no diff at all**, because their only fixable content *was* the corrupting edit — correct suppression, not lost functionality. Corpus-wide rewrites 114 → 94 cells, fully accounted for by those two classes.

## The gate proved it, which was the point of landing infra first

Before re-recording, INFRA-4 emitted 16 lines of `recorded as broken but is now CLEAN — a fix landed`. That is the monotone gate mechanically demonstrating the guard worked, rather than me asserting it.

## Still broken — recorded, not hidden (9 entries)

- the `\input`-filename class (region 3)
- the **pilot-only** tabular-preamble corruption in `good_longtable_free` (region 5)
- two non-idempotence entries

Regions 3–5 are the next PR, and INFRA-4 will prove them the same way.

## Not claiming soundness

The vcu scanner this shares a codebase with mishandles `\lstinline[opt]` — that range is **misplaced**, not merely wide, so real verbatim content stays exposed. That's the OR-1 shared-verb-scanner fix, still open. I'm deliberately not writing "sound" until it lands.