### PR TITLE
feat(R7-INFRA-4): run property (b) automatically — it ran nowhere at all

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,10 +108,15 @@ jobs:
         #
         # This step evaluates the two CLI-only properties, (a) idempotence and
         # (c) verdict-non-degradation. Property (b), oracle-class preservation,
-        # needs real pdflatex and is NOT covered here; it runs in
-        # pre_release_check.py locally. Wiring (b) into the tex-oracle workflow is
-        # blocked on the pinned TeX image having python3, which is unconfirmed —
-        # the image is deliberately dependency-free. Tracked, not silently skipped.
+        # needs real pdflatex and is still NOT covered here — this runner has no
+        # TeX, so the script's own `have_tex` is false and (b) is skipped.
+        #
+        # (b) now runs in tex-oracle.yml, ADVISORY, behind a preflight that
+        # asserts the pinned image has both python3 and coreutils `timeout`
+        # (the script hard-exits 2 without a timeout binary). Before that it ran
+        # in NO automated path at all: the comment here used to say it ran in
+        # pre_release_check.py locally, but release.sh invokes that gate with
+        # --skip-build, which skips the whole BUILD_CHECKS list that (b) lives in.
         #
         # Monotone like the false-READY gate: known defects live in
         # corpora/apply_fixes/manifest.json, so this lands green and fails on a

--- a/.github/workflows/tex-oracle.yml
+++ b/.github/workflows/tex-oracle.yml
@@ -184,3 +184,39 @@ jobs:
             -e HOME=/tmp -e REQUIRE_PDFLATEX=1 \
             -e EXPECT_TEX_VERSION="$TEX_EXPECT_VERSION" \
             "$TEX_IMAGE" bash scripts/tools/diff_compile_check.sh
+
+      # R7-INFRA-4 property (b): "a document that compiled must still compile
+      # after --apply-fixes". It is the ONLY check anywhere that can observe the
+      # fixer turning a compiling document into a non-compiling one — the
+      # project's second-worst failure mode — and until now it ran in NO
+      # automated path. ci.yml runs the script but has no TeX, so `have_tex` is
+      # false and (b) is skipped; its only --require-pdflatex caller sits in
+      # pre_release_check.py's BUILD_CHECKS list, which release.sh skips via
+      # --skip-build. The script's own docstring claimed it "rides the
+      # pinned-image tex-oracle workflow". It did not. Now it does.
+      - name: Preflight the image for property (b)
+        run: |
+          set -euo pipefail
+          # BOTH are load-bearing, and the second is easy to miss:
+          # check_apply_fixes_roundtrip.py hard-exits 2 under REQUIRE_PDFLATEX=1
+          # when neither gtimeout nor timeout is on PATH, because an unbounded
+          # pdflatex hang would otherwise be scored as a compile failure.
+          docker run --rm "$TEX_IMAGE" bash -c 'python3 --version && command -v timeout' \
+            || { echo "::error::pinned TeX image lacks python3 and/or coreutils timeout; property (b) cannot run here"; exit 2; }
+
+      # ADVISORY ON PURPOSE, matching this workflow's existing posture: tex-oracle
+      # is not among the nine required contexts, and the first runs are EXPECTED
+      # to be yellow rather than green. corpora/apply_fixes/manifest.json records
+      # pdflatex_graded=true but carries no oracle.version pin (unlike
+      # corpora/false_ready/manifest.json), so its five baseline rows were
+      # measured on a local engine, not this pinned TL2026 image. Any disagreement
+      # is a baseline-provenance artefact to be re-recorded here, NOT a new defect
+      # — which is exactly why this does not block on day one.
+      - name: Apply-fixes round-trip, property (b) — advisory
+        continue-on-error: true
+        run: |
+          set -euo pipefail
+          docker run --rm \
+            -v "$PWD:$PWD" -w "$PWD" \
+            -e HOME=/tmp -e REQUIRE_PDFLATEX=1 \
+            "$TEX_IMAGE" python3 scripts/tools/check_apply_fixes_roundtrip.py --repo .

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -95,9 +95,16 @@ if [[ "$DRY_RUN" == "--dry-run" ]]; then
 fi
 
 # 6b. PR #245 (p1.11): pre-release uber-gate before any state mutation.
