### PR TITLE
perf: de-quadratic the MOD family's shared paragraph-mixing helper

### DIFF
--- a/latex-parse/src/bench_rule_timings.ml
+++ b/latex-parse/src/bench_rule_timings.ml
@@ -1,0 +1,121 @@
+(* bench_rule_timings — PER-RULE attribution for the rules stage.
+
+   R-BUDGET measured the warm readiness kernel spending ~329 ms of ~344 ms at
+   300 KB inside RULE EXECUTION, linear at ~1.1 ms/KB. That says the cost is
+   spread over rules, but not WHICH rules, and #521 already showed that guessing
+   from call-site counts is unreliable — memoising the 91-call-site math scan
+   bought 5-9%, not the order of magnitude it looked like. This bench answers
+   the question with data instead.
+
+   [Validators.run_all_with_timings] already computes exactly this and has never
+   been reachable from any executable. It returns a duration for EVERY rule,
+   fired or not, so a rule that costs a lot and finds nothing is visible — those
+   are the ones inspection misses.
+
+   TWO CACHING HAZARDS, both deliberately defeated:
+
+   1. [run_all] memoises whole-document results through [Cache_key], so
+   benchmarking it in-process makes reps 2..N cache hits (bench_readiness_
+   kernel's own header says so). [run_all_with_timings] does NOT consult that
+   cache — it executes the rule list directly — which is why it is the right
+   entry point here.
+
+   2. The shared range scanners ([find_exempt_ranges],
+   [find_verbatim_comment_url_ranges], [find_math_ranges]) memoise on the
+   buffer's PHYSICAL identity. Handing the same string object to every rep would
+   leave those caches warm from rep 1, so the first rule to need a scanner would
+   be charged nothing and the attribution would be wrong. Each rep therefore
+   gets a FRESH copy of the source, which is what a new document in an editor
+   session looks like. Within a rep the caches behave normally, because that IS
+   the real behaviour of one pass.
+
+   Usage: bench_rule_timings <reps> <file.tex> [--top N] *)
+
+let read_file p =
+  let ic = open_in_bin p in
+  Fun.protect
+    ~finally:(fun () -> close_in_noerr ic)
+    (fun () -> really_input_string ic (in_channel_length ic))
+
+let median xs =
+  let a = Array.of_list xs in
+  Array.sort compare a;
+  let n = Array.length a in
+  if n = 0 then 0.0
+  else if n mod 2 = 1 then a.(n / 2)
+  else (a.((n / 2) - 1) +. a.(n / 2)) /. 2.0
+
+(* The shipped compile-gate surface is exactly the DELIM-/ENC-/PRT- prefixes, so
+   tagging by prefix mirrors [Validators.is_compile_blocking] without exporting
+   it. These are the rules on the KEYSTROKE path; everything else is
+   batch-only. *)
+let is_blocking id =
+  let p s =
+    String.length id >= String.length s && String.sub id 0 (String.length s) = s
+  in
+  p "DELIM-" || p "ENC-" || p "PRT-"
+
+let () =
+  if Array.length Sys.argv < 3 then (
+    prerr_endline "usage: bench_rule_timings <reps> <file.tex> [--top N]";
+    exit 2);
+  let reps = int_of_string Sys.argv.(1) in
+  let path = Sys.argv.(2) in
+  let top =
+    let rec find i =
+      if i + 1 >= Array.length Sys.argv then 25
+      else if Sys.argv.(i) = "--top" then int_of_string Sys.argv.(i + 1)
+      else find (i + 1)
+    in
+    find 3
+  in
+  let src = read_file path in
+  let n = String.length src in
+  (* Fresh object per rep: see hazard 2 above. String.init defeats any sharing
+     the compiler might apply to a literal or a previously-read buffer. *)
+  let fresh () = String.init n (fun i -> String.unsafe_get src i) in
+  ignore (Latex_parse_lib.Validators.run_all_with_timings (fresh ()));
+  let acc : (string, float list) Hashtbl.t = Hashtbl.create 1024 in
+  let totals = ref [] in
+  for _ = 1 to reps do
+    let _res, total_ms, timings =
+      Latex_parse_lib.Validators.run_all_with_timings (fresh ())
+    in
+    totals := total_ms :: !totals;
+    List.iter
+      (fun (id, ms) ->
+        let prev = try Hashtbl.find acc id with Not_found -> [] in
+        Hashtbl.replace acc id (ms :: prev))
+      timings
+  done;
+  let rows =
+    Hashtbl.fold (fun id xs a -> (id, median xs) :: a) acc []
+    |> List.sort (fun (_, a) (_, b) -> compare b a)
+  in
+  let grand = List.fold_left (fun a (_, ms) -> a +. ms) 0.0 rows in
+  let blocking =
+    List.fold_left
+      (fun a (id, ms) -> if is_blocking id then a +. ms else a)
+      0.0 rows
+  in
+  Printf.printf "# %s — %d bytes, %d reps, %d rules\n" path n reps
+    (List.length rows);
+  Printf.printf "# summed per-rule median: %.1f ms   (wall median %.1f ms)\n"
+    grand (median !totals);
+  Printf.printf
+    "# of that, the %d compile-blocking rules (keystroke path): %.1f ms (%.1f%%)\n"
+    (List.length (List.filter (fun (id, _) -> is_blocking id) rows))
+    blocking
+    (if grand > 0.0 then 100.0 *. blocking /. grand else 0.0);
+  Printf.printf "%-14s %10s %8s %8s  %s\n" "rule" "median_ms" "share%" "cum%"
+    "keystroke?";
+  let cum = ref 0.0 in
+  List.iteri
+    (fun i (id, ms) ->
+      if i < top then (
+        cum := !cum +. ms;
+        Printf.printf "%-14s %10.2f %7.1f%% %7.1f%%  %s\n" id ms
+          (if grand > 0.0 then 100.0 *. ms /. grand else 0.0)
+          (if grand > 0.0 then 100.0 *. !cum /. grand else 0.0)
+          (if is_blocking id then "YES" else "")))
+    rows

--- a/latex-parse/src/dune
+++ b/latex-parse/src/dune
@@ -181,6 +181,11 @@
  (modules bench_readiness_kernel)
  (libraries latex_parse_lib unix))
 
