### PR TITLE
fix(R7-INFRA-4): track the cross-reference-key class, and stop --record destroying the baseline

### DIFF
--- a/corpora/apply_fixes/adv_label_key.tex
+++ b/corpora/apply_fixes/adv_label_key.tex
@@ -1,0 +1,28 @@
+% Adversarial fixture: a cross-reference KEY corrupted by a math producer.
+%
+% A \label sitting inside an equation environment counts as MATH, so SCRIPT-001
+% rewrites the multi-character subscript eq:lower_bound -> eq:lower_{bound} and
+% SCRIPT-007 then -> eq:lower_{\text{bound}}. The \eqref in prose is NOT math and
+% is left alone, so the definition and the reference DIVERGE.
+%
+% Two things make this worth a fixture rather than a footnote:
+%   * it fires in the DEFAULT profile, not only under pilot;
+%   * \text inside \label is a hard error, so pdflatex goes 0 -> 1 with
+%     "! Missing \endcsname inserted" and produces NO PDF -- while
+%     --compile-check reports READY on both sides. A manufactured false-READY.
+%
+% It needs a MULTI-CHARACTER subscript: eq:a_b is left alone, eq:lower_bound is
+% not. A single-character variant of this fixture would be VACUOUS.
+%
+% Region 4 of Fix_guard (cross-reference key arguments) is the fix. Until then
+% this is recorded as a known defect so the class is measured rather than merely
+% believed to be absent.
+\documentclass{article}
+\usepackage{amsmath}
+\begin{document}
+See \eqref{eq:lower_bound} for the result.
+\begin{equation}
+\label{eq:lower_bound}
+x = 1
+\end{equation}
+\end{document}

