### PR TITLE
feat(R7-3): fix guard region 3 — filename and package-spec arguments

### DIFF
--- a/corpora/apply_fixes/adv--sty.sty
+++ b/corpora/apply_fixes/adv--sty.sty
@@ -1,0 +1,13 @@
+\NeedsTeXFormat{LaTeX2e}
+\ProvidesPackage{adv--sty}[2026/08/01 R7-3 region 3b adversarial fixture]
+% A local package whose FILE NAME contains a double hyphen. Nothing here
+% matters except that the file exists under this name: the point of the
+% fixture is that rewriting the name in the loading document makes the load
+% fail.
+% Swallow any option, so adv_option_bracket.tex can pass a keyval option whose
+% VALUE contains a right bracket -- the shape that broke the region-3 option
+% scan -- and still compile before the fix is applied. Without this the
+% document fails pristine and the round-trip gate cannot grade it.
+\DeclareOption*{\relax}
+\ProcessOptions\relax
+\endinput

--- a/corpora/apply_fixes/adv_input_bare.tex
+++ b/corpora/apply_fixes/adv_input_bare.tex
@@ -1,0 +1,11 @@
+% Adversarial fixture: the BARE plain-TeX include form, no braces.
+% The filename runs from the command to the next whitespace, so a typography
+% rewrite of the double hyphen destroys it exactly as it does in the braced
+% form -- and a guard that only understands braces would miss this path.
+% NOTE: like the other fixtures here, this comment avoids writing the include
+% command itself, because T2's include extraction is comment-blind and would
+% treat the mention as a real edge.
+\documentclass{article}
+\begin{document}
+\input adv--child
+\end{document}

--- a/corpora/apply_fixes/adv_lstinput_filename.tex
+++ b/corpora/apply_fixes/adv_lstinput_filename.tex
@@ -1,0 +1,11 @@
+% Adversarial fixture: a filename command that is NOT the include family, read
+% through an OPTIONAL argument first. The guard has to consume the bracketed
+% group before it reaches the braced one; a scanner that stops at the first
+% non-brace byte after the command name would leave the filename exposed.
+% NOTE: this comment avoids writing the include command itself, because T2's
+% include extraction is comment-blind and would treat the mention as an edge.
+\documentclass{article}
+\usepackage{listings}
+\begin{document}
+\lstinputlisting[basicstyle=\ttfamily]{adv--child.tex}
+\end{document}

--- a/corpora/apply_fixes/adv_option_bracket.tex
+++ b/corpora/apply_fixes/adv_option_bracket.tex
@@ -1,0 +1,16 @@
+% Adversarial fixture: a right bracket nested inside a BRACED OPTION VALUE, in
+% an option list that WRAPS ACROSS LINES.
+% An option scan that stops at the first raw bracket ends the group early; the
+% range then stops at end of THAT line, so the package name on the next line is
+% left exposed and the typography fix lands in it. Closing only at an unescaped
+% bracket at brace depth 0 -- the semantics of the verified drop_after_rbracket
+% in proofs/BodyTokenFrontEnd.v -- is what actually covers this.
+% The line wrap is load-bearing: on a single line the end-of-line fallback
+% already rescues it, so a one-line version of this fixture is VACUOUS.
+% NOTE: adv--sty.sty ships next to this file.
+\documentclass{article}
+\usepackage[Ligatures={x]y},
+            Numbers=OldStyle]{adv--sty}
+\begin{document}
+Body.
+\end{document}

--- a/corpora/apply_fixes/adv_usepackage_local.tex
+++ b/corpora/apply_fixes/adv_usepackage_local.tex
@@ -1,0 +1,11 @@
+% Adversarial fixture: region 3b, a LOCAL package whose file name contains a
+% double hyphen. A package specification is a filename too -- adv--sty.sty sits
+% next to this file -- so the same typography rewrite that destroys an include
+% name destroys the package load, and the document stops compiling.
+% This is the case that argues region 3b is not merely defensive: CTAN names
+% are tame, but names the author chose for their own .sty are not.
+\documentclass{article}
+\usepackage{adv--sty}
+\begin{document}
+Body.
+\end{document}

