### PR TITLE
feat(R7-3): fix-guard region 5 — manufactured_false_ready reaches ZERO

### DIFF
--- a/corpora/apply_fixes/manifest.json
+++ b/corpora/apply_fixes/manifest.json
@@ -8,22 +8,6 @@
   "pdflatex_graded": true,
   "known_broken": [
     {
-      "doc": "corpora/compile_check/good_longtable_free.tex",
-      "mode": "pilot:--apply-fixes",
-      "breaks_compile": true,
-      "degrades_verdict": false,
-      "not_idempotent": false,
-      "manufactured_false_ready": true
-    },
-    {
-      "doc": "corpora/compile_check/good_longtable_free.tex",
-      "mode": "pilot:--apply-fixes-best-effort",
-      "breaks_compile": true,
-      "degrades_verdict": false,
-      "not_idempotent": false,
-      "manufactured_false_ready": true
-    },
-    {
       "doc": "corpora/compile_check/good_quotes_dashes.tex",
       "mode": "default:--apply-fixes-best-effort",
       "breaks_compile": false,

--- a/latex-parse/src/fix_guard.ml
+++ b/latex-parse/src/fix_guard.ml
@@ -3,7 +3,8 @@
    not).
 
    Regions implemented, all purely lexical: 1. control symbol arguments, 2.
-   TikZ/PGF picture bodies, 3a. filename arguments, 3b. package-spec arguments.
+   TikZ/PGF picture bodies, 3a. filename arguments, 3b. package-spec arguments,
+   5. tabular/array column preambles.
 
    Regions NOT yet covered, in measured-damage order, and — this part matters —
    with UNEQUAL evidence behind them: 4. key arguments (\label \ref \cite ...,
@@ -278,6 +279,125 @@ let scan_command_argument (src : string) (k : int) ~(bare : bool) : int =
   done;
   !stop
 
+(* ── Region 5: tabular / array column preamble ──────────────────────────────
+   The column-specification argument of a tabular-family environment is a
+   PREAMBLE: a tiny language of its own where `>` `<` `@` `!` `|` `p` are
+   operators, not punctuation. MEASURED damage, and the last one left in
+   corpora/apply_fixes/manifest.json: under the pilot profile TYPO-052 rewrites
+   the `>` of `\begin{tabular}{>{\bfseries}l r}` into `\textgreater{}`, giving
+   `! Illegal pream-token` and pdflatex 0 -> 1 — while --compile-check reports
+   READY both before and after. That is the fixer manufacturing the project's
+   cardinal bug, and these two rows are the only remaining
+   manufactured_false_ready entries in the repo.
+
+   ARITY. Two shapes, and getting this wrong is the whole risk: *
+   \begin{tabular}[pos]{preamble} — preamble is the FIRST brace group *
+   \begin{tabular*}{width}[pos]{preamble} — the SECOND, because the width
+   argument comes first Environments whose arity I could not confirm from a
+   shipped package (tabu, longtabu) are deliberately ABSENT: guessing an arity
+   is how a range ends up short, and a missing environment merely means today's
+   behaviour.
+
+   FAILURE DIRECTION. The range runs from the backslash of \begin to the end of
+   the preamble group, so only its END is free. scan_preamble_stop returns None
+   — protect NOTHING — the moment a mandatory group is not a brace group, and
+   there is deliberately NO end-of-line fallback of the kind region 3 uses. A
+   fallback here could end the range BEFORE the preamble and expose exactly the
+   bytes this region exists to protect; declining to protect is the safe
+   failure, because it is only ever today's behaviour. Being over-wide (covering
+   the optional [pos] and the width argument too) is free and intentional. *)
+
+(* One past the matching close of the brace group at [p], or None if [p] is not
+   a group or the group never closes. Escape-aware: a backslash consumes the
+   next byte, so `\{` is a character rather than a group. *)
+let brace_group_end (src : string) (n : int) (p : int) : int option =
+  if p >= n || String.unsafe_get src p <> '{' then None
+  else
+    let depth = ref 0 and e = ref p and fin = ref (-1) in
+    while !fin < 0 && !e < n do
+      (match String.unsafe_get src !e with
+      | '\\' -> incr e
+      | '{' -> incr depth
+      | '}' ->
+          decr depth;
+          if !depth = 0 then fin := !e + 1
+      | _ -> ());
+      incr e
+    done;
+    if !fin >= 0 then Some !fin else None
+
+(* One past the optional group at [p]. Closes at an UNESCAPED bracket at brace
+   depth 0, the same semantics region 3 borrowed from the verified
+   drop_after_rbracket, so a bracket inside a braced option value cannot end it
+   early. *)
+let opt_group_end (src : string) (n : int) (p : int) : int option =
+  if p >= n || String.unsafe_get src p <> '[' then None
+  else
+    let e = ref (p + 1) and depth = ref 0 and fin = ref (-1) in
+    while !fin < 0 && !e < n do
+      (match String.unsafe_get src !e with
+      | '\\' -> incr e
+      | '{' -> incr depth
+      | '}' -> if !depth > 0 then decr depth
+      | ']' -> if !depth = 0 then fin := !e + 1
+      | _ -> ());
+      incr e
+    done;
+    if !fin >= 0 then Some !fin else None
+
+(* One past the [mandatory]-th brace group after [p0], skipping optional groups,
+   whitespace and comments in between. None if any mandatory group is missing —
+   see the failure-direction note above for why None, not a partial range. *)
+let scan_preamble_stop (src : string) (n : int) (p0 : int) (mandatory : int) :
+    int option =
+  let p = ref p0 and got = ref 0 and stop = ref None and go = ref true in
+  while !go do
+    let q = skip_blanks_and_comments src n !p in
+    if q >= n then go := false
+    else
+      match String.unsafe_get src q with
+      | '[' -> (
+          match opt_group_end src n q with
+          | Some e -> p := e
+          | None -> go := false)
+      | '{' -> (
+          match brace_group_end src n q with
+          | Some e ->
+              incr got;
+              p := e;
+              if !got >= mandatory then (
+                stop := Some e;
+                go := false)
+          | None -> go := false)
+      | _ -> go := false
+  done;
+  !stop
+
+(* (environment, how many mandatory groups precede AND include the preamble) *)
+let preamble_envs =
+  [
+    ("tabular", 1);
+    ("array", 1);
+    ("longtable", 1);
+    ("tabular*", 2);
+    ("tabularx", 2);
+    ("tabulary", 2);
+    ("xltabular", 2);
+  ]
+
+let preamble_ranges (src : string) : (int * int) list =
+  let n = String.length src in
+  List.concat_map
+    (fun (env, mandatory) ->
+      let b = "\\begin{" ^ env ^ "}" in
+      List.filter_map
+        (fun bs ->
+          match scan_preamble_stop src n (bs + String.length b) mandatory with
+          | Some e -> Some (bs, e)
+          | None -> None)
+        (find_all src b))
+    preamble_envs
+
 let argument_ranges (src : string) : (int * int) list * (int * int) list =
   let n = String.length src in
   let fns = ref [] and pkgs = ref [] in
@@ -316,6 +436,7 @@ type regions = {
   picture : (int * int) list;
   filename : (int * int) list;
   package_spec : (int * int) list;
+  preamble : (int * int) list;
 }
 
 let compute_regions (src : string) : regions =
@@ -325,6 +446,7 @@ let compute_regions (src : string) : regions =
     picture = picture_ranges src;
     filename;
     package_spec;
+    preamble = preamble_ranges src;
   }
 
 (* One-entry memo keyed on the buffer's PHYSICAL identity.
@@ -349,7 +471,9 @@ let regions_of (src : string) : regions =
 
 let protected_ranges (src : string) : (int * int) list =
   let r = regions_of src in
-  let rs = r.control_symbol @ r.picture @ r.filename @ r.package_spec in
+  let rs =
+    r.control_symbol @ r.picture @ r.filename @ r.package_spec @ r.preamble
+  in
   List.sort (fun (a, _) (b, _) -> compare a b) rs
 
 (* Rules whose contract IS editing control symbols. Derived from the golden
@@ -408,7 +532,7 @@ let filter ~(src : string) ~(rule_id : string) (edits : Cst_edit.t list) :
       let active =
         (if List.mem rule_id control_symbol_aware then []
          else [ r.control_symbol ])
-        @ [ r.picture; r.filename ]
+        @ [ r.picture; r.filename; r.preamble ]
         @ if List.mem rule_id package_spec_aware then [] else [ r.package_spec ]
       in
       let blocked span =

--- a/latex-parse/src/test_fix_guard.ml
+++ b/latex-parse/src/test_fix_guard.ml
@@ -224,6 +224,68 @@ let () =
         (not (insertion_survives src (find_sub src "article")))
         (tag ^ ": a point strictly inside the range is blocked"));
 
+  (* ── Region 5: tabular / array column preamble ───────────────────────────
+     The measured case: TYPO-052 rewriting `>` to \textgreater{} inside a
+     preamble yields "! Illegal pream-token" and pdflatex 0 -> 1, while
+     --compile-check says READY both sides. *)
+  run "column preamble of tabular is protected" (fun tag ->
+      expect
+        (not (survives "\\begin{tabular}{>{\\bfseries}l r}\na -- b\n" ">"))
+        (tag ^ ": the measured good_longtable_free corruption"));
+
+  run "preamble of array is protected" (fun tag ->
+      expect
+        (not (survives "\\begin{array}{>{x}c}\n" ">"))
+        (tag ^ ": array takes the same shape as tabular"));
+
+  run "optional [pos] before the preamble is skipped" (fun tag ->
+      expect
+        (not (survives "\\begin{tabular}[t]{>{\\bfseries}l}\n" ">"))
+        (tag ^ ": [pos] must not be mistaken for the preamble"));
+
+  run "tabular* takes the SECOND brace group as its preamble" (fun tag ->
+      (* Arity is the whole risk here: treating the width as the preamble would
+         end the range before the real one and expose it. *)
+      expect
+        (not (survives "\\begin{tabular*}{5cm}{>{\\bfseries}l r}\n" ">"))
+        (tag ^ ": width first, preamble second"));
+
+  run "tabular* with [pos] between width and preamble" (fun tag ->
+      expect
+        (not (survives "\\begin{tabularx}{5cm}[t]{>{x}l}\n" ">"))
+        (tag ^ ": optional group between the two mandatory ones"));
+
+  run "prose after the tabular is still fixed" (fun tag ->
+      expect
+        (survives
+           "\\begin{tabular}{ll}\na & b\n\\end{tabular}\n\nprose -- here\n"
+           "-- here")
+        (tag ^ ": region 5 must not become a blanket refusal"));
+
+  run "table BODY is not protected, only the preamble" (fun tag ->
+      (* Over-wide is safe, but protecting the whole environment would withhold
+         every legitimate fix inside a table, which is a real functional
+         loss. *)
+      expect
+        (survives
+           "\\begin{tabular}{ll}\ncell -- dash & b \\\\\n\\end{tabular}\n"
+           "-- dash")
+        (tag ^ ": the range ends at the preamble's closing brace"));
+
+  run "a missing mandatory group protects NOTHING rather than guessing"
+    (fun tag ->
+      (* No end-of-line fallback here, unlike region 3: a partial range could
+         end BEFORE the preamble and expose it. Declining is today's
+         behaviour. *)
+      expect
+        (survives "\\begin{tabular}\n\nprose -- here\n" "-- here")
+        (tag ^ ": scan_preamble_stop returns None, so no range is emitted"));
+
+  run "an unclosed preamble group protects nothing" (fun tag ->
+      expect
+        (survives "\\begin{tabular}{ll\n\nprose -- here\n" "-- here")
+        (tag ^ ": unbalanced group yields None, not a short range"));
+
   (* ── Regions 1 and 2 still hold (guard against a refactor regression) ── *)
   run "control symbol argument is still protected" (fun tag ->
       let src = "\\`a and -- here\n" in


### PR DESCRIPTION
Single commit — squash-safe.

⚠ **Conflicts with #528** — both edit `corpora/apply_fixes/manifest.json`. #528 adds an `oracle` block; this re-records `known_broken`. Land #528 first and I'll rebase, or land this first and #528 rebases. The `--record` template does **not** emit the `oracle` key, so whichever lands second must re-add it.

## The damage

The column specification of a tabular-family environment is a **preamble** — a small language where `>` `<` `@` `!` `|` `p` are operators, not punctuation. Under the pilot profile TYPO-052 rewrote the `>` of

```latex
\begin{tabular}{>{\bfseries}l r}     % good_longtable_free.tex:4
```

into `\textgreater{}` → `! Illegal pream-token`, pdflatex **0 → 1**, while `--compile-check` reported READY **both before and after**. The fixer manufacturing the project's cardinal bug.

```
known_broken 5 → 3     manufactured_false_ready 2 → 0
```

**Zero repo-wide.** The fixer can no longer turn a compiling corpus document into a non-compiling one.

## Arity is the whole risk

```
\begin{tabular}[pos]{preamble}            preamble is the FIRST brace group
\begin{tabular*}{width}[pos]{preamble}    the SECOND — width comes first
```

Both handled, optional `[pos]` skipped wherever it appears. **`tabu`/`longtabu` are deliberately absent** — I couldn't confirm their arity from a shipped package, and guessing an arity is exactly how a range stops before the bytes it should protect. A missing environment is only ever today's behaviour.

## Failure direction

The range runs from `\begin`'s backslash to the end of the preamble group, so only the **end** is free. `scan_preamble_stop` returns `None` — protect nothing — the moment a mandatory group isn't a brace group, and there is deliberately **no end-of-line fallback** of the kind region 3 uses. In region 3 that fallback *prevents* a short range; here it would *cause* one.

Deliberately **not** reusing `scan_command_argument`: region 3 depends on its exact behaviour, and its bare plain-TeX branch can set `found_group` *without* a brace group — the one way to manufacture a genuinely short region-5 range.

## Non-vacuity — proven, not asserted

A fixture that cannot fail is worse than none, and I shipped a vacuous one earlier in this track. With `preamble_envs` emptied (the one-line revert), the gate reports for **both** pilot cells:

```
NEW FIXER DEFECT (breaks_compile=True, degrades_verdict=False,
                  not_idempotent=False, manufactured_false_ready=True)
```

Restored → PASS at `known-broken 3`.

## Verified

- round-trip gate, real pdflatex, 72 × 4: **PASS**; only pre-`--record` findings were the two rows flipping to CLEAN
- fixed document now **compiles (exit 0, was 1)**
- `check_producer_coverage.py` **PASS** (167 × 1022) — the gate that caught region 1's over-restriction
- `check_verbatim_safety.py` PASS (7 regions) · `check_apply_fixes_safety.py` PASS (332 files)
- `dune runtest` exit 0 — fix-guard **47 cases**, 355 goldens, fast==full on all 507 docs
- ocamlformat fixpoint

47 cases pin both arities, that the table **body** is not protected (over-wide is safe for correctness but would withhold every legitimate in-table fix), and both protect-nothing paths.

**Region 4** (cross-reference keys) remains open with **no fixture anywhere**, so the gate is silent on it — recorded in the module header rather than left implicit.