### PR TITLE
fix(ci): stop required contexts being published twice per commit

### DIFF
--- a/.github/workflows/catalogue-compliance.yml
+++ b/.github/workflows/catalogue-compliance.yml
@@ -1,7 +1,11 @@
 name: Catalogue Compliance
 
 on:
+  # SCOPED DELIBERATELY (was a bare `push:`). A bare `push:` fires on every branch,
+  # so a PR branch published this workflow's check twice per commit under the same
+  # required-context name. Full rationale in .github/workflows/unit-tests.yml.
   push:
+    branches: [main]
   pull_request:
 
 

--- a/.github/workflows/catalogue-deep.yml
+++ b/.github/workflows/catalogue-deep.yml
@@ -1,7 +1,11 @@
 name: Catalogue Deep Validation
 
 on:
+  # SCOPED DELIBERATELY (was a bare `push:`). A bare `push:` fires on every branch,
+  # so a PR branch published this workflow's check twice per commit under the same
+  # required-context name. Full rationale in .github/workflows/unit-tests.yml.
   push:
+    branches: [main]
   pull_request:
 
 

--- a/.github/workflows/l1-smoke.yml
+++ b/.github/workflows/l1-smoke.yml
@@ -1,7 +1,11 @@
 name: L1 Rules Smoke
 
 on:
+  # SCOPED DELIBERATELY (was a bare `push:`). A bare `push:` fires on every branch,
+  # so a PR branch published this workflow's check twice per commit under the same
+  # required-context name. Full rationale in .github/workflows/unit-tests.yml.
   push:
+    branches: [main]
   pull_request:
 
 

--- a/.github/workflows/messages-validate.yml
+++ b/.github/workflows/messages-validate.yml
@@ -1,7 +1,11 @@
 name: Messages Validation
 
 on:
+  # SCOPED DELIBERATELY (was a bare `push:`). A bare `push:` fires on every branch,
+  # so a PR branch published this workflow's check twice per commit under the same
+  # required-context name. Full rationale in .github/workflows/unit-tests.yml.
   push:
+    branches: [main]
   pull_request:
 
 

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -1,5 +1,11 @@
 name: Mutation Baseline
-on: [push, pull_request]
+on:
+  # SCOPED DELIBERATELY (was `on: [push, pull_request]`, i.e. every branch). Same
+  # duplicate-required-context defect as the twelve sibling workflows; full rationale
+  # in .github/workflows/unit-tests.yml.
+  push:
+    branches: [main]
+  pull_request:
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/perf-ci.yml
+++ b/.github/workflows/perf-ci.yml
@@ -1,7 +1,11 @@
 name: Performance Gate CI
 
 on:
+  # SCOPED DELIBERATELY (was a bare `push:`). A bare `push:` fires on every branch,
+  # so a PR branch published this workflow's check twice per commit under the same
+  # required-context name. Full rationale in .github/workflows/unit-tests.yml.
   push:
+    branches: [main]
   pull_request:
 
 

--- a/.github/workflows/proof.yml
+++ b/.github/workflows/proof.yml
@@ -1,7 +1,11 @@
 name: Proof CI (Coq)
 
 on:
+  # SCOPED DELIBERATELY (was a bare `push:`). A bare `push:` fires on every branch,
+  # so a PR branch published this workflow's check twice per commit under the same
+  # required-context name. Full rationale in .github/workflows/unit-tests.yml.
   push:
+    branches: [main]
   pull_request:
 
 

--- a/.github/workflows/rest-schema.yml
+++ b/.github/workflows/rest-schema.yml
@@ -1,7 +1,11 @@
 name: REST Schema Validation
 
 on:
+  # SCOPED DELIBERATELY (was a bare `push:`). A bare `push:` fires on every branch,
+  # so a PR branch published this workflow's check twice per commit under the same
+  # required-context name. Full rationale in .github/workflows/unit-tests.yml.
   push:
+    branches: [main]
   pull_request:
 
 

--- a/.github/workflows/spec-drift.yml
+++ b/.github/workflows/spec-drift.yml
@@ -66,6 +66,16 @@ jobs:
         # this now.
         run: python3 scripts/tools/check_repo_facts.py --facts governance/project_facts.yaml --repo .
 
+      - name: "Meta-gate: required status checks are unambiguous"
+        # The job id IS the status-check context. This gate asserts that every
+        # context in .github/required-status-checks.json resolves to exactly one
+        # job, and that no such job sits behind an unfiltered `push:` (which
+        # publishes the same required context twice per commit on a PR branch --
+        # the defect that blocked PR #531 with a cancelled duplicate run while
+        # the real run had passed). Also catches an orphaned requirement after a
+        # job rename, which hangs every PR pending with nothing to point at.
+        run: python3 scripts/tools/check_workflow_triggers.py --repo .
+
       - name: "Meta-gate: every gate script is runnable"
         # P1.8 found check_regression_gates had a typo'd binary name.
         # This gate verifies every gate-script itself runs without

