### PR TITLE
perf(R-SHARED): memoise the math-range scan (measured 5-9%)

### DIFF
--- a/latex-parse/src/validators_common.ml
+++ b/latex-parse/src/validators_common.ml
@@ -276,7 +276,7 @@ let strip_math_segments (s : string) : string =
    (TYPO-004 v27.0.6+) to filter match offsets that fall inside math, where a
    textual auto-replacement would corrupt the semantic meaning (e.g.,
    apostrophe-pair as double-prime). *)
-let find_math_ranges (s : string) : (int * int) list =
+let compute_math_ranges (s : string) : (int * int) list =
   let len = String.length s in
   let math_envs =
     [
@@ -415,6 +415,30 @@ let find_math_ranges (s : string) : (int * int) list =
   | Some s -> ranges := (s, len) :: !ranges
   | None -> ());
   List.rev !ranges
+
+(* R-SHARED: memoise the math scan, exactly as the vcu/exempt scanners below are
+   memoised (see the cache note above [find_verbatim_comment_url_ranges] for the
+   full correctness argument). This one is the heaviest of the three by call
+   volume: 91 rule call sites across L0/L1/L4 each handed the SAME source-string
+   object, so before this every one of them re-ran an O(n) scan of the whole
+   document — on EVERY pass of the apply-fixes converge loop.
+
+   ⚠ Deliberately NOT used by [compute_exempt_ranges], which scans a BLANKED
+   copy obtained via [Bytes.unsafe_to_string]. Caching a string that shares its
+   bytes with a live [Bytes] would key the cache on something whose contents
+   could still change; routing that caller to [compute_math_ranges] keeps the
+   hazard out of the cache entirely, and as a bonus stops the blanked copy
+   evicting the raw source between rules. *)
+let _math_cache : (string * (int * int) list) option ref = ref None
+
+(** Memoised [compute_math_ranges] — see the cache note above. *)
+let find_math_ranges (s : string) : (int * int) list =
+  match !_math_cache with
+  | Some (s', r) when s' == s -> r
+  | _ ->
+      let r = compute_math_ranges s in
+      _math_cache := Some (s, r);
+      r
 
 (** [is_in_math_range ranges off] — true iff [off] falls inside any range in
     [ranges]. Linear in the number of ranges (typically small). Use with
@@ -639,7 +663,10 @@ let compute_exempt_ranges (s : string) : (int * int) list =
         Bytes.set blanked k ' '
       done)
     vcu;
-  let math = find_math_ranges (Bytes.unsafe_to_string blanked) in
+  (* [compute_math_ranges], NOT the memoised wrapper: see the warning on
+     [_math_cache]. The blanked copy shares its bytes with a live [Bytes], and
+     it would also evict the raw source that the 91 rule call sites want. *)
+  let math = compute_math_ranges (Bytes.unsafe_to_string blanked) in
   List.sort (fun (a, _) (c, _) -> compare a c) (List.rev_append vcu math)
 
 let _exempt_cache : (string * (int * int) list) option ref = ref None


### PR DESCRIPTION
Single commit — squash-safe. Independent of #520; touches only `validators_common.ml`.

`find_math_ranges` has **91 runtime call sites** and was not memoised, while both its siblings in the same file are, via the 1-entry physical-identity cache documented at `validators_common.ml:597`. Every rule in a pass gets the same source-string object, so those 91 sites each re-ran an O(n) scan of the whole document — on every pass of the converge loop.

This applies the file's own idiom: `compute_math_ranges` does the work, `find_math_ranges` is the memoised wrapper.

### One deliberate asymmetry worth reviewing

`compute_exempt_ranges` calls `compute_math_ranges`, **not** the wrapper. It scans a blanked copy obtained via `Bytes.unsafe_to_string`; caching a string that shares bytes with a live `Bytes` would key the cache on something whose contents can still change. Routing that caller past the cache removes the hazard, and stops the blanked copy evicting the raw source between rules.

### Measured — and smaller than the call-site count suggests

Interleaved A/B, best-of-5 per arm, binaries swapped back to back:

| | old | new | |
|---|---|---|---|
| `--compile-check` @ 25 KB | 0.11 s | 0.10 s | 9% |
| `--compile-check` @ 100 KB | 0.36 s | 0.36 s | 0% |
| `--apply-fixes-best-effort` @ 25 KB | 0.90 s | 0.82 s | 9% |
| `--apply-fixes-best-effort` @ 100 KB | 3.73 s | 3.56 s | 5% |

I expected far more from 91 call sites and was wrong: most rules reach math ranges indirectly through `find_exempt_ranges`, which was already memoised. This removes real duplicated work and is worth landing, but it does **not** move `--apply-fixes` into a different regime. What dominates a full-lint pass is still unmeasured.

⚠ The absolute numbers are from a heavily contended machine. The **ratios** are trustworthy (interleaved arms); the absolute latencies are not, and no threshold should be set from them.

### Verified on this change alone, based on main

- `dune runtest latex-parse/src` exit 0 — 355 goldens, fast==full on 506 docs
- `check_producer_coverage.py` PASS (167 × 1022)
- `check_verbatim_safety.py` PASS
- `check_apply_fixes_safety.py` PASS (332 files, no apply-abort)
- ocamlformat fixpoint verified