### PR TITLE
fix(ci): revive unicode-smoke — a REQUIRED check that tested nothing for 185 days

### DIFF
--- a/corpora/unicode/CHAR-012_zero_width_joiner.tex
+++ b/corpora/unicode/CHAR-012_zero_width_joiner.tex
@@ -1,0 +1,4 @@
+\documentclass{article}
+\begin{document}
+A zero‍width joiner sits outside any ligature context here.
+\end{document}

--- a/corpora/unicode/CHAR-014_replacement_char.tex
+++ b/corpora/unicode/CHAR-014_replacement_char.tex
@@ -1,0 +1,4 @@
+\documentclass{article}
+\begin{document}
+A decoding error left a � replacement character in this line.
+\end{document}

--- a/corpora/unicode/CHAR-016_fullwidth_punct_ascii.tex
+++ b/corpora/unicode/CHAR-016_fullwidth_punct_ascii.tex
@@ -1,0 +1,4 @@
+\documentclass{article}
+\begin{document}
+An ASCII sentence with fullwidth punctuation， and more。
+\end{document}

--- a/corpora/unicode/CHAR-019_unicode_minus_text.tex
+++ b/corpora/unicode/CHAR-019_unicode_minus_text.tex
@@ -1,0 +1,4 @@
+\documentclass{article}
+\begin{document}
+The temperature fell to −5 degrees, written in text mode.
+\end{document}

--- a/corpora/unicode/CHAR-021_bom_mid_paragraph.tex
+++ b/corpora/unicode/CHAR-021_bom_mid_paragraph.tex
@@ -1,0 +1,4 @@
+\documentclass{article}
+\begin{document}
+A zero width no-break﻿space sits inside this paragraph body.
+\end{document}

--- a/corpora/unicode/CJK-004_raw_cjk_no_package.tex
+++ b/corpora/unicode/CJK-004_raw_cjk_no_package.tex
@@ -1,0 +1,4 @@
+\documentclass{article}
+\begin{document}
+A paragraph containing raw 中文字符 glyphs with no package loaded.
+\end{document}

--- a/corpora/unicode/ENC-007_zero_width_space.tex
+++ b/corpora/unicode/ENC-007_zero_width_space.tex
@@ -1,0 +1,4 @@
+\documentclass{article}
+\begin{document}
+A sentence with a zero​width space hidden inside a word.
+\end{document}

--- a/corpora/unicode/ENC-015_micro_homoglyph.tex
+++ b/corpora/unicode/ENC-015_micro_homoglyph.tex
@@ -1,0 +1,4 @@
+\documentclass{article}
+\begin{document}
+A measurement of 5µm uses the micro sign, not Greek mu.
+\end{document}

--- a/corpora/unicode/ENC-018_nb_hyphen_outside_url.tex
+++ b/corpora/unicode/ENC-018_nb_hyphen_outside_url.tex
@@ -1,0 +1,4 @@
+\documentclass{article}
+\begin{document}
+A non‑breaking hyphen sits outside any URL in this line.
+\end{document}

--- a/corpora/unicode/ENC-019_duplicate_combining.tex
+++ b/corpora/unicode/ENC-019_duplicate_combining.tex
@@ -1,0 +1,4 @@
+\documentclass{article}
+\begin{document}
+A base glyph carrying duplicate combining accents: é́ here.
+\end{document}