--- a/.github/workflows/unicode-smoke.yml
+++ b/.github/workflows/unicode-smoke.yml
@@ -1,7 +1,11 @@
 name: Unicode Rules Smoke
 
 on:
+  # SCOPED DELIBERATELY (was a bare `push:`). A bare `push:` fires on every branch,
+  # so a PR branch published this workflow's check twice per commit under the same
+  # required-context name. Full rationale in .github/workflows/unit-tests.yml.
   push:
+    branches: [main]
   pull_request:
 
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,7 +1,32 @@
 name: Unit Tests
 
 on:
+  # SCOPED DELIBERATELY. This was a bare `push:`, which fires on EVERY branch — so a
+  # commit on a PR branch ran this workflow TWICE (once on `push`, once on
+  # `pull_request`) and published two check-runs under the SAME required-context name
+  # on the SAME sha.
+  #
+  # The two runs never cancel each other: the concurrency group below falls back to
+  # `github.ref` when `github.event.pull_request.number` is absent, so the push-event
+  # run and the pull_request-event run land in DIFFERENT groups. GitHub's status
+  # rollup then honours whichever check-run reported LAST, not whichever passed.
+  #
+  # That is exactly how PR #531 was blocked: the push-event `unit-tests` PASSED in
+  # 11m50s (check-run 91955339989) while the duplicate pull_request-event run hit a
+  # 25-minute network timeout inside setup-ocaml-env and was CANCELLED (run
+  # 30898021798, check-run 91955461031). One flake, zero real failures, and a hard
+  # merge block that reads as "green" in the check list — you only see it in
+  # `gh pr view --json statusCheckRollup`.
+  #
+  # Thirteen workflows carried this bare `push:`, and they were precisely the
+  # thirteen contexts that appeared twice in #531's rollup — seven of them required.
+  #
+  # Scoping push to `main` keeps main covered after merge; PR coverage is unchanged,
+  # because `pull_request:` already fires on every push to an open PR. It also
+  # roughly halves CI minutes and halves flake exposure per PR. `develop` is
+  # deliberately NOT listed: no such branch exists on origin.
   push:
+    branches: [main]
   pull_request:
 
 

--- a/.github/workflows/validators-pilot-smoke-cli.yml
+++ b/.github/workflows/validators-pilot-smoke-cli.yml
@@ -1,7 +1,11 @@
 name: Validators Pilot Smoke (CLI)
 
 on:
+  # SCOPED DELIBERATELY (was a bare `push:`). A bare `push:` fires on every branch,
+  # so a PR branch published this workflow's check twice per commit under the same
+  # required-context name. Full rationale in .github/workflows/unit-tests.yml.
   push:
+    branches: [main]
   pull_request:
 
 

--- a/.github/workflows/validators-pilot-smoke.yml
+++ b/.github/workflows/validators-pilot-smoke.yml
@@ -1,7 +1,11 @@
 name: Validators Pilot Smoke
 
 on:
+  # SCOPED DELIBERATELY (was a bare `push:`). A bare `push:` fires on every branch,
+  # so a PR branch published this workflow's check twice per commit under the same
+  # required-context name. Full rationale in .github/workflows/unit-tests.yml.
   push:
+    branches: [main]
   pull_request:
 
 

--- a/.github/workflows/xxh-selfcheck.yml
+++ b/.github/workflows/xxh-selfcheck.yml
@@ -1,7 +1,11 @@
 name: XXH64 SIMD Selfcheck
 
 on:
+  # SCOPED DELIBERATELY (was a bare `push:`). A bare `push:` fires on every branch,
+  # so a PR branch published this workflow's check twice per commit under the same
+  # required-context name. Full rationale in .github/workflows/unit-tests.yml.
   push:
+    branches: [main]
   pull_request:
 
 

--- a/scripts/tools/check_gates_meta.py
+++ b/scripts/tools/check_gates_meta.py
@@ -49,6 +49,9 @@ GATE_SCRIPTS = [
      ["--repo", ".", "--skip-generated"]),
     # PR #246 (p1.12) addition — skip-exec used for meta-check (gate
     # script runnable without requiring a built test_l2_gate.exe).
+    # v27.1.63: required-status-check topology (duplicate context / job-name
+    # collision / orphaned requirement).
+    ("scripts/tools/check_workflow_triggers.py", ["--repo", "."]),
     ("scripts/tools/check_perf_ratchet.py",
      ["--repo", ".", "--skip-exec", "--input", "/dev/null"]),
 ]