--- a/corpora/apply_fixes/manifest.json
+++ b/corpora/apply_fixes/manifest.json
@@ -8,38 +8,6 @@
   "pdflatex_graded": true,
   "known_broken": [
     {
-      "doc": "corpora/apply_fixes/adv_input_filename.tex",
-      "mode": "default:--apply-fixes",
-      "breaks_compile": true,
-      "degrades_verdict": true,
-      "not_idempotent": false,
-      "manufactured_false_ready": false
-    },
-    {
-      "doc": "corpora/apply_fixes/adv_input_filename.tex",
-      "mode": "default:--apply-fixes-best-effort",
-      "breaks_compile": true,
-      "degrades_verdict": true,
-      "not_idempotent": false,
-      "manufactured_false_ready": false
-    },
-    {
-      "doc": "corpora/apply_fixes/adv_input_filename.tex",
-      "mode": "pilot:--apply-fixes",
-      "breaks_compile": true,
-      "degrades_verdict": true,
-      "not_idempotent": false,
-      "manufactured_false_ready": false
-    },
-    {
-      "doc": "corpora/apply_fixes/adv_input_filename.tex",
-      "mode": "pilot:--apply-fixes-best-effort",
-      "breaks_compile": true,
-      "degrades_verdict": true,
-      "not_idempotent": true,
-      "manufactured_false_ready": false
-    },
-    {
       "doc": "corpora/compile_check/good_longtable_free.tex",
       "mode": "pilot:--apply-fixes",
       "breaks_compile": true,

--- a/latex-parse/src/dune
+++ b/latex-parse/src/dune
@@ -220,6 +220,11 @@
  (libraries latex_parse_lib test_helpers unix))
 
 (test
+ (name test_fix_guard)
+ (modules test_fix_guard)
+ (libraries latex_parse_lib test_helpers unix))
+
+(test
  (name test_context_exemption)
  (modules test_context_exemption)
  (libraries latex_parse_lib test_helpers unix))

--- a/latex-parse/src/fix_guard.ml
+++ b/latex-parse/src/fix_guard.ml
@@ -2,14 +2,20 @@
    note (this is a SUBTRACTIVE filter: over-wide is safe, narrow/misplaced is
    not).
 
-   v1 implements the two highest-damage regions, both purely lexical and both
-   over-wide-safe. Regions deliberately NOT yet covered, in measured-damage
-   order: 3. filename arguments (\input \include \includegraphics \bibliography
-   ...) 4. key arguments (\label \ref \cite ... — also the SCRIPT-001->007
-   cascade) 5. tabular/array preamble (the pilot-only good_longtable_free
-   corruption) Their fixtures stay recorded as known breakages in
-   corpora/apply_fixes/, so the round-trip gate proves exactly which classes are
-   closed and which are not. *)
+   Regions implemented, all purely lexical: 1. control symbol arguments, 2.
+   TikZ/PGF picture bodies, 3a. filename arguments, 3b. package-spec arguments.
+
+   Regions NOT yet covered, in measured-damage order, and — this part matters —
+   with UNEQUAL evidence behind them: 4. key arguments (\label \ref \cite ...,
+   also the SCRIPT-001->007 cascade). NO fixture exists for this class anywhere
+   in the corpora, so the round-trip gate is SILENT on it. Its absence from the
+   gate's baseline is not evidence that it is harmless; it is evidence that
+   nobody has measured it. A key-argument corruption would ship with every gate
+   green. 5. tabular/array preamble. This one IS measured: good_longtable_free
+   under the pilot profile occupies two rows of
+   corpora/apply_fixes/manifest.json and is, after region 3, the ONLY remaining
+   manufactured false-READY. An earlier version of this comment claimed both
+   classes were fixture-tracked. Only region 5 is. *)
 
 let is_letter c = (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')
 
@@ -88,12 +94,264 @@ let picture_ranges (src : string) : (int * int) list =
         (find_all src b))
     picture_envs
 