--- a/corpora/unicode/README.md
+++ b/corpora/unicode/README.md
@@ -1,0 +1,29 @@
+# `corpora/unicode` — fixtures for the REQUIRED `unicode-smoke` check
+
+Fourteen minimal documents, one per Unicode defect class, plus a pure-ASCII
+negative control. They are the input to `scripts/smoke_rules_unicode.sh`, driven
+by `specs/rules/unicode_golden.yaml`, which is what the required `unicode-smoke`
+status check runs.
+
+**Why they exist.** `specs/rules/unicode_golden.yaml` was deleted on 2026-02-16
+(`f24fc191`), and its last tracked content was a bare `cases:` with no entries —
+so the check was vacuous before the deletion and took its `SKIP … exit 0` branch
+for 185 days after it. Twenty CHAR/ENC/CJK/SPC/TYPO rule IDs had no regression
+coverage at all while a required check reported green.
+
+**Design rules for anything added here.**
+
+- One defect class per file, wrapped in a minimal `article` document. Keep the
+  prose free of anything that trips an unrelated rule — the CJK fixture
+  deliberately avoids the *word* "CJK" so the acronym rule stays quiet, and the
+  leader fixture avoids `\dots` so the spacing rule stays quiet.
+- Every expectation in the golden must be **observed** against the running
+  service in the `pilot` profile, never predicted.
+- Prefer a `forbid` list that asserts confusable families do not bleed into each
+  other (the three invisible-character rules; the four symbol rules). That half
+  catches over-firing, which `expect` alone cannot.
+- `clean_ascii_control.tex` must stay pure ASCII and must forbid every ID the
+  other fixtures expect. It is the over-rejection guard; do not weaken it.
+- Never encode a finding you believe is wrong. Two known gaps are documented at
+  the head of the golden rather than asserted — `TYPO-043` fires outside
+  verbatim despite its title, and `ENC-003` did not fire on U+2018/2019/201C/201D.

--- a/corpora/unicode/TYPO-053_unicode_leader.tex
+++ b/corpora/unicode/TYPO-053_unicode_leader.tex
@@ -1,0 +1,4 @@
+\documentclass{article}
+\begin{document}
+A midline leader ⋯ appears in running text right here.
+\end{document}

--- a/corpora/unicode/TYPO-060_smart_quotes_in_verbatim.tex
+++ b/corpora/unicode/TYPO-060_smart_quotes_in_verbatim.tex
@@ -1,0 +1,6 @@
+\documentclass{article}
+\begin{document}
+\begin{verbatim}
+He said “hello” inside verbatim.
+\end{verbatim}
+\end{document}

--- a/corpora/unicode/TYPO-061_unicode_times_text.tex
+++ b/corpora/unicode/TYPO-061_unicode_times_text.tex
@@ -1,0 +1,4 @@
+\documentclass{article}
+\begin{document}
+The grid is 3×4 in running text rather than in math mode.
+\end{document}

--- a/corpora/unicode/clean_ascii_control.tex
+++ b/corpora/unicode/clean_ascii_control.tex
@@ -1,0 +1,4 @@
+\documentclass{article}
+\begin{document}
+A perfectly ordinary ASCII sentence containing nothing unusual.
+\end{document}

--- a/scripts/smoke_rules_unicode.sh
+++ b/scripts/smoke_rules_unicode.sh
@@ -14,9 +14,32 @@ if ! command -v jq >/dev/null 2>&1; then
   exit 1
 fi
 
+# NON-VACUITY, part 1: a missing golden is a HARD FAILURE, not a skip.
+#
+# This branch used to `echo SKIP; exit 0`. specs/rules/unicode_golden.yaml was
+# deleted on 2026-02-16 (f24fc191) -- and its last tracked content was already a
+# bare `cases:` with no entries -- so this REQUIRED status check printed SKIP and
+# exited 0 on every run for 185 days while any CHAR/ENC/CJK regression merged
+# unopposed. A required check that tests nothing is strictly worse than no check:
+# it converts "nobody is looking" into a green tick.
 if [[ ! -f "$GOLDEN" ]]; then