--- a/corpora/apply_fixes/manifest.json
+++ b/corpora/apply_fixes/manifest.json
@@ -17,6 +17,38 @@
   },
   "known_broken": [
     {
+      "doc": "corpora/apply_fixes/adv_label_key.tex",
+      "mode": "default:--apply-fixes",
+      "breaks_compile": true,
+      "degrades_verdict": false,
+      "not_idempotent": false,
+      "manufactured_false_ready": true
+    },
+    {
+      "doc": "corpora/apply_fixes/adv_label_key.tex",
+      "mode": "default:--apply-fixes-best-effort",
+      "breaks_compile": false,
+      "degrades_verdict": false,
+      "not_idempotent": true,
+      "manufactured_false_ready": false
+    },
+    {
+      "doc": "corpora/apply_fixes/adv_label_key.tex",
+      "mode": "pilot:--apply-fixes",
+      "breaks_compile": true,
+      "degrades_verdict": false,
+      "not_idempotent": false,
+      "manufactured_false_ready": true
+    },
+    {
+      "doc": "corpora/apply_fixes/adv_label_key.tex",
+      "mode": "pilot:--apply-fixes-best-effort",
+      "breaks_compile": false,
+      "degrades_verdict": false,
+      "not_idempotent": true,
+      "manufactured_false_ready": false
+    },
+    {
       "doc": "corpora/compile_check/good_quotes_dashes.tex",
       "mode": "default:--apply-fixes-best-effort",
       "breaks_compile": false,

--- a/scripts/tools/check_apply_fixes_roundtrip.py
+++ b/scripts/tools/check_apply_fixes_roundtrip.py
@@ -164,6 +164,27 @@ def main() -> int:
     elif not args.record:
         return die(f"{MANIFEST} missing — run with --record to create the baseline")
 
+    # REFUSE to re-record a pdflatex-graded baseline on a runner without TeX.
+    # Property (b) is the only one that can see the fixer break a compiling
+    # document, and without pdflatex `broke` is False for EVERY cell — so a
+    # --record here silently deletes every breaks_compile row while leaving an
+    # oracle block that still claims it was graded against TL2026. The result
+    # looks like a clean baseline and is actually a blindfolded one.
+    #
+    # Checked HERE rather than at the write, so it costs nothing: the refusal
+    # lands before the 73-document sweep instead of after it.
+    if args.record and not have_tex and manifest_path.exists():
+        try:
+            prior_graded = json.loads(manifest_path.read_text()).get("pdflatex_graded")
+        except Exception:  # noqa: BLE001
+            prior_graded = None
+        if prior_graded:
+            return die(
+                "refusing to re-record: the existing baseline is pdflatex_graded "
+                "but pdflatex is not on PATH, so every breaks_compile row would "
+                "be erased. Re-record inside the pinned image — tex-oracle.yml "
+                "already runs this script there.")
+
     findings: list[str] = []
     observed_broken: list[dict] = []
     n_docs = 0
@@ -306,6 +327,23 @@ def main() -> int:
                     f"update {MANIFEST} to lock it in (--record)")
 
     if args.record:
+        # CARRY FORWARD anything this writer does not own. The template below is
+        # a fixed literal, so every top-level key absent from it is DESTROYED on
+        # each --record. That is not hypothetical: the `oracle` block recording
+        # which pdflatex graded this baseline was added separately, and
+        # tex-oracle.yml now ASSERTS manifest["oracle"]["version"] against the
+        # pinned image — so the next --record would have deleted the key and
+        # turned that assertion into a KeyError rather than a readable failure.
+        # Carrying unknown keys forward keeps a re-record from silently
+        # discarding provenance that another gate depends on.
+        owned = {"description", "properties", "pdflatex_graded", "known_broken"}
+        carried: dict = {}
+        if manifest_path.exists():
+            try:
+                carried = {k: v for k, v in json.loads(manifest_path.read_text()).items()
+                           if k not in owned}
+            except Exception:  # noqa: BLE001
+                carried = {}
         manifest_path.parent.mkdir(parents=True, exist_ok=True)
         manifest_path.write_text(json.dumps({
             "description": (
@@ -319,6 +357,7 @@ def main() -> int:
                 "b_oracle_class_preserving": "a document that compiled must still compile",
             },
             "pdflatex_graded": have_tex,
+            **carried,
             "known_broken": sorted(observed_broken, key=lambda e: (e["doc"], e["mode"])),
         }, indent=2) + "\n", encoding="utf-8")
         print(f"[fixer-roundtrip] recorded {len(observed_broken)} known breakage(s) "


### PR DESCRIPTION
Single commit — squash-safe.

## ⚠ Correction to #529 first

#529's headline said **"manufactured_false_ready reaches ZERO repo-wide."** That was **corpus-scoped**, not repo-wide: zero across the two corpora the gate reads, and the shape below was in neither. I had written the correct principle into `fix_guard.ml`'s own header the day before — *"absence from the gate's baseline is not evidence that it is harmless; it is evidence that nobody has measured it"* — and then published its opposite.

```
known_broken 3 → 7        manufactured_false_ready 0 → 2
```

**The number gets worse because the measurement got better.** Nothing regressed.

## The defect

A `\label` inside an `equation` counts as **math**, so SCRIPT-001 rewrites `eq:lower_bound` → `eq:lower_{bound}` and SCRIPT-007 then → `eq:lower_{\text{bound}}`, while the `\eqref` in prose is untouched. Definition and reference **diverge**.

- Fires in the **default** profile, not only pilot.
- `\text` inside `\label` is a **hard error** — `! Missing \endcsname inserted`, no PDF, pdflatex 0 → 1 — while `--compile-check` reports READY on **both** sides. A manufactured false-READY, which the *existing* property (b) catches once the shape lives in a corpus the gate reads.
- Requires a **multi-character** subscript: `eq:a_b` is untouched, `eq:lower_bound` isn't. My first reproduction used `_b` and didn't fire — a single-character variant would be **vacuous**, and the fixture says so in a comment.
- Four labels in `corpora/lint/i18n_qa/i18n_qa_he_paper.tex` are **already rewritten today** — harmlessly *there* (none is referenced), but that file isn't in the gate's corpora either.

Tracked in all four cells: two `breaks_compile + manufactured_false_ready`, two `not_idempotent` — the latter is the SCRIPT-001→007 cascade visible in the data, since best-effort is single-pass and stops one step short.

Region 4 is the fix. Recording first is the R7-INFRA-1 pattern: **a class nobody measures is a class nobody can fix.**

## Two `--record` integrity guards

The gate that maintains the baseline could destroy it.

| # | hazard | consequence |
|---|---|---|
| 1 | writer built the manifest from a fixed 4-key literal | every unlisted top-level key **deleted** on each `--record` — including the `oracle` pin #528 added, which `tex-oracle.yml` now asserts in a `set -euo pipefail` step with no `continue-on-error` → **KeyError**, not a readable failure |
| 2 | re-record **without pdflatex** | `broke = False` for every cell → **erases every `breaks_compile` row** while keeping an `oracle` block claiming TL2026. Looks like a clean baseline; is a blindfolded one |

**I found #1 by reading the writer. #2 I would have shipped without.** Both refuse **before** the 73-document sweep, so the refusal costs 0.465s instead of ~90.

Guard #1 now carries forward *any* key it doesn't own, so the trap can't reopen when the next provenance block is added.

## Verified

- TeX-less `--record` refusal fires in **0.465s** (stripped PATH)
- `--record` preserves `oracle`: confirmed after a real re-record
- round-trip gate **PASS** at known-broken 7, 73 docs × 4 cells, real pdflatex
- fixture non-vacuity is structural: pristine exit 0, fixed exit 1 with no PDF

## Separate correction, for the record

**#530's commit and PR both said the `\endinput` arm was "corpus-silent — 0 of 1611 files."** That is false: **38** `.tex` files contain it. I repeated a figure from a plan without running the grep. The corrected evidence is *favourable* — in every file sampled the first `\endinput` follows the first `\end{document}` (acmart's `\end{document}\endinput` idiom) — so DWR-3b's over-rejection safety is **measurable**, and my stated reason for deferring it doesn't hold.