+(* ── Region 3: filename and package-spec arguments ─────────────────────────
+   The braced argument of an include-family command is a FILESYSTEM IDENTIFIER,
+   not prose. Measured on adv_input_filename.tex in all four fixer modes:
+   TYPO-002 rewrites the double hyphen of \input{adv--child} to an en dash, and
+   the pilot profile additionally inserts a thin-space command INTO the name, so
+   the emitted document asks TeX for a file that does not exist.
+
+   Two command sets, because they need different exemptions.
+
+   3a FILENAME arguments — names the author chose, which really do contain the
+   characters typography rules target (fig--v2, data-2020). No producer has any
+   business rewriting one, so this region has no exemption list.
+
+   3b PACKAGE-SPEC arguments — \usepackage and friends. The argument is still a
+   filename (a .sty or .cls, which for a local package the author also named)
+   and the same rewrite corrupts it; but four shipped producers reorder whole
+   \usepackage lines as their CONTRACT, so this region carries the
+   package_spec_aware exemption below. Splitting 3a from 3b keeps that exemption
+   narrow: PKG-002 is exempt from package specs only, and is still blocked from
+   filenames.
+
+   FAILURE DIRECTION (the argument this module requires of every region). A
+   range always STARTS at the command backslash and runs contiguously forward,
+   so it may be over-wide; the danger is the opposite — a SHORT range that ends
+   before the argument and leaves load-bearing bytes exposed.
+
+   An earlier draft of this scanner claimed it could be over-wide but never
+   short. That was FALSE. An audit produced three shapes that broke it, all of
+   them shapes region 3 exists for. Each is now handled explicitly and pinned by
+   a test: (1) a right bracket inside a braced option VALUE, as in
+   backslash-usepackage[Ligatures={x]y}]{name} — the option group now closes
+   only at an UNESCAPED bracket at brace DEPTH 0, mirroring the verified
+   drop_after_rbracket in proofs/BodyTokenFrontEnd.v, which was written for
+   exactly this shape; (2) a TeX comment between the command and its argument —
+   now skipped to end of line, because TeX swallows it before reading the
+   argument; (3) any other byte this scanner does not model, in practice a
+   control sequence — the range now extends to end of line instead of stopping
+   at the command name.
+
+   The remaining deliberate choices all err over-wide, which only withholds a
+   fix: * a mention inside a comment or a verbatim block is protected too. Those
+   bytes are never typeset, and declining to model them avoids inheriting the
+   comment-blindness bug class that has bitten every scanner reused in this
+   codebase. * an unclosed brace or option group protects to end of file — what
+   TeX itself does with the unclosed group, and the same choice region 2 makes
+   for an unmatched \begin.
+
+   Accepted UNDER-reach, recorded rather than left silent: an argument sitting
+   on a LATER line than its command, reached past a token this scanner does not
+   model, is not covered; and the plain-TeX bare form is honoured for \input
+   only, up to the next whitespace. *)
+let filename_arg_cmds =
+  [
+    "input";
+    "include";
+    "includeonly";
+    "includegraphics";
+    "lstinputlisting";
+    "verbatiminput";
+    "InputIfFileExists";
+    "subfile";
+    "subfileinclude";
+    "bibliography";
+    "addbibresource";
+    "bibliographystyle";
+    "graphicspath";
+  ]
+
+let package_arg_cmds =
+  [
+    "usepackage";
+    "RequirePackage";
+    "RequirePackageWithOptions";
+    "documentclass";
+    "LoadClass";
+    "LoadClassWithOptions";
+  ]
+
+let is_blank c = c = ' ' || c = '\t' || c = '\n' || c = '\r'
+
+(* Advance past whitespace and TeX comments. A comment runs from an unescaped
+   percent to end of line and TeX swallows it before reading the argument, so
+   stepping over one EXTENDS the search rather than truncating it. Not doing so
+   ended the range at the command name for [\includegraphics%c] followed by the
+   braced filename on the next line, leaving the filename exposed. *)
+let rec skip_blanks_and_comments (src : string) (n : int) (p : int) : int =
+  if p >= n then p
+  else if is_blank (String.unsafe_get src p) then
+    skip_blanks_and_comments src n (p + 1)
+  else if String.unsafe_get src p = '%' then (
+    let e = ref p in
+    while !e < n && String.unsafe_get src !e <> '\n' do
+      incr e
+    done;
+    skip_blanks_and_comments src n !e)
+  else p
+
+(* From [k], one past the command name, consume an optional star, any number of
+   bracketed option groups, and the first braced group; return one past the last
+   byte consumed. [bare] additionally accepts the plain-TeX form (a filename
+   terminated by whitespace) when no brace follows. Never returns less than
+   [k]. *)
+let scan_command_argument (src : string) (k : int) ~(bare : bool) : int =
+  let n = String.length src in
+  let stop = ref k in
+  let i = ref k in
+  let found_group = ref false in
+  if !i < n && String.unsafe_get src !i = '*' then (
+    incr i;
+    stop := !i);
+  let scanning = ref true in
+  while !scanning do
+    let j = ref (skip_blanks_and_comments src n !i) in
+    if !j >= n then scanning := false
+    else
+      match String.unsafe_get src !j with
+      | '[' ->
+          (* Option group. This mirrors the semantics of the VERIFIED
+             [drop_after_rbracket] (proofs/BodyTokenFrontEnd.v:388, shipped in
+             #508 for exactly this shape): the group closes at an UNESCAPED
+             right bracket at brace DEPTH 0. Closing at the first raw bracket
+             instead ended the range before the filename in
+             [\usepackage[Ligatures={x]y}]{fontspec-local}] — a SHORT range,
+             which is the one failure this module must not produce. An unclosed
+             group runs to end of file, which is over-wide and therefore
+             safe. *)
+          let e = ref (!j + 1) and depth = ref 0 and fin = ref (-1) in
+          while !fin < 0 && !e < n do
+            (match String.unsafe_get src !e with
+            | '\\' -> incr e
+            | '{' -> incr depth
+            | '}' -> if !depth > 0 then decr depth
+            | ']' -> if !depth = 0 then fin := !e + 1
+            | _ -> ());
+            incr e
+          done;
+          let e = if !fin >= 0 then !fin else n in
+          stop := e;
+          i := e
+      | '{' ->
+          let depth = ref 0 and e = ref !j and fin = ref (-1) in
+          while !fin < 0 && !e < n do
+            (match String.unsafe_get src !e with
+            | '\\' -> incr e (* an escaped brace is a character, not a group *)
+            | '{' -> incr depth
+            | '}' ->
+                decr depth;
+                if !depth = 0 then fin := !e + 1
+            | _ -> ());
+            incr e
+          done;
+          stop := if !fin >= 0 then !fin else n;
+          found_group := true;
+          scanning := false
+      | c ->
+          (* Bare plain-TeX form. Refuse the openers that cannot start a
+             filename, so a command with no argument at all does not swallow the
+             next control sequence or a comment. *)
+          if bare && not (c = '\\' || c = '%' || c = '}' || c = '$' || c = '&')
+          then (
+            let e = ref !j in
+            while !e < n && not (is_blank (String.unsafe_get src !e)) do
+              incr e
+            done;
+            if !e > !j then (
+              stop := !e;
+              found_group := true))
+          else if not !found_group then (
+            (* We bailed on a byte belonging to no argument shape this scanner
+               understands — in practice a control sequence, as in
+               [\includegraphics\relax{fig-1}]. Ending here would leave a
+               filename later on the SAME LINE exposed, so extend to end of
+               line: over-wide only withholds a fix, short exposes load-bearing
+               bytes. Bounded at the newline so it cannot swallow the
+               document. *)
+            let e = ref !j in
+            while !e < n && String.unsafe_get src !e <> '\n' do
+              incr e
+            done;
+            stop := max !stop !e);
+          scanning := false
+  done;
+  !stop
+
+let argument_ranges (src : string) : (int * int) list * (int * int) list =
+  let n = String.length src in
+  let fns = ref [] and pkgs = ref [] in
+  let i = ref 0 in
+  while !i < n do
+    if String.unsafe_get src !i = '\\' && !i + 1 < n then
+      if is_letter (String.unsafe_get src (!i + 1)) then (
+        let start = !i in
+        let j = ref (!i + 1) in
+        while !j < n && is_letter (String.unsafe_get src !j) do
+          incr j
+        done;
+        (* Whole-name comparison, so \include does not match inside
+           \includegraphics. *)
+        let name = String.sub src (start + 1) (!j - start - 1) in
+        let fn = List.mem name filename_arg_cmds in
+        let pk = (not fn) && List.mem name package_arg_cmds in
+        if fn || pk then (
+          let stop =
+            scan_command_argument src !j ~bare:(String.equal name "input")
+          in
+          let r = (start, max stop !j) in
+          if fn then fns := r :: !fns else pkgs := r :: !pkgs;
+          i := max !j stop)
+        else i := !j)
+      else
+        (* Control SYMBOL: step past both bytes, so the second backslash of a
+           doubled escape is not re-read as the start of a fresh command. *)
+        i := !i + 2
+    else incr i
+  done;
+  (List.rev !fns, List.rev !pkgs)
+
+type regions = {
+  control_symbol : (int * int) list;
+  picture : (int * int) list;
+  filename : (int * int) list;
+  package_spec : (int * int) list;
+}
+
+let compute_regions (src : string) : regions =
+  let filename, package_spec = argument_ranges src in
+  {
+    control_symbol = control_symbol_ranges src;
+    picture = picture_ranges src;
+    filename;
+    package_spec;
+  }
+
+(* One-entry memo keyed on the buffer's PHYSICAL identity.
+
+   [filter] is called once per FIRING RULE per converge pass — up to 64 passes,
+   with every rule in a pass seeing the same buffer — and the scanners are all
+   linear in the buffer (region 2's substring search allocates once per byte per
+   needle), so recomputing them per rule dominated the fixer's cost.
+
+   OCaml strings are immutable, so [==] implies equal contents: a stale entry
+   can only ever cause a MISS, never a wrong answer. The fix path is
+   single-threaded; a concurrent caller would at worst lose the cache hit. *)
+let memo : (string * regions) option ref = ref None
+
+let regions_of (src : string) : regions =
+  match !memo with
+  | Some (s, r) when s == src -> r
+  | _ ->
+      let r = compute_regions src in
+      memo := Some (src, r);
+      r
+
 let protected_ranges (src : string) : (int * int) list =
