### PR TITLE
feat(R7 DWR-3a): \iffalse dead spans — false-READY baseline 7 → 6

### DIFF
--- a/corpora/false_ready/manifest.json
+++ b/corpora/false_ready/manifest.json
@@ -11,8 +11,8 @@
     ]
   },
   "baseline": {
-    "false_ready_total": 7,
-    "strong_fatal": 7,
+    "false_ready_total": 6,
+    "strong_fatal": 6,
     "error_halt": 0
   },
   "fixtures": [
@@ -149,8 +149,9 @@
       "fix_rank": 2,
       "tier": "lp-extended",
       "pdflatex": "strong-fatal",
-      "expected_cli": "READY",
-      "note": "the only \\end{document} is inside a never-taken \\iffalse; TeX skips it, EOF with no legal \\end"
+      "expected_cli": "NOT-READY",
+      "note": "the only \\end{document} is inside a never-taken \\iffalse; TeX skips it, EOF with no legal \\end",
+      "fixed_by": "R7 DWR-3a: no_live_end_document_fatal now skips spans an executed \\iffalse would skip, so the \\end{document} inside \\iffalse...\\fi is no longer counted as live."
     },
     {
       "id": "fr_verb_eol",

--- a/latex-parse/src/compile_gate_checks.ml
+++ b/latex-parse/src/compile_gate_checks.ml
@@ -713,11 +713,69 @@ let no_live_end_document_fatal (s : string) : string option =
     done;
     starts "{document}" !j
   in
+  (* A control word ends at a non-letter, so `\fi` must not match inside `\fill`
+     and `\iffalse` must not match inside `\iffalsething`. Matching a longer
+     word as a shorter one would invent a conditional that is not there. *)
+  let starts_cw pfx j =
+    starts pfx j
+    &&
+    let k = j + String.length pfx in
+    k >= n
+    ||
+    let c = String.unsafe_get s k in
+    not ((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z'))
+  in
+  (* Spans that an executed \iffalse skips. From the \iffalse to the FIRST
+     following \else or \fi — deliberately an UNDER-approximation, because a
+     nested conditional inside makes the span too SHORT, never too long. SHORT
+     IS THE SAFE DIRECTION HERE. This detector fires when NO live \end{document}
+     is found, so a shorter dead span means it still SEES the \end{document} and
+     stays quiet: today's behaviour. A longer one would make it fire more, i.e.
+     over-reject.
+
+     Only the \iffalse itself is required to be at brace depth 0.
+     `\newcommand{\hidden}{\iffalse}` is a definition BODY, not an executed
+     conditional, and treating it as one could mark a genuinely live
+     \end{document} dead.
+
+     ⚠ The honest limit, stated because an earlier draft of a sibling region
+     claimed more than it could deliver: this does NOT decide deadness. An
+     \iffalse that is itself inside a non-executed branch is still treated as
+     executed. It is an under-approximation of what TeX skips, nothing more. *)
+  let dead =
+    let acc = ref [] and j = ref 0 and depth = ref 0 in
+    while !j < n do
+      if in_ranges skip !j || is_escaped !j then incr j
+      else
+        let c = String.unsafe_get s !j in
+        if c = '{' then (
+          incr depth;
+          incr j)
+        else if c = '}' then (
+          if !depth > 0 then decr depth;
+          incr j)
+        else if !depth = 0 && starts_cw "\\iffalse" !j then (
+          let k = ref (!j + 8) and stop = ref (-1) in
+          while !stop < 0 && !k < n do
+            if in_ranges skip !k || is_escaped !k then incr k
+            else if starts_cw "\\else" !k then stop := !k + 5
+            else if starts_cw "\\fi" !k then stop := !k + 3
+            else incr k
+          done;
+          (* An executed \iffalse with no \fi at all is itself `! Incomplete
+             \iffalse`, so treating the rest of the file as dead is right. *)
+          let e = if !stop >= 0 then !stop else n in
+          acc := (!j, e) :: !acc;
+          j := e)
+        else incr j
+    done;
+    List.rev !acc
+  in
   let found = ref false in
   let i = ref 0 in
   while !i < n && not !found do
     let pos = !i in
-    if in_ranges skip pos || is_escaped pos then incr i
+    if in_ranges skip pos || is_escaped pos || in_ranges dead pos then incr i
     else if is_end_document pos then found := true
     else incr i
   done;

--- a/latex-parse/src/test_compile_gate.ml
+++ b/latex-parse/src/test_compile_gate.ml
@@ -281,4 +281,89 @@ let () =
         t);
   ()
 
+(* ── DWR-3a: \iffalse dead spans in no_live_end_document_fatal ─────────────
+   fr_end_in_iffalse was a false-READY: the only \end{document} sits inside
+   \iffalse...\fi, so TeX never executes it and emergency-stops, while the
+   detector found the string and reported READY. Tested through the exported
+   structural_fatal_reasons because the detector itself is internal.
+
+   The counter-examples matter more than the positive case: this arm can only
+   make the detector fire MORE, so every risk here is over-rejection, and a real
+   paper that uses \iffalse to comment out a block must stay READY. *)
+let () =
+  let fatal src =
+    List.length (Compile_gate_checks.structural_fatal_reasons src) >= 1
+  in
+  run "end{document} only inside \\iffalse..\\fi is FATAL" (fun t ->
+      expect
+        (fatal
+           "\\documentclass{article}\n\
+            \\begin{document}\n\
+            Hi.\n\
+            \\iffalse\n\
+            \\end{document}\n\
+            \\fi\n")
+        t);
+  run "a LIVE end{document} after an \\iffalse block is fine" (fun t ->
+      expect
+        (not
+           (fatal
+              "\\documentclass{article}\n\
+               \\begin{document}\n\
+               \\iffalse\n\
+               dead\n\
+               \\fi\n\
+               Hi.\n\
+               \\end{document}\n"))
+        t);
+  run "\\iffalse block BEFORE the end is fine (the common comment-out shape)"
+    (fun t ->
+      expect
+        (not
+           (fatal
+              "\\documentclass{article}\n\
+               \\begin{document}\n\
+               \\iffalse\n\
+               \\section{old}\n\
+               \\fi\n\
+               text\n\
+               \\end{document}\n"))
+        t);
+  run "\\else terminates the dead span, so the else-branch is live" (fun t ->
+      expect
+        (not
+           (fatal
+              "\\documentclass{article}\n\
+               \\begin{document}\n\
+               \\iffalse\n\
+               dead\n\
+               \\else\n\
+               \\end{document}\n\
+               \\fi\n"))
+        t);
+  run "\\iffalse inside a brace group is a definition body, not a conditional"
+    (fun t ->
+      (* \newcommand{\hidden}{\iffalse} must NOT start a dead span, or a live
+         \end{document} after it would be wrongly called dead. *)
+      expect
+        (not
+           (fatal
+              "\\documentclass{article}\n\
+               \\newcommand{\\hidden}{\\iffalse}\n\
+               \\begin{document}\n\
+               Hi.\n\
+               \\end{document}\n"))
+        t);
+  run "\\fill must not be read as \\fi (control-word boundary)" (fun t ->
+      expect
+        (not
+           (fatal
+              "\\documentclass{article}\n\
+               \\begin{document}\n\
+               \\hspace{\\fill}\n\
+               Hi.\n\
+               \\end{document}\n"))
+        t);
+  ()
+
 let () = finalise "compile_gate"


### PR DESCRIPTION
Single commit — squash-safe. Closes `fr_end_in_iffalse`.

## The cardinal bug in its purest form

```latex
\iffalse
\end{document}
\fi
```

The document's only `\end{document}` sits inside `\iffalse…\fi`, so TeX never executes it and emergency-stops — while `--compile-check` found the string, knew nothing about conditionals, and said **READY**.

`no_live_end_document_fatal` now skips spans an executed `\iffalse` would skip.

```
corpora/false_ready/manifest.json   baseline.false_ready_total 7 → 6
```

## Failure direction

This arm can only make the detector fire **more**, so it cannot introduce a false-READY relative to today — the entire risk is over-rejection. The dead span therefore runs to the **first** following `\else`/`\fi`: deliberately an **under**-approximation, since a nested conditional makes the span too *short*, and short means the detector still sees the `\end{document}` and stays quiet (today's behaviour).

⚠ **It does not decide deadness.** An `\iffalse` inside another conditional's non-executed branch is still treated as executed. Stated plainly in the module comment — a sibling region shipped a draft claiming more than it could deliver and an audit falsified it three ways.

## Two details I'd have got wrong, now pinned by counter-example tests

- **Brace depth 0 required.** `\newcommand{\hidden}{\iffalse}` is a definition *body*, not a conditional. Without the check it opens a dead span and a genuinely **live** `\end{document}` after it gets called dead — turning an over-rejection risk into a false-NOT-READY on real documents.
- **Control-word boundaries.** `\fi` must not match inside `\fill`, `\iffalse` not inside `\iffalsething`. Matching a longer word as a shorter one invents a conditional that isn't in the source.

## Over-rejection: measured at zero (R7 DoD)

Differential over the real-paper corpus, **1507 .tex files**, two binaries built from `origin/main` and from this tree:

```
READY before 423 → after 422        newly NOT-READY: 1
```

That one is `fr_end_in_iffalse.tex` — the fixture being fixed. The fast-vs-full parity corpus moved by the same single document (171 → 170 READY), an independent confirmation of the delta.

### ⚠ How that number was almost wrong

My **first** differential reported 0 over-rejection from a **stale binary**: `cp` failed with `Permission denied` (dune emits read-only executables, destination existed from work several PRs earlier), so the "after" arm predated the change and could only ever report zero. The rebuilt harness asserts its preconditions before measuring — arms must differ by md5, and each must give the *expected* verdict on the fixture — and refuses to run otherwise.

## Verified

- `check_known_false_ready.py` **PASS at baseline 6** — it correctly **failed first** with `UNRECORDED FIX` until the manifest was flipped, which is the monotone gate working
- `check_apply_fixes_roundtrip.py` PASS, known-broken 3
- `dune runtest` exit 0 — compile_gate **75 cases**, 355 goldens, fast==full on 507 docs
- ocamlformat fixpoint

## Not included

The **`\endinput` arm** of DWR-3. It is corpus-silent — no real file in the tree contains `\endinput` — so its over-rejection safety would be *argued* rather than measured, and an earlier prototype was dropped for over-rejecting `\ifdefined\previewmode\endinput\fi`. It gets its own revertible commit and its own differential.