--- a/scripts/tools/check_workflow_triggers.py
+++ b/scripts/tools/check_workflow_triggers.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""Gate: the workflows behind REQUIRED status checks must be unambiguous.
+
+Three failure modes, each of which has actually bitten this repo:
+
+1. DUPLICATE REQUIRED CONTEXT (the reason this gate exists).
+   A workflow with an unfiltered `push:` fires on every branch, so a commit
+   on a PR branch runs it TWICE -- once on `push`, once on `pull_request` --
+   publishing two check-runs under the SAME required-context name on the SAME
+   sha. They do not cancel each other: the usual concurrency group key,
+   `${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}`,
+   falls back to `github.ref` when there is no pull_request number, so the two
+   runs land in different groups. GitHub's status rollup then honours whichever
+   check-run reported LAST rather than whichever passed.
+
+   PR #531 was blocked exactly this way: the push-event `unit-tests` passed in
+   11m50s while the duplicate pull_request-event run hit a 25-minute network
+   timeout in setup-ocaml-env and was cancelled. One flake, zero real failures,
+   a hard merge block -- and the check LIST looked green, because the failure is
+   only visible in `gh pr view --json statusCheckRollup`.
+
+2. COLLIDING JOB NAME. The job id IS the status-check context. Two workflow
+   files declaring the same job id make a required context ambiguous: it can
+   resolve to the wrong workflow, or hang pending forever. spec-drift.yml's own
+   job comment records a prior instance ("renamed from the generic [check],
+   which collided with another workflow's job of the same name"). At the time of
+   writing, `build` is declared by BOTH ci.yml and spacy-container.yml -- which
+   is why `build` cannot be promoted to required until one is renamed. This gate
+   makes that prerequisite mechanical instead of remembered.
+
+3. ORPHANED REQUIRED CONTEXT. Renaming a job that is in the required list
+   orphans the requirement: no run ever publishes it, so every PR waits pending
+   forever with no failing check to point at.
+
+Authority: .github/required-status-checks.json. That file -- never the
+branch-protection API -- is the source of truth; branch-protection.yml PUTs its
+contents on every push to main, so an API patch is reverted on the next push.
+
+Exit 1 on any violation.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import yaml
+
+WORKFLOW_DIR = Path(".github/workflows")
+REQUIRED_JSON = Path(".github/required-status-checks.json")
+
+# A `push:` trigger counts as SCOPED if it carries any of these filters. Any one
+# of them stops the workflow firing on every branch of every PR, which is all
+# this gate cares about.
+PUSH_FILTERS = ("branches", "branches-ignore", "tags", "tags-ignore", "paths",
+                "paths-ignore")
+
+
+def load_on_block(doc: dict) -> dict | list | None:
+    """Return a workflow's trigger block.
+
+    YAML 1.1 parses a bare `on:` key as the boolean True, so the block can be
+    filed under either "on" or True depending on quoting. Check both.
+    """
+    if "on" in doc:
+        return doc["on"]
+    return doc.get(True)
+
+
+def push_is_unfiltered(on_block: dict | list | None) -> bool:
+    """True iff this workflow fires on a push to ANY branch."""
+    if isinstance(on_block, str):
+        return on_block == "push"
+    if isinstance(on_block, list):
+        # Flow style, e.g. `on: [push, pull_request]` -- no filters possible.
+        return "push" in on_block
+    if not isinstance(on_block, dict) or "push" not in on_block:
+        return False
+    push = on_block["push"]
+    if push is None:  # bare `push:` with an empty body
+        return True
+    if isinstance(push, dict):
+        return not any(k in push for k in PUSH_FILTERS)
+    return False
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--repo", default=".", help="repository root")
+    ns = ap.parse_args()
+    repo = Path(ns.repo).resolve()
+
+    required_path = repo / REQUIRED_JSON
+    if not required_path.is_file():
+        print(f"FAIL: {REQUIRED_JSON} not found", file=sys.stderr)
+        return 1
+    required = [c["context"] for c in
+                json.loads(required_path.read_text())["checks"]]
+
+    # Non-vacuity, both halves. A gate that silently processes nothing is worse
+    # than no gate: it reports PASS forever. This repo has one required check
+    # that has SKIPped for 185 days for exactly that reason.
+    if not required:
+        print(f"FAIL: {REQUIRED_JSON} lists zero required checks", file=sys.stderr)
+        return 1
+
+    workflows = sorted((repo / WORKFLOW_DIR).glob("*.yml"))
+    if not workflows:
+        print(f"FAIL: no workflows found under {WORKFLOW_DIR}", file=sys.stderr)
+        return 1
+
+    # job id -> [workflow paths declaring it]. The job id is the context name;
+    # a `name:` field would override it, so prefer that when present.
+    publishers: dict[str, list[str]] = {}
+    unfiltered: set[str] = set()
+
+    for wf in workflows:
+        try:
+            doc = yaml.safe_load(wf.read_text()) or {}
+        except yaml.YAMLError as exc:
+            print(f"FAIL: {wf.relative_to(repo)} is not valid YAML: {exc}",
+                  file=sys.stderr)
+            return 1
+        bare_push = push_is_unfiltered(load_on_block(doc))
+        for job_id, job in (doc.get("jobs") or {}).items():
+            name = job.get("name", job_id) if isinstance(job, dict) else job_id
+            # A templated name is not a stable context; fall back to the id.
+            context = job_id if "${{" in str(name) else str(name)
+            publishers.setdefault(context, []).append(str(wf.relative_to(repo)))
+            if bare_push:
+                unfiltered.add(context)
+
+    findings: list[str] = []
+
+    for context in required:
+        who = publishers.get(context, [])
+        if not who:
+            findings.append(
+                f"ORPHANED: required context '{context}' is published by no job "
+                f"in {WORKFLOW_DIR}. Every PR will wait pending forever with no "
+                f"failing check to point at. Rename the job back, or drop the "
+                f"context from {REQUIRED_JSON}.")
+        elif len(who) > 1:
+            findings.append(
+                f"AMBIGUOUS: required context '{context}' is declared by "
+                f"{len(who)} workflows ({', '.join(who)}). The job id IS the "
+                f"status-check context; a collision resolves to the wrong "
+                f"workflow or hangs pending. Rename one.")
+        if context in unfiltered:
+            findings.append(
+                f"DUPLICATED: '{context}' is published by a workflow with an "
+                f"unfiltered `push:`, so a PR branch publishes this required "
+                f"context TWICE per commit under one name and the rollup "
+                f"honours whichever finished last, not whichever passed. Scope "
+                f"push to `branches: [main]` -- `pull_request:` already covers "
+                f"every push to an open PR.")
+
+    if findings:
+        print(f"[workflow-triggers] FAIL: {len(findings)} violation(s)",
+              file=sys.stderr)
+        for f in findings:
+            print(f"  - {f}", file=sys.stderr)
+        return 1
+
+    print(f"[workflow-triggers] PASS: {len(required)} required context(s) each "
+          f"resolve to exactly one job, none with an unfiltered push trigger "
+          f"({len(workflows)} workflows scanned)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What

Thirteen workflows carried an unfiltered `push:`, so every commit on a PR branch ran them **twice** — once on `push`, once on `pull_request` — publishing two check-runs under the **same required-context name** on the same sha. **Seven of the nine required contexts** were affected. The thirteen bare-push workflows are exactly the thirteen contexts that appear twice in #531's rollup.

The two runs never cancel each other: the concurrency group key falls back to `github.ref` when there is no `pull_request.number`, so the push-event run and the pull_request-event run land in **different groups**. GitHub's status rollup then honours whichever check-run reported **last**, not whichever passed.

## Why it matters — this blocked #531

| | |
|---|---|
| push-event `unit-tests` | **PASSED** in 11m50s (check-run `91955339989`) |
| pull_request-event `unit-tests` | **CANCELLED** at 25m16s — network timeout in `setup-ocaml-env` (run `30898021798`) |
| Result | `statusCheckRollup = FAILURE`, hard merge block |

One flake, zero real failures. And the check **list** reads green — the failure is only visible in `gh pr view --json statusCheckRollup`.

## The fix

Scope `push:` to `branches: [main]` on all thirteen. Main stays covered after merge; **PR coverage is unchanged**, because `pull_request:` already fires on every push to an open PR. Also roughly halves CI minutes and flake exposure per PR.

`develop` is deliberately not listed — no such branch exists on origin, so the `[main, develop]` scoping elsewhere is already dead config.

## The ratchet

`scripts/tools/check_workflow_triggers.py`, wired into the **required** `spec-drift` job. It fails on three things, each of which has bitten this repo:

1. a required context behind an unfiltered `push:` — this defect;
2. a required context declared by **two** workflows. `build` is declared by both `ci.yml` and `spacy-container.yml` today, which is why `build` cannot be promoted to required until one is renamed. `spec-drift.yml`'s own job comment records a prior instance of exactly this collision;
3. a required context published by **no** job, which hangs every PR pending forever with nothing to point at.

## Verification

Verified in **both** directions, not just the passing one:

| Arm | Result |
|---|---|
| Clean tree | `PASS: 9 required context(s) each resolve to exactly one job` |
| Inject bare `push:` into `unit-tests.yml` | `FAIL — DUPLICATED` |
| Rename the `l1-smoke` job | `FAIL — ORPHANED` |
| Make two workflows declare `perf-ci` | `FAIL — AMBIGUOUS` |
| Empty required list | `FAIL — non-vacuity` |

Registered in `check_gates_meta.py` (15 scripts). **All 15 required `spec-drift` gates pass locally.**

Zero application code touched.