-  echo "[unicode-smoke] SKIP: golden file $GOLDEN not found (no unicode cases defined)"
-  exit 0
+  echo "[unicode-smoke] FAIL: golden file $GOLDEN not found." >&2
+  echo "[unicode-smoke]   This check is REQUIRED. It must never pass by absence." >&2
+  echo "[unicode-smoke]   Restore the golden, or remove unicode-smoke from" >&2
+  echo "[unicode-smoke]   .github/required-status-checks.json -- not both silently." >&2
+  exit 1
+fi
+
+# NON-VACUITY, part 2: how many cases does the golden DECLARE? The awk reader
+# below is line-oriented and would silently yield zero records if the file's shape
+# drifted, which reproduces the same green-on-nothing failure by a different route.
+# Compare declared against actually-executed at the end.
+declared=$(grep -c '^[[:space:]]*-[[:space:]]*file:' "$GOLDEN" || true)
+MIN_CASES=${UNICODE_SMOKE_MIN_CASES:-12}
+if [[ "$declared" -lt "$MIN_CASES" ]]; then
+  echo "[unicode-smoke] FAIL: golden declares $declared case(s), minimum is $MIN_CASES." >&2
+  echo "[unicode-smoke]   Lower UNICODE_SMOKE_MIN_CASES deliberately if that is really intended." >&2
+  exit 1
 fi
 
 pass=0; fail=0
@@ -107,5 +130,15 @@ done < <(
   ' "$GOLDEN"
 )
 
-echo "[unicode-smoke] Summary: pass=$pass fail=$fail"
+echo "[unicode-smoke] Summary: pass=$pass fail=$fail declared=$declared"
+
+# NON-VACUITY, part 3: every declared case must actually have been executed. A
+# parser that drops records would otherwise report "pass=0 fail=0" and exit 0.
+executed=$((pass + fail))
+if [[ "$executed" -ne "$declared" ]]; then
+  echo "[unicode-smoke] FAIL: golden declares $declared case(s) but $executed ran." >&2
+  echo "[unicode-smoke]   The reader dropped records -- check the golden's shape." >&2
+  exit 1
+fi
+
 [[ $fail -eq 0 ]]