-  let rs = control_symbol_ranges src @ picture_ranges src in
+  let r = regions_of src in
+  let rs = r.control_symbol @ r.picture @ r.filename @ r.package_spec in
   List.sort (fun (a, _) (b, _) -> compare a b) rs
 
-(* Half-open intersection. A pure insertion (s = e) is a point, and a point on a
-   protected range's exclusive end is NOT inside it. *)
 (* Rules whose contract IS editing control symbols. Derived from the golden
    variants in check_producer_coverage.py: each of these was measured emitting a
    legitimate fix that region 1 withheld. That gate is the completeness check —
@@ -115,6 +373,26 @@ let control_symbol_aware =
     "TYPO-062" (* literal backslash to \textbackslash *);
   ]
 
+(* Rules whose contract IS rewriting a package specification: each reorders two
+   whole \usepackage lines, so its edit necessarily spans one. Derived the same
+   way as the list above — from the golden variants in
+   check_producer_coverage.py, which is the completeness check.
+
+   The package INSERTERS (CJK-004, CJK-006, PKG-011, PKG-012, REF-011,
+   STRUCT-001) are deliberately absent: they emit a pure insertion at the offset
+   just PAST the closing brace, and a point on a range's exclusive end is not
+   inside it, so region 3b never withholds them. That is verified by the same
+   gate, not assumed here. *)
+let package_spec_aware =
+  [
+    "PKG-002" (* geometry before hyperref *);
+    "PKG-007" (* hyperref load order *);
+    "PKG-023" (* unicode-math before microtype *);
+    "TIKZ-007" (* tikz before hyperref *);
+  ]
+
+(* Half-open intersection. A pure insertion (s = e) is a point, and a point on a
+   protected range's exclusive end is NOT inside it. *)
 let intersects (s, e) (a, b) = if s = e then a <= s && s < b else s < b && a < e
 
 let filter ~(src : string) ~(rule_id : string) (edits : Cst_edit.t list) :
@@ -122,16 +400,23 @@ let filter ~(src : string) ~(rule_id : string) (edits : Cst_edit.t list) :
   match edits with
   | [] -> []
   | _ ->
-      (* A control-symbol-aware rule still gets the picture region: no producer
-         has any business rewriting inside a TikZ path. *)
-      let ranges =
-        if List.mem rule_id control_symbol_aware then picture_ranges src
-        else protected_ranges src
+      let r = regions_of src in
+      (* Exemptions are PER REGION, never global. A control-symbol-aware rule
+         still gets the picture, filename and package regions; a package-aware
+         reorderer is still blocked from filenames and TikZ paths. Nothing is
+         ever exempt from regions 2 and 3a. *)
+      let active =
+        (if List.mem rule_id control_symbol_aware then []
+         else [ r.control_symbol ])
+        @ [ r.picture; r.filename ]
+        @ if List.mem rule_id package_spec_aware then [] else [ r.package_spec ]
       in
-      if ranges = [] then edits
-      else
-        List.filter
-          (fun (ed : Cst_edit.t) ->
-            let span = (ed.start_offset, ed.end_offset) in
-            not (List.exists (fun r -> intersects span r) ranges))
-          edits
+      let blocked span =
+        List.exists
+          (fun rs -> List.exists (fun rg -> intersects span rg) rs)
+          active
+      in
+      List.filter
+        (fun (ed : Cst_edit.t) ->
+          not (blocked (ed.start_offset, ed.end_offset)))
+        edits

--- a/latex-parse/src/fix_guard.mli
+++ b/latex-parse/src/fix_guard.mli
@@ -34,7 +34,10 @@ val protected_ranges : string -> (int * int) list
 (** [protected_ranges src] — half-open byte ranges of [src] whose contents are
     syntax rather than prose, so a textual fix must not touch them. Ranges are
     returned in ascending order of start offset and may be adjacent; they are
-    not guaranteed disjoint. *)
+    not guaranteed disjoint.
+
+    This is the union of every region. {!filter} does NOT use it: exemptions are
+    per region, so it selects the applicable regions per rule instead. *)
 
 val control_symbol_aware : string list
 (** Rules whose CONTRACT is to edit control symbols, and which are therefore
@@ -49,6 +52,21 @@ val control_symbol_aware : string list
     be backed by the golden variants in
     [scripts/tools/check_producer_coverage.py] — that gate fails if a
     legitimately-blocked fix is withheld, so the list cannot silently rot. *)
+
+val package_spec_aware : string list
+(** Rules whose CONTRACT is to rewrite a package specification — the load-order
+    producers, each of which swaps two whole [\usepackage] lines and therefore
+    emits an edit spanning one. Exempt from the package-spec region (3b) only,
+    never from the filename region (3a): a load-order rule has no business
+    inside [\input{...}] either.
+
+    Same evidence standard as {!control_symbol_aware}: membership is a claim
+    backed by the golden variants in [scripts/tools/check_producer_coverage.py].
+
+    The package INSERTERS are deliberately NOT here. They emit a pure insertion
+    at the offset just past the closing brace, which is the range's exclusive
+    end and therefore outside it, so the region never withholds them — a
+    property the coverage gate checks rather than one this list asserts. *)
 
 val filter : src:string -> rule_id:string -> Cst_edit.t list -> Cst_edit.t list
 (** [filter ~src ~rule_id edits] — drop every edit whose half-open span

--- a/latex-parse/src/test_fix_guard.ml
+++ b/latex-parse/src/test_fix_guard.ml
@@ -1,0 +1,260 @@
+(** Unit tests for the fix guard ({!Latex_parse_lib.Fix_guard}).
+
+    The guard is a SUBTRACTIVE filter over fix edits: it withholds any edit that
+    would rewrite bytes TeX reads as syntax. Its error polarity is inverted from
+    the usual one in this repo — an over-wide protected range only withholds a
+    fix, while a narrow or misplaced one lets a producer corrupt a document. So
+    these cases pin two things per region: that a load-bearing byte IS blocked,
+    and that ordinary prose next to it is NOT (the guard must not turn into a
+    blanket refusal, which the round-trip and coverage gates would then read as
+    a healthy fixer that simply never fixes anything).
+
+    The fixture-level proof lives in corpora/apply_fixes/ and the round-trip
+    gate; these are the fast deterministic sentinels for the range algebra
+    itself. *)
+
+open Latex_parse_lib
+open Test_helpers
+
+(* Byte offset of the first occurrence of [sub] in [s]. *)
+let find_sub s sub =
+  let n = String.length s and m = String.length sub in
+  let rec go i =
+    if i + m > n then failwith ("test bug: substring not found: " ^ sub)
+    else if String.sub s i m = sub then i
+    else go (i + 1)
+  in
+  go 0
+
+(* Would a fix from [rule_id] rewriting the first occurrence of [sub] survive
+   the guard? [false] = withheld. *)
+let survives ?(rule_id = "TYPO-002") src sub =
+  let i = find_sub src sub in
+  let e =
+    Cst_edit.replace ~start_offset:i
+      ~end_offset:(i + String.length sub)
+      "\xe2\x80\x93"
+  in
+  Fix_guard.filter ~src ~rule_id [ e ] <> []
+
+(* Would a pure insertion at [at] survive? *)
+let insertion_survives ?(rule_id = "PKG-011") src at =
+  Fix_guard.filter ~src ~rule_id [ Cst_edit.insert ~at "x" ] <> []
+
+let () =
+  (* ── Region 3a: filename arguments ──────────────────────────────────── *)
+  run "double hyphen inside an include filename is withheld" (fun tag ->
+      expect
+        (not (survives "\\input{adv--child}\n" "--"))
+        (tag ^ ": the measured adv_input_filename corruption"));
+
+  run "the same double hyphen in prose is still fixed" (fun tag ->
+      expect
+        (survives "\\input{child}\n\nan em -- dash\n" "-- dash")
+        (tag ^ ": the guard must not become a blanket refusal"));
+
+  List.iter
+    (fun cmd ->
+      run
+        ("filename argument of " ^ cmd ^ " is protected")
+        (fun tag ->
+          expect
+            (not (survives ("\\" ^ cmd ^ "{a--b}\n") "--"))
+            (tag ^ ": " ^ cmd)))
+    [
+      "input";
+      "include";
+      "includegraphics";
+      "subfile";
+      "bibliography";
+      "addbibresource";
+      "bibliographystyle";
+      "lstinputlisting";
+    ];
+
+  run "optional argument is consumed before the braced one" (fun tag ->
+      expect
+        (not (survives "\\includegraphics[width=2cm]{fig--1}\n" "--"))
+        (tag ^ ": the [..] group must not stop the scan"));
+
+  run "starred form is consumed" (fun tag ->
+      expect
+        (not (survives "\\includegraphics*{fig--1}\n" "--"))
+        (tag ^ ": the star must not stop the scan"));
+
+  run "whitespace between command and argument is skipped" (fun tag ->
+      expect
+        (not (survives "\\input  {adv--child}\n" "--"))
+        (tag ^ ": TeX allows the space"));
+
+  run "bare plain-TeX form of \\input is protected" (fun tag ->
+      expect
+        (not (survives "\\input adv--child\n" "--"))
+        (tag ^ ": no braces, filename ends at whitespace"));
+
+  run "bare form stops at whitespace" (fun tag ->
+      expect
+        (survives "\\input child\n\ntext -- here\n" "-- here")
+        (tag ^ ": prose after the filename stays live"));
+
+  run "bare form does not swallow a following control sequence" (fun tag ->
+      expect
+        (survives "\\input \\fname\n\ntext -- here\n" "-- here")
+        (tag ^ ": a macro is not a filename"));
+
+  run "nested braces inside a filename argument are balanced" (fun tag ->
+      expect
+        (not (survives "\\graphicspath{{img--a/}{img--b/}}\n" "--"))
+        (tag ^ ": the whole outer group is one argument"));
+
+  run "an unclosed argument protects to end of file" (fun tag ->
+      expect
+        (not (survives "\\input{adv\n\ntext -- here\n" "-- here"))
+        (tag ^ ": TeX reads the unclosed group to EOF; over-wide is safe"));
+
+  run "whole-name match: \\include does not match inside \\includegraphics"
+    (fun tag ->
+      (* If the scanner matched a prefix, it would stop the range after
+         [graphics] and leave the real filename exposed. *)
+      expect
+        (not (survives "\\includegraphics{fig--1}\n" "--"))
+        (tag ^ ": prefix matching would misplace the range"));
+
+  run "a command that is not in the set is not protected" (fun tag ->
+      expect
+        (survives "\\emph{a -- b}\n" "--")
+        (tag ^ ": only include-family commands take filenames"));
+
+  (* ── SHORT-range regressions found by audit against the first draft ─────
+     Each of these ended the protected range BEFORE the filename, which is the
+     one failure direction this module must not have. They are the exact shapes
+     region 3 exists for, so they are pinned here as well as in the corpus. *)
+  run "right bracket inside a braced option value does not close the group"
+    (fun tag ->
+      expect
+        (not (survives "\\usepackage[Ligatures={x]y}]{fontspec--local}\n" "--"))
+        (tag ^ ": closes only at an unescaped ] at brace depth 0"));
+
+  run "same, for a filename command" (fun tag ->
+      expect
+        (not (survives "\\includegraphics[caption={a]b}]{fig--1}\n" "--"))
+        (tag ^ ": region 3a must not end before the filename"));
+
+  run "option group wrapping across lines still reaches the argument"
+    (fun tag ->
+      (* The case that ISOLATES the depth-aware bracket scan. On one line the
+         end-of-line fallback already rescues a mis-closed group, so the
+         single-line version of this test would pass even with a naive scan. *)
+      expect
+        (not
+           (survives
+              "\\usepackage[Ligatures={x]y},\n\
+              \            Numbers=OldStyle]{adv--sty}\n"
+              "--"))
+        (tag ^ ": the argument is on the line AFTER the mis-close"));
+
+  run "escaped right bracket does not close the option group" (fun tag ->
+      expect
+        (not (survives "\\includegraphics[alt=a\\]b]{fig--1}\n" "--"))
+        (tag ^ ": an escaped bracket is a character"));
+
+  run "comment between command and argument is skipped" (fun tag ->
+      expect
+        (not (survives "\\includegraphics%c\n{fig--1}\n" "--"))
+        (tag ^ ": TeX swallows the comment before the argument"));
+
+  run "unmodelled token before the argument extends to end of line" (fun tag ->
+      expect
+        (not (survives "\\includegraphics\\relax{fig--1}\n" "--"))
+        (tag ^ ": short range would expose the filename"));
+
+  run "that end-of-line fallback does not cross the newline" (fun tag ->
+      expect
+        (survives "\\includegraphics\\relax\n\ntext -- here\n" "-- here")
+        (tag ^ ": bounded at the newline, not the whole document"));
+
+  (* ── Whole-span testing (not just the start offset) ──────────────────── *)
+  run "an edit starting before the range and ending inside it is withheld"
+    (fun tag ->
+      let src = "x \\input{adv--child}\n" in
+      let e =
+        Cst_edit.replace ~start_offset:0 ~end_offset:(find_sub src "--" + 2) "y"
+      in
+      expect
+        (Fix_guard.filter ~src ~rule_id:"TYPO-002" [ e ] = [])
+        (tag ^ ": straddling edits must not slip through"));
+
+  (* ── Region 3b: package specifications ───────────────────────────────── *)
+  run "double hyphen in a package name is withheld" (fun tag ->
+      expect
+        (not (survives "\\usepackage{adv--sty}\n" "--"))
+        (tag ^ ": a local .sty is a filename too"));
+
+  run "double hyphen in a class option is withheld" (fun tag ->
+      expect
+        (not (survives "\\documentclass[a--b]{article}\n" "--"))
+        (tag ^ ": options are consumed as part of the spec"));
+
+  run "a load-order rule is exempt from the package region" (fun tag ->
+      expect
+        (survives ~rule_id:"PKG-002" "\\usepackage{a--b}\n" "--")
+        (tag ^ ": reordering whole \\usepackage lines is its contract"));
+
+  run "a load-order rule is still blocked inside a filename" (fun tag ->
+      expect
+        (not (survives ~rule_id:"PKG-002" "\\input{a--b}\n" "--"))
+        (tag ^ ": the exemption is per region, never global"));
+
+  run "a control-symbol-aware rule is still blocked inside a filename"
+    (fun tag ->
+      expect
+        (not (survives ~rule_id:"TYPO-017" "\\input{a--b}\n" "--"))
+        (tag ^ ": region 1 exemption does not carry to region 3"));
+
+  run "insertion just past the closing brace survives" (fun tag ->
+      let src = "\\documentclass{article}\n\\begin{document}\n" in
+      let at = find_sub src "\n" in
+      expect
+        (insertion_survives src at)
+        (tag ^ ": package inserters must keep working"));
+
+  run "insertion inside the braced argument is withheld" (fun tag ->
+      let src = "\\documentclass{article}\n" in
+      expect
+        (not (insertion_survives src (find_sub src "article")))
+        (tag ^ ": a point strictly inside the range is blocked"));
+
+  (* ── Regions 1 and 2 still hold (guard against a refactor regression) ── *)
+  run "control symbol argument is still protected" (fun tag ->
+      let src = "\\`a and -- here\n" in
+      let e = Cst_edit.replace ~start_offset:0 ~end_offset:2 "x" in
+      expect
+        (Fix_guard.filter ~src ~rule_id:"TYPO-013" [ e ] = [])
+        (tag ^ ": region 1 unchanged"));
+
+  run "TikZ path operator is still protected" (fun tag ->
+      expect
+        (not
+           (survives
+              "\\begin{tikzpicture}\\draw (0,0) -- (1,1);\\end{tikzpicture}\n"
+              "--"))
+        (tag ^ ": region 2 unchanged"));
+
+  (* ── Memoisation ────────────────────────────────────────────────────── *)
+  run "equal content in a distinct buffer gets the same answer" (fun tag ->
+      (* The memo is keyed on physical identity, so a fresh string with the same
+         bytes must MISS and recompute rather than reuse a neighbour's ranges.
+         String.init defeats any sharing the compiler might do on literals. *)
+      let a = "\\input{adv--child}\n" in
+      let b = String.init (String.length a) (fun i -> a.[i]) in
+      let c =
+        String.init (String.length a) (fun i -> if i = 8 then 'x' else a.[i])
+      in
+      expect
+        ((not (survives a "--"))
+        && (not (survives b "--"))
+        && Fix_guard.protected_ranges b = Fix_guard.protected_ranges a
+        && Fix_guard.protected_ranges c <> [])
+        (tag ^ ": a stale entry may only cause a miss, never a wrong answer"));
+
+  finalise "fix-guard"

--- a/scripts/tools/check_verbatim_safety.py
+++ b/scripts/tools/check_verbatim_safety.py
@@ -18,6 +18,13 @@ each protected-region kind, runs `--apply-fixes` (pilot AND default), and assert
 the bytes between the sentinels are byte-identical afterwards. Any producer —
 existing or newly added — that corrupts a protected region fails the gate.
 
+R7-3 widened the gate past the verbatim family. `\\input{name}` and
+`\\usepackage{name}` are NOT author-verbatim — nobody typed them to be shown
+literally — but they are still bytes TeX reads as an identifier, and a typography
+fix inside one asks TeX for a file that does not exist. Those regions are
+withheld a layer later, by `Fix_guard`, so a failure on them points at the guard
+rather than at a producer's exempt wiring.
+
 Exit 0 if every protected region is preserved, 1 otherwise (listing each
 corrupted region with a before/after diff so the offending bytes are obvious).
 """
@@ -69,6 +76,17 @@ REGIONS = [
     ("inline-verb", b"text \\verb|SREG_IA ", b" SREG_IB| more\n"),
     ("comment", b"%% SREG_CA ", b" SREG_CB\n"),
     ("url", b"see \\url{http://x/SREG_UA", b"SREG_UB} ok\n"),
+    # R7-3 region 3: load-bearing ARGUMENTS. These are not protected by the P3
+    # exempt layer at all — the author did not write them verbatim, they are
+    # simply bytes TeX reads as an identifier rather than as prose. They are
+    # withheld one layer later, by Fix_guard, so a failure here means the GUARD
+    # has a hole, not that a producer needs mk_result_with_fix_exempt.
+    # Planting the whole battery inside them is the point: the fixture corpus
+    # proves the region against TYPO-002, this proves it against every producer
+    # family at once. The battery's braces are balanced, so the argument's own
+    # closing brace is still found.
+    ("include-filename", b"\\input{SREG_FA", b"SREG_FB}\n"),
+    ("package-spec", b"\\usepackage{SREG_PA", b"SREG_PB}\n"),
 ]
 
 
@@ -107,6 +125,19 @@ def between(data: bytes, a: bytes, b: bytes):
 def check(binp: str, env, label: str, violations: list) -> None:
     src = build_torture()
     out = apply_fixes(binp, src, env)
+    # NON-VACUITY. Every assertion below is "these bytes did not change", which
+    # a fixer that produced nothing at all would satisfy perfectly. A CLI that
+    # failed to run, a profile that enabled no producer, or a future refactor
+    # that stopped the battery triggering would all read as a clean PASS. So
+    # require positive evidence that the fixer fired somewhere OUTSIDE the
+    # protected regions before trusting that it left the inside alone.
+    if out == src:
+        violations.append(
+            f"[{label}] VACUOUS: --apply-fixes changed nothing anywhere in the "
+            f"torture document, so byte-preservation inside the protected "
+            f"regions proves nothing. The fixer is not running, or no producer "
+            f"in this profile matches the battery.")
+        return
     for name, pre, suf in REGIONS:
         # sentinels are the first token after pre and last before suf
         sa = pre.split()[-1]
@@ -157,17 +188,22 @@ def main() -> int:
     if violations:
         print(
             f"[verbatim-safety] FAIL: {len(violations)} protected-region corruption(s). "
-            f"A fix producer rewrote literal bytes inside verbatim/\\verb/comment/url. "
-            f"Route its fix through Validators_common.mk_result_with_fix_exempt "
-            f"(or filter offsets by is_in_exempt_range):",
+            f"A fix producer rewrote bytes it must not touch. For a verbatim / "
+            f"\\verb / comment / url region, route the fix through "
+            f"Validators_common.mk_result_with_fix_exempt (or filter offsets by "
+            f"is_in_exempt_range). For include-filename / package-spec, the "
+            f"producer is not at fault — Fix_guard has a hole:",
             file=sys.stderr,
         )
         for v in violations:
             print(f"  {v}", file=sys.stderr)
         return 1
+    # Name the regions from REGIONS rather than a hardcoded list, so adding one
+    # cannot leave the success line claiming less than was actually checked.
     print(
-        "[verbatim-safety] PASS: all verbatim / lstlisting / \\verb / comment / url "
-        "regions byte-preserved under --apply-fixes (pilot + default)."
+        f"[verbatim-safety] PASS: {len(REGIONS)} regions byte-preserved under "
+        f"--apply-fixes (pilot + default): "
+        f"{', '.join(name for name, _pre, _suf in REGIONS)}."
     )
     return 0
 


### PR DESCRIPTION
Single commit — squash-safe.

Closes the largest remaining block in the R7-INFRA-4 round-trip baseline: **9 → 5 recorded defects**, graded by real pdflatex. The 4 `adv_input_filename` cells (all four profile × flag modes) are now clean.

## What was wrong

`--apply-fixes` rewrote the braced argument of an include-family command as if it were prose. TYPO-002 turns `\input{adv--child}` into an en-dashed name, and the **pilot** profile additionally inserts a thin-space command *into* the filename. The emitted document then asks TeX for a file that does not exist — while `--compile-check` reports READY before *and* after. That is the fixer manufacturing the project's cardinal bug.

## Design

Region 3 is split, because the halves need different exemptions:

- **3a filename arguments** — no exemption list. No producer has business rewriting a name the author chose.
- **3b package specifications** — still a filename (a local `.sty`/`.cls`), but four shipped producers reorder whole `\usepackage` lines as their *contract*. New `package_spec_aware` exempts them from **3b only**; they remain blocked from filenames and TikZ paths.

## ⚠ The part worth reviewing

My first draft claimed in a comment that the scanner "can be over-wide, but never MISPLACED". **That was false.** An adversarial audit produced three shapes that broke it — all shapes region 3 exists for — each yielding a SHORT range ending before the filename, the one failure direction this module must not have:

| shape | fix |
|---|---|
| `\usepackage[Ligatures={x]y}]{name}` — `]` inside a braced option value | close only at an **unescaped `]` at brace depth 0**, mirroring the **verified** `drop_after_rbracket` (`proofs/BodyTokenFrontEnd.v`, written for exactly this shape in #508) |
| a `%` comment between command and argument | skipped to end of line, as TeX does |
| any other unmodelled byte (a control sequence) | range extends to end of line instead of truncating |

I should have reused the verified scanner rather than writing a naive one. The comment now states what is actually guaranteed, including the residual under-reach.

Also corrects a second false claim inherited from #519: the header said regions 4 and 5 both stay fixture-tracked. **Only region 5 is.** Region 4 has no fixture anywhere, so the gate is silent on it — now recorded explicitly, because absence from a baseline is not evidence of harmlessness.

## Verification — the project's own gates

- `check_producer_coverage.py` **PASS** (167 × 1022). This *determined* the exemption list: the four reorderers fail without it; the package inserters pass without it because their edit is a pure insertion at the range's exclusive end — asserted by the gate, not by the comment.
- `check_apply_fixes_roundtrip.py --require-pdflatex` **PASS** — 72 docs × 4 cells, baseline 9 → 5.
- `check_verbatim_safety.py` **PASS** — extended with two sentinel regions, so the whole producer battery (not just TYPO-002) is planted inside `\input{}`/`\usepackage{}` and asserted byte-identical. Verified non-vacuous (514 B extracted per region).
- That gate also gained a **non-vacuity assertion**: every check in it is "these bytes did not change", which a fixer producing nothing satisfies perfectly. Proven to fire by pointing it at a no-op fixer.
- `test_fix_guard.ml` — 38 cases; pins each region *and* that prose beside a protected range is still fixed.
- `dune runtest latex-parse/src` exit 0 (355 goldens, fast==full on 507 docs).
- `check_apply_fixes_safety.py` PASS on all 332 corpus files.
- Perf A/B vs main's guard: no regression.

## Fixtures

Five adversarial fixtures — the natural corpus contains none of these shapes. One had to be rewritten: the **single-line** bracket case is vacuous, because the new end-of-line fallback rescues it, so only a **multi-line** option group isolates the depth-aware scan. Every fixture's non-vacuity was measured by reverting each fix in turn.

## Remaining in the baseline

2 pilot-only `good_longtable_free` cells (region 5 — the only remaining manufactured false-READYs) and 3 documented best-effort non-idempotence cells.