+(executable
+ (name bench_rule_timings)
+ (modules bench_rule_timings)
+ (libraries latex_parse_lib unix))
+
 (test
  (name test_strip_math)
  (modules test_strip_math)
@@ -217,6 +222,11 @@
 (test
  (name test_exempt_ranges)
  (modules test_exempt_ranges)
+ (libraries latex_parse_lib test_helpers unix))
+
+(test
+ (name test_mixed_paragraph_parity)
+ (modules test_mixed_paragraph_parity)
  (libraries latex_parse_lib test_helpers unix))
 
 (test

--- a/latex-parse/src/test_mixed_paragraph_parity.ml
+++ b/latex-parse/src/test_mixed_paragraph_parity.ml
@@ -1,0 +1,158 @@
+(** Parity test for the [mixed_paragraph_ranges] de-quadratication.
+
+    That helper is shared by twelve MOD-* rules (validators_l1.ml:98-339) and it
+    decides, per paragraph, whether the paragraph mixes legacy and modern font
+    commands. It used to ask "does any command in the WHOLE document fall inside
+    this paragraph?" once per paragraph — O(paragraphs x commands), measurably
+    superlinear (the MOD family scaled 6.1-7.3x for 3x the bytes where the
+    median rule scales 3.13x). It now assigns each command to its paragraph by
+    binary search.
+
+    A speedup that changes a verdict is a regression, not an optimisation, and
+    twelve rules ride this one function. So this test keeps the ORIGINAL
+    implementation verbatim as a reference oracle and asserts the shipped one
+    agrees with it byte-for-byte on every input — the same tactic the repo uses
+    for the Coq-extract/hand-mirror parity.
+
+    The reference is deliberately a copy rather than a shared abstraction: if
+    someone "simplifies" the shipped version into agreeing with a rewritten
+    oracle, the test stops testing anything. *)
+
+open Latex_parse_lib
+open Latex_parse_lib.Validators_common
+open Test_helpers
+
+(* The pre-2026-08-02 implementation, verbatim. Do not refactor. *)
+let reference (s : string) ~(legacy : string list) ~(modern : string list) :
+    (int * int) list =
+  let paras = split_into_paragraphs s in
+  let pcs = Validators_context.get_post_commands () in
+  let tokens = command_tokens s in
+  let matches set value = List.exists (( = ) value) set in
+  let ctx_has off len names =
+    List.exists
+      (fun (pc : Validators_context.post_command) ->
+        pc.s >= off && pc.s < off + len && matches names pc.name)
+      pcs
+  in
+  let tokens_have off len names =
+    List.exists
+      (fun (name, pos) -> pos >= off && pos < off + len && matches names name)
+      tokens
+  in
+  let has_cmd off len names =
+    ctx_has off len names || tokens_have off len names
+  in
+  let check_para off len = has_cmd off len legacy && has_cmd off len modern in
+  let ranges = if paras = [] then [ (0, String.length s) ] else paras in
+  List.filter (fun (off, len) -> check_para off len) ranges
+
+(* The real MOD-002..007 sets, plus deliberately awkward ones. *)
+let sets =
+  [
+    ([ "bf"; "it"; "tt" ], [ "textbf"; "textit"; "texttt" ]);
+    ([ "bf" ], [ "bfseries" ]);
+    ([], [ "textbf" ]) (* empty legacy: nothing can ever mix *);
+    ([ "bf" ], []) (* empty modern *);
+    ([ "bf" ], [ "bf" ]) (* same name in BOTH sets *);
+    ([ "nosuchcmd" ], [ "alsomissing" ]);
+  ]
+
+let check name src =
+  List.iteri
+    (fun i (legacy, modern) ->
+      let got = mixed_paragraph_ranges src ~legacy ~modern in
+      let want = reference src ~legacy ~modern in
+      run (Printf.sprintf "%s / set %d" name i) (fun tag ->
+          expect (got = want)
+            (Printf.sprintf "%s: shipped %s <> reference %s" tag
+               (String.concat ";"
+                  (List.map (fun (a, b) -> Printf.sprintf "(%d,%d)" a b) got))
+               (String.concat ";"
+                  (List.map (fun (a, b) -> Printf.sprintf "(%d,%d)" a b) want)))))
+    sets
+
+(* Deterministic pseudo-random documents: no Random.self_init, so a failure is
+   reproducible. Mixes paragraph breaks, legacy/modern commands, commands in the
+   gaps BETWEEN paragraphs, and comment/verbatim noise. *)
+let gen seed =
+  let st = Random.State.make [| seed |] in
+  let b = Buffer.create 4096 in
+  let cmds =
+    [| "bf"; "it"; "tt"; "textbf"; "textit"; "texttt"; "emph"; "bfseries" |]
+  in
+  let n = 20 + Random.State.int st 120 in
+  for _ = 1 to n do
+    match Random.State.int st 8 with
+    | 0 -> Buffer.add_string b "\n\n"
+    | 1 -> Buffer.add_string b "\n"
+    | 2 ->
+        Buffer.add_char b '\\';
+        Buffer.add_string b cmds.(Random.State.int st (Array.length cmds));
+        Buffer.add_char b ' '
+    | 3 -> Buffer.add_string b "% a comment line\n"
+    | 4 -> Buffer.add_string b "\\begin{verbatim}\\bf\\end{verbatim}"
+    | 5 -> Buffer.add_string b "some ordinary prose "
+    | 6 -> Buffer.add_string b "$x^2$ "
+    | _ -> Buffer.add_string b "word "
+  done;
+  Buffer.contents b
+
+let () =
+  (* ── Hand-built edge cases ─────────────────────────────────────────────── *)
+  check "empty" "";
+  check "no paragraphs" "\\bf and \\textbf on one line";
+  check "single break" "\\bf here\n\n\\textbf there";
+  check "mixing in one paragraph" "\\bf x \\textbf y\n\npara two";
+  check "second paragraph mixes" "plain\n\n\\bf x \\textbf y";
+  check "trailing blank lines" "\\bf a \\textbf b\n\n\n\n";
+  check "leading blank lines" "\n\n\\bf a \\textbf b";
+  check "command in the gap between paragraphs"
+    "para one\n\n\\bf\n\npara \\textbf two";
+  check "only legacy" "\\bf x\n\n\\bf y";
+  check "only modern" "\\textbf x\n\n\\textbf y";
+
+  (* ── Deterministic generated corpus ────────────────────────────────────── *)
+  for seed = 1 to 60 do
+    check (Printf.sprintf "generated/%d" seed) (gen seed)
+  done;
+
+  (* ── Real documents, which is where paragraph shapes get strange ───────── *)
+  let read p =
+    try
+      let ic = open_in_bin p in
+      Fun.protect
+        ~finally:(fun () -> close_in_noerr ic)
+        (fun () -> Some (really_input_string ic (in_channel_length ic)))
+    with _ -> None
+  in
+  (* dune runs tests from inside _build, and `dune exec` from the project root,
+     so neither a repo-relative nor a build-relative literal works for both.
+     Walk up until the corpus is visible. *)
+  let dir =
+    let rec up d n =
+      if n = 0 then "corpora/compile_check"
+      else
+        let c = Filename.concat d "corpora/compile_check" in
+        if Sys.file_exists c && Sys.is_directory c then c
+        else up (Filename.concat d Filename.parent_dir_name) (n - 1)
+    in
+    up "." 8
+  in
+  (match Sys.readdir dir with
+  | files ->
+      Array.sort compare files;
+      Array.iter
+        (fun f ->
+          if Filename.check_suffix f ".tex" then
+            match read (Filename.concat dir f) with
+            | Some src -> check ("corpus/" ^ f) src
+            | None -> ())
+        files
+  | exception _ ->
+      (* Refuse to look green if the corpus could not be read at all: the
+         generated cases alone are a weaker test than this file claims to be. *)
+      run "corpus readable" (fun tag ->
+          expect false (tag ^ ": could not read " ^ dir)));
+
+  finalise "mixed-paragraph-parity"

--- a/latex-parse/src/validators_common.ml
+++ b/latex-parse/src/validators_common.ml
@@ -1709,29 +1709,66 @@ let count_matches (re : Re_compat.regexp) (s : string) : int =
    locate the legacy tokens that need normalising, so the returned spans and the
    boolean firing decision stay in lock-step (the diagnostic count is
    unchanged). *)
+(* PERF: this was O(paragraphs x commands) and it is shared by twelve MOD-*
+   rules (validators_l1.ml:98-339), which made it the largest SUPERLINEAR
+   cluster in the whole rule set.
+
+   The previous shape asked, for every paragraph, "does any command anywhere in
+   the document fall inside you?" — a [List.exists] over the entire token list
+   AND the entire post-command list, run twice per paragraph (legacy, modern).
+   Both factors grow with document size (795 paragraphs at 100 KB, 2406 at 300
+   KB), so the work grew quadratically.
+
+   Measured with bench_rule_timings, 100 KB -> 300 KB (3x the bytes): the twelve
+   MOD rules scaled 6.2-7.3x where the median rule in the whole set scales
+   3.13x, and together with TYPO-018 they were 16.6% of total rule time at 300
+   KB — a share that grows with every extra kilobyte.
+
+   Inverted here: each command is assigned to its paragraph by BINARY SEARCH
+   (paragraph spans come out of [split_into_paragraphs] ascending and disjoint),
+   so the cost is O((tokens + post_commands) * log paragraphs).
+
+   Semantics are unchanged by construction. The old predicate kept a paragraph
+   iff some legacy-named command AND some modern-named command had a position
+   inside its span, drawn from EITHER the post-command context or the token
+   scan; the flags below record exactly that, from the same two sources, with
+   the same [matches] test. A command that names both sets marks both flags, as
+   before. *)
 let mixed_paragraph_ranges (s : string) ~(legacy : string list)
     ~(modern : string list) : (int * int) list =
   let paras = split_into_paragraphs s in
-  let pcs = Validators_context.get_post_commands () in
-  let tokens = command_tokens s in
-  let matches set value = List.exists (( = ) value) set in
-  let ctx_has off len names =
-    List.exists
-      (fun (pc : Validators_context.post_command) ->
-        pc.s >= off && pc.s < off + len && matches names pc.name)
-      pcs
-  in
-  let tokens_have off len names =
-    List.exists
-      (fun (name, pos) -> pos >= off && pos < off + len && matches names name)
-      tokens
-  in
-  let has_cmd off len names =
-    ctx_has off len names || tokens_have off len names
-  in
-  let check_para off len = has_cmd off len legacy && has_cmd off len modern in
   let ranges = if paras = [] then [ (0, String.length s) ] else paras in
-  List.filter (fun (off, len) -> check_para off len) ranges
+  let arr = Array.of_list ranges in
+  let np = Array.length arr in
+  (* Index of the paragraph containing [pos], or -1. Positions between
+     paragraphs belong to none, exactly as the old bounds test implied. *)
+  let find_para pos =
+    let lo = ref 0 and hi = ref (np - 1) and res = ref (-1) in
+    while !res < 0 && !lo <= !hi do
+      let mid = (!lo + !hi) / 2 in
+      let off, len = arr.(mid) in
+      if pos < off then hi := mid - 1
+      else if pos >= off + len then lo := mid + 1
+      else res := mid
+    done;
+    !res
+  in
+  let matches set value = List.exists (( = ) value) set in
+  let has_legacy = Array.make (max np 1) false in
+  let has_modern = Array.make (max np 1) false in
+  let mark name pos =
+    let l = matches legacy name and m = matches modern name in
+    if l || m then
+      let k = find_para pos in
+      if k >= 0 then (
+        if l then has_legacy.(k) <- true;
+        if m then has_modern.(k) <- true)
+  in
+  List.iter
+    (fun (pc : Validators_context.post_command) -> mark pc.name pc.s)
+    (Validators_context.get_post_commands ());
+  List.iter (fun (name, pos) -> mark name pos) (command_tokens s);
+  List.filteri (fun i _ -> has_legacy.(i) && has_modern.(i)) ranges
 
 let has_mixed_in_paragraphs (s : string) ~(legacy : string list)
     ~(modern : string list) : bool =


### PR DESCRIPTION
Single commit — squash-safe. Follows #522, which established *where* the time goes but not *which rules*.

## Instrument first

`Validators.run_all_with_timings` has always computed a per-rule duration for **every** rule, fired or not, and has never been reachable from any executable. `bench_rule_timings` exposes it, defeating two caching hazards: `run_all` memoises via `Cache_key` (wrong entry point — `bench_readiness_kernel`'s own header warns about this), and the shared range scanners memoise on **physical string identity**, so each rep gets a fresh copy or rep 1 pays for the scanners and later reps are charged nothing.

This ordering was deliberate: #521 inferred a large win from 91 call sites and got 5–9%.

## What it measured — 100 KB, 548 rules

- **The distribution is flat.** Top rule 1.5%; top ten 10.2% cumulative. Removing the single worst rule entirely would buy 1.5%. Per-rule micro-optimisation is a dead end and that half is architectural (R-SHARED / R-SIMD).
- **Per-rule cost is near-constant** — 5.4 ms/rule overall vs 4.8 ms/rule for the 37 compile-blocking ones. Cost tracks document size, not rule identity.
- **But hidden inside the flat distribution:** scaling 100 KB → 300 KB is **3.13× median** and **6.1–7.3× for thirteen rules**, which were **16.6% of rule time at 300 KB and growing**. Nine were `MOD-*`, with near-identical ratios *and* absolute times — one shared helper, not nine bugs.

## The bug

`mixed_paragraph_ranges`, shared by **twelve** MOD rules (`validators_l1.ml:98–339`), asked for every paragraph *"does any command anywhere in the document fall inside you?"* — `List.exists` over the whole token list **and** the whole post-command list, twice per paragraph. Both factors grow with size (795 paragraphs @100 KB → 2406 @300 KB). **O(paragraphs × commands).**

Inverted to binary search, since `split_into_paragraphs` yields ascending disjoint spans: **O((tokens + post_commands) · log paragraphs)**.

## Result

| rule | before @300KB | after | speedup | scaling before → after |
|---|---|---|---|---|
| MOD-011 | 123.6 ms | 26.4 ms | 4.7× | 6.70× → 3.59× |
| MOD-002 | 122.6 ms | 25.4 ms | 4.8× | 7.30× → 3.49× |
| MOD-013 | 114.3 ms | 24.6 ms | 4.6× | 6.88× → 3.29× |

Total rule time @300 KB: **8593 → 7926 ms (7.8%)**.

**The scaling exponent is the point, not the 7.8%.** These rules were on the wrong curve; they're now on the same linear curve as everything else, so the win grows with document size instead of staying a fixed percentage.

## Why the parity test exists

Twelve rules ride this function, and a speedup that changes a verdict is a regression. `test_mixed_paragraph_parity` keeps the **original implementation verbatim** as a reference oracle and asserts the shipped one agrees byte-for-byte — the tactic the repo already uses for Coq-extract/hand-mirror parity.

**816 cases**: ten hand-built edge cases (empty input, no paragraph breaks, commands in the *gaps between* paragraphs, leading/trailing blank runs), sixty deterministic generated documents, and all 66 `compile_check` corpus files — each against six legacy/modern sets including empty sets and a name present in **both**.

The reference is deliberately a copy rather than a shared abstraction: if someone "simplifies" the shipped version into agreeing with a rewritten oracle, the test stops testing anything. The corpus branch fails loudly rather than skipping if the directory can't be read — that assertion **fired for real** during development, when a relative path was wrong under dune's build-tree cwd.

## Also verified

- `dune runtest latex-parse/src` exit 0 — 355 goldens, ast-parity
- `check_producer_coverage.py` PASS (167 × 1022)
- `test_candidate_fixes` 348 cases, `test_validators_l1` 76 cases — the MOD rules' own suites
- ocamlformat fixpoint on all three files

⚠ Absolute timings come from a machine at load 30–50 and are inflated. The **ratios and scaling exponents** are what this rests on, and those are measured within single interleaved runs.