### PR TITLE
chore(R7-INFRA-4): pin the apply-fixes oracle version, now that it is verified

### DIFF
--- a/.github/workflows/tex-oracle.yml
+++ b/.github/workflows/tex-oracle.yml
@@ -91,6 +91,15 @@ jobs:
           case "$man" in *"$TEX_EXPECT_VERSION"*) ;; *)
             echo "::error::PIN MISMATCH: manifest oracle.version '$man' != pinned '$TEX_EXPECT_VERSION'."
             exit 1 ;; esac
+          # Same assertion for the apply-fixes corpus, which property (b) grades.
+          # It previously recorded only `pdflatex_graded: true` — no engine, no
+          # version — so an image bump would have silently redefined what its
+          # five known_broken rows mean.
+          amn=$(python3 -c "import json;print(json.load(open('corpora/apply_fixes/manifest.json'))['oracle']['version'])")
+          echo "apply_fixes manifest : $amn"
+          case "$amn" in *"$TEX_EXPECT_VERSION"*) ;; *)
+            echo "::error::PIN MISMATCH: corpora/apply_fixes/manifest.json oracle.version '$amn' != pinned '$TEX_EXPECT_VERSION'. Re-record property (b) against the pinned image."
+            exit 1 ;; esac
 
       # The anti-silent-green measure. A missing .sty grades identically to the
       # intended fatal (strong-fatal), so an under-provisioned image would let

--- a/corpora/apply_fixes/manifest.json
+++ b/corpora/apply_fixes/manifest.json
@@ -6,6 +6,15 @@
     "b_oracle_class_preserving": "a document that compiled must still compile"
   },
   "pdflatex_graded": true,
+  "oracle": {
+    "engine": "pdflatex",
+    "distribution": "TeX Live 2026",
+    "version": "pdfTeX 3.141592653-2.6-1.40.29",
+    "protocols": [
+      "-interaction=nonstopmode -halt-on-error"
+    ],
+    "note": "Mirrors corpora/false_ready/manifest.json's oracle block, which tex-oracle.yml pin-asserts. This corpus had pdflatex_graded=true and NOTHING ELSE: no engine, no version, no protocol, and nothing asserting any of them. A TeX Live upgrade would silently change what property (b) means for these rows and no gate would notice. Recorded now because it is VERIFIED rather than assumed: the first CI run of property (b) against the pinned image (tex-oracle run 30834930925) reproduced this baseline exactly \u2014 72 documents x 4 cells, the same 5 known_broken rows, PASS."
+  },
   "known_broken": [
     {
       "doc": "corpora/compile_check/good_longtable_free.tex",


### PR DESCRIPTION
Single commit — squash-safe. Additive manifest key + one assertion.

## The asymmetry

| | `false_ready/manifest.json` | `apply_fixes/manifest.json` |
|---|---|---|
| engine / distribution / version / protocols | ✅ full `oracle` block | ❌ only `pdflatex_graded: true` |
| asserted against the pinned image | ✅ `tex-oracle.yml` fails loudly | ❌ nothing |

A TeX Live image bump would silently redefine what property (b) means for the five `known_broken` rows, and no gate would notice — the exact drift the `false_ready` pin exists to prevent.

## Why now, and why this isn't a guess

#527 made property (b) run automatically for the first time. Its **first CI execution** (tex-oracle run `30834930925`, image `texlive/texlive@sha256:d79913b7…`, reporting `pdfTeX 3.141592653-2.6-1.40.29 (TeX Live 2026)`) reproduced this baseline **exactly**: 72 docs × 4 cells, same five `known_broken` rows, PASS.

So this records a *measured* agreement between the recorded baseline and the pinned engine, rather than asserting one I hope holds.

That agreement wasn't a foregone conclusion — **#527 explicitly predicted the first run would be yellow**, precisely because those rows had been measured on a local engine with no pin. It came back green. Pinning now is what stops that from silently ceasing to be true.

## Verified

- CLI-only run: PASS, same 5 `known_broken`
- `--require-pdflatex` run: PASS, same 5
- `tex-oracle.yml` parses; `known_broken` array untouched (the `oracle` block is additive, and the gate reads only `known_broken`)