--- a/specs/rules/unicode_golden.yaml
+++ b/specs/rules/unicode_golden.yaml
@@ -1,0 +1,82 @@
+# Unicode rule golden -- the corpus behind the REQUIRED `unicode-smoke` check.
+#
+# HISTORY, because it matters: this file was deleted on 2026-02-16 (f24fc191) and
+# its last tracked content was a bare `cases:` with NO entries. So the required
+# check had been vacuous BEFORE the deletion too -- afterwards
+# scripts/smoke_rules_unicode.sh took its `SKIP: golden file not found` branch and
+# exited 0 on every run for 185 days. A required status check that tests nothing is
+# worse than no check: it reports green while any CHAR/ENC/CJK regression merges
+# unopposed. The script now hard-FAILS on a missing golden and enforces a minimum
+# case count, so this cannot recur silently.
+#
+# Every expectation below was OBSERVED against the real service (pilot profile,
+# the same profile unicode-smoke.yml runs), not predicted. `forbid` is the
+# valuable half: it asserts confusable rule families do not bleed into each other,
+# and the final case is a pure-ASCII negative control that must stay silent.
+#
+# 14 cases, 20 distinct rule IDs.
+#
+# KNOWN GAPS, deliberately NOT encoded here (encoding them would cement a defect):
+#   * TYPO-043 is titled "Smart quotes inside verbatim detected" but fires on
+#     smart quotes in ORDINARY PROSE with no verbatim anywhere. TYPO-060 is the
+#     correctly-scoped rule. Only the verbatim case below is asserted.
+#   * ENC-003 ("LATIN-1 smart quotes detected") did not fire on U+2018/2019/201C/
+#     201D. It may require genuinely mis-decoded CP1252 bytes, which this JSON
+#     transport cannot carry. Untested here rather than asserted either way.
+cases:
+  # U+200B -- forbids the other two invisible-character rules: the three must not bleed into each other
+  - file: corpora/unicode/ENC-007_zero_width_space.tex
+    expect: ["ENC-007"]
+    forbid: ["CHAR-012", "CHAR-014", "CHAR-021", "ENC-002", "SPC-012"]
+  # U+200D -- same invisible-character non-bleed assertion
+  - file: corpora/unicode/CHAR-012_zero_width_joiner.tex
+    expect: ["CHAR-012"]
+    forbid: ["CHAR-014", "CHAR-021", "ENC-002", "ENC-007", "SPC-012"]
+  # U+FEFF -- three rules fire on one codepoint by design: the paragraph rule, the mid-file BOM rule and the BOM-position rule
+  - file: corpora/unicode/CHAR-021_bom_mid_paragraph.tex
+    expect: ["CHAR-021", "ENC-002", "SPC-012"]
+    forbid: ["CHAR-012", "CHAR-014", "ENC-007"]
+  # U+FFFD -- the only fixture allowed to carry a replacement character
+  - file: corpora/unicode/CHAR-014_replacement_char.tex
+    expect: ["CHAR-014"]
+    forbid: []
+  # U+2212 -- CHAR-019 and MATH-083 are two spellings of the same finding; both must stay
+  - file: corpora/unicode/CHAR-019_unicode_minus_text.tex
+    expect: ["CHAR-019", "MATH-083"]
+    forbid: ["CHAR-014", "ENC-018", "TYPO-053", "TYPO-061"]
+  # U+00D7 -- forbids the sibling symbol rules
+  - file: corpora/unicode/TYPO-061_unicode_times_text.tex
+    expect: ["TYPO-061"]
+    forbid: ["CHAR-014", "CHAR-019", "ENC-018", "MATH-083", "TYPO-053"]
+  # U+22EF -- forbids the sibling symbol rules
+  - file: corpora/unicode/TYPO-053_unicode_leader.tex
+    expect: ["TYPO-053"]
+    forbid: ["CHAR-014", "CHAR-019", "ENC-018", "MATH-083", "TYPO-061"]
+  # U+2011 -- outside a URL, so TYPO-063 (inside-URL) must NOT fire
+  - file: corpora/unicode/ENC-018_nb_hyphen_outside_url.tex
+    expect: ["ENC-018"]
+    forbid: ["CHAR-014", "CHAR-019", "MATH-083", "TYPO-053", "TYPO-061", "TYPO-063"]
+  # U+00B5 -- micro sign, not Greek mu
+  - file: corpora/unicode/ENC-015_micro_homoglyph.tex
+    expect: ["ENC-015"]
+    forbid: ["CHAR-014"]
+  # U+FF0C U+3002 -- fullwidth punctuation in an ASCII context
+  - file: corpora/unicode/CHAR-016_fullwidth_punct_ascii.tex
+    expect: ["CHAR-016", "CJK-001"]
+    forbid: ["CHAR-014"]
+  # U+0301 x2 -- NFD input, so the non-canonical-form rule fires alongside
+  - file: corpora/unicode/ENC-019_duplicate_combining.tex
+    expect: ["ENC-010", "ENC-019"]
+    forbid: ["CHAR-014"]
+  # U+4E2D... -- raw CJK glyphs with no xeCJK; deliberately avoids the acronym 'CJK' in prose so the acronym rule stays quiet
+  - file: corpora/unicode/CJK-004_raw_cjk_no_package.tex
+    expect: ["CJK-004"]
+    forbid: ["CHAR-014"]
+  # U+201C U+201D -- smart quotes INSIDE verbatim -- the correctly-scoped rule. TYPO-043 co-fires here legitimately
+  - file: corpora/unicode/TYPO-060_smart_quotes_in_verbatim.tex
+    expect: ["TYPO-043", "TYPO-060", "VERB-004"]
+    forbid: ["CHAR-014"]
+  # none -- NEGATIVE CONTROL: pure ASCII, so every rule above must stay silent. This is the over-rejection guard
+  - file: corpora/unicode/clean_ascii_control.tex
+    expect: []
+    forbid: ["CHAR-012", "CHAR-014", "CHAR-016", "CHAR-019", "CHAR-021", "CJK-001", "CJK-004", "ENC-002", "ENC-007", "ENC-010", "ENC-015", "ENC-018", "ENC-019", "MATH-083", "SPC-012", "TYPO-043", "TYPO-053", "TYPO-060", "TYPO-061", "VERB-004"]