-# Runs EVERY gate + full build + all tests. Fails fast if ANY check
-# is red. Skipped in --dry-run (the user is expected to have run this
-# manually before invoking release.sh).
+# Skipped in --dry-run (the user is expected to have run this manually
+# before invoking release.sh).
+#
+# ⚠ It does NOT run every gate, despite what this comment used to claim.
+# The invocation below passes --skip-build, and pre_release_check.py gates
+# its entire BUILD_CHECKS list on `not skip_build` — so every build-dependent
+# gate is dropped here, including the --require-pdflatex round-trip that is
+# the only local evaluation of property (b). Nor does it fail fast: it runs
+# all remaining gates and returns non-zero at the end.
+# Property (b) is now covered automatically by tex-oracle.yml instead.
 if [[ "$DRY_RUN" != "--dry-run" ]]; then
   echo "[release] Running pre-release uber-gate (all gates + build + tests)..."
   if ! python3 scripts/tools/pre_release_check.py --allow-dirty --skip-build; then

--- a/scripts/tools/check_apply_fixes_roundtrip.py
+++ b/scripts/tools/check_apply_fixes_roundtrip.py
@@ -36,8 +36,18 @@ THE THREE PROPERTIES (the audit's R7-INFRA-4)
   (b) ORACLE-CLASS-PRESERVING a document that compiled must still compile
 
 (a) and (c) need only the CLI, so they run in CI's `build` job. (b) needs real
-pdflatex and rides the pinned-image `tex-oracle` workflow. Same split as the
-false-READY gates: check_known_false_ready.py (CLI-only) vs false_ready_oracle.sh.
+pdflatex and rides the pinned-image `tex-oracle` workflow, ADVISORY. Same split
+as the false-READY gates: check_known_false_ready.py (CLI-only) vs
+false_ready_oracle.sh.
+
+⚠ This sentence was ASPIRATIONAL until the wiring landed: tex-oracle.yml never
+invoked this script, and the only --require-pdflatex caller was
+pre_release_check.py's BUILD_CHECKS, which release.sh skips via --skip-build. So
+(b) — the one property that can see the fixer break a compiling document — ran
+in no automated path at all, while this docstring said otherwise. If you are
+reading this because (b) is failing, check first whether
+corpora/apply_fixes/manifest.json's baseline was recorded on the same engine:
+unlike corpora/false_ready/manifest.json it carries no oracle.version pin.
 
 MONOTONE, LIKE THE FALSE-READY CORPUS
 -------------------------------------
@@ -179,6 +189,23 @@ def main() -> int:
                 [str(cli), "--compile-check", str(doc)],
                 capture_output=True).returncode == 0
 
+            # (b) BEFORE-half, hoisted out of the cell loop. The pristine
+            # compile depends only on the DOCUMENT, never on the fixer cell, so
+            # grading it once per doc instead of once per cell removes three of
+            # every four pdflatex runs on this half (576 -> 360 across the
+            # sweep) for a bit-identical answer. That is what makes running
+            # property (b) per-PR affordable rather than a ~25-minute tax.
+            # b4 is bound OUTSIDE the have_tex guard on purpose: the cell loop
+            # reads it unconditionally, so leaving it unbound would raise
+            # UnboundLocalError on every no-pdflatex run — which is the path CI
+            # actually takes today.
+            b4: bool | None = None
+            if have_tex:
+                with tempfile.TemporaryDirectory(prefix="fixer-rt-pristine-") as ptmp:
+                    pristine = Path(ptmp) / "p"
+                    shutil.copytree(corpus, pristine)
+                    b4 = pdflatex_ok(pristine, base, timeout_bin)
+
             for pname, penv, flag in CELLS:
                 mode = f"{pname}:{flag}"
                 env = {**os.environ, **penv}
@@ -213,12 +240,10 @@ def main() -> int:
                         capture_output=True).returncode == 0
                     degraded = before_ready and not after_ready
 
-                    # (b) oracle-class preservation
+                    # (b) oracle-class preservation. The AFTER half only:
+                    # b4 was graded once per document above.
                     broke = False
                     if have_tex:
-                        pristine = Path(tmp) / "p"
-                        shutil.copytree(corpus, pristine)
-                        b4 = pdflatex_ok(pristine, base, timeout_bin)
                         for junk in ("aux", "log", "pdf", "out"):
                             (stage / f"{base[:-4]}.{junk}").unlink(missing_ok=True)
                         af = pdflatex_ok(stage, base, timeout_bin)
@@ -305,7 +330,7 @@ def main() -> int:
           f"known-broken {len(recorded)}")
     if not have_tex and not require_tex:
         print("[fixer-roundtrip] NOTE: property (b) not evaluated without pdflatex; "
-              "the tex-oracle workflow covers it.")
+              "the tex-oracle workflow covers it (advisory).")
     if findings:
         print("\n[fixer-roundtrip] FAIL:\n", file=sys.stderr)
         for f in findings:


### PR DESCRIPTION
Single commit — squash-safe. Closes the audit's #2 finding.

## What was wrong

Property (b) — *"a document that compiled must still compile after `--apply-fixes`"* — is the **only** check anywhere that can observe the fixer turning a compiling document into a non-compiling one. That's the project's second-worst failure mode, and #519 established a post-fix verdict re-check **cannot** detect it: `--compile-check` says READY before *and* after while pdflatex goes 0 → 1.

**It ran in no automated path.** Three places said otherwise:

| claim | reality |
|---|---|
| script docstring: (b) "rides the pinned-image `tex-oracle` workflow" | `tex-oracle.yml` never invoked the script |
| `ci.yml`: (b) "runs in `pre_release_check.py` locally" | `release.sh:103` passes `--skip-build`, which drops the whole `BUILD_CHECKS` list (b) lives in |
| `release.sh`: uber-gate "Runs EVERY gate… Fails fast if ANY check is red" | does neither |

All three corrected here, in the same commit that makes the first one true.

## The wiring

`tex-oracle.yml` gains a preflight plus an **advisory** step. The preflight asserts the pinned image has **both `python3` and coreutils `timeout`**. The second is easy to miss and load-bearing: `check_apply_fixes_roundtrip.py:140-141` hard-exits 2 under `REQUIRE_PDFLATEX=1` when neither `gtimeout` nor `timeout` is on PATH, because an unbounded pdflatex hang would otherwise be scored as a compile failure. `python3`-in-the-image was previously recorded as "unconfirmed"; the preflight makes it self-answering instead of failing obscurely.

Advisory on purpose — `tex-oracle` isn't among the nine required contexts, and this workflow is already advisory by design.

## Making it affordable

The pristine compile is hoisted out of the per-cell loop: it depends only on the **document**, never the fixer cell, so it was run four times for a bit-identical answer. 72 docs × 4 cells = 288 cells, so **576 → 72 + 288 = 360 pdflatex invocations, a deterministic 37.5% cut**. That's arithmetic from the code structure, not a timing claim — I measured 9:18 → 1:36 wall-clock but the earlier figure was taken under heavy load, so it's confounded and I'm not claiming it.

⚠ `b4` is bound **outside** the `have_tex` guard deliberately. The cell loop reads it unconditionally, so leaving it unbound raises `UnboundLocalError` on every no-pdflatex run — the path CI takes today.

## Verified

- **no-pdflatex path** (what `ci.yml` runs): PASS, 72 × 4, known-broken 5, no crash — the path the hoist could most easily have broken
- **full `--require-pdflatex` path**: PASS, same 72 × 4, **same 5 known-broken rows** — bit-identical verdict to before the refactor
- `check_roadmap_facts.py` (required `spec-drift`) passes
- both YAML files parse; `release.sh` passes `bash -n`; python parses

## ⚠ Expect the first run yellow, not green

`corpora/apply_fixes/manifest.json` records `pdflatex_graded: true` but carries **no `oracle.version` pin** — unlike `corpora/false_ready/manifest.json`, which this workflow pin-asserts. Its five baseline rows were measured on a local engine, not the pinned TL2026 image. Any disagreement is **baseline provenance to re-record**, not a new defect, and `continue-on-error` absorbs it. That is exactly why this lands advisory rather than blocking.