### PR DESCRIPTION
## The defect

`unicode-smoke` is one of the **nine required status checks**. It has been passing **by absence** since 2026-02-16.

`scripts/smoke_rules_unicode.sh:17-20` prints `SKIP: golden file not found` and `exit 0` when `specs/rules/unicode_golden.yaml` is missing. That file was deleted in `f24fc191` — and

```
$ git show f24fc191^:specs/rules/unicode_golden.yaml
cases:
```

…returns a bare `cases:` with **no entries**, so the check was already vacuous *before* the deletion. Either way it asserted nothing for **185 days** while a required green tick said otherwise. Twenty CHAR/ENC/CJK/SPC/TYPO rule IDs had no regression coverage at all.

## The fix

**1. `corpora/unicode/`** — 13 minimal single-defect fixtures + a pure-ASCII negative control. A *new* directory rather than `corpora/lint`, so `run_differential_test.py`, `check_ast_parity.py` and `check_apply_fixes_safety.py` keep the corpus they were measured against.

**2. `specs/rules/unicode_golden.yaml`** — 14 cases, **20 distinct rule IDs**. Every expectation was **observed** against the running service in the `pilot` profile (the profile `unicode-smoke.yml` actually uses), never predicted.

The `forbid` half is the valuable one: it asserts confusable families don't bleed into each other — the three invisible-character rules (U+200B / U+200D / U+FEFF) and the four symbol rules (U+2212 / U+00D7 / U+22EF / U+2011) — and the control case forbids all twenty, which is the over-rejection guard.

**3. Three non-vacuity guards**, because the failure here was not a wrong assertion but an absent one:

| Guard | Effect |
|---|---|
| Missing golden | hard **FAIL**, no longer SKIP |
| Minimum declared-case floor | 12 (override with `UNICODE_SMOKE_MIN_CASES`) |
| `declared` vs `executed` | a record the reader drops can't masquerade as "nothing to do" |

## Verification — both directions

Clean run: `pass=14 fail=0 declared=14`, exit 0.

| Injected drift | Exit |
|---|---|
| Golden missing | 1 |
| Golden with zero cases | 1 |
| `expect` names a rule that does not fire | 1 |
| `forbid` names a rule that does fire | 1 |
| **Simulated rule regression** (strip the U+200B, watch ENC-007 vanish) | 1 |
| A declared record the reader silently skips | 1 |

All ten required `spec-drift` gates pass locally; `bash -n` clean.

## Two findings documented rather than asserted

Encoding a finding I believe is wrong would cement it, so neither is in the golden:

- **`TYPO-043` is over-broad.** Its title is *"Smart quotes inside verbatim detected"*, but it fires on smart quotes in **ordinary prose with no verbatim anywhere**. `TYPO-060` is the correctly-scoped rule. Probe:

  | input | ids |
  |---|---|
  | smart quotes in prose only | `[TYPO-043]` ← should be empty |
  | smart quotes in verbatim | `[TYPO-043, TYPO-060, VERB-004]` |
  | straight quotes in prose | `[TYPO-001]` |

  Only the genuine verbatim case is asserted here; the prose fixture was built, observed, and deliberately removed.

- **`ENC-003` ("LATIN-1 smart quotes detected") did not fire** on U+2018/U+2019/U+201C/U+201D. It may require genuinely mis-decoded CP1252 bytes, which this JSON transport cannot carry. Left untested rather than asserted either way.

Zero application code touched.