### PR TITLE
fix(ci): make the cardinal-invariant gates actually block a merge

### DIFF
--- a/.github/required-status-checks.json
+++ b/.github/required-status-checks.json
@@ -8,6 +8,8 @@
     {"context": "perf-ci",        "app_id": 15368},
     {"context": "xxh-selfcheck",  "app_id": 15368},
     {"context": "unit-tests",     "app_id": 15368},
-    {"context": "spec-drift",     "app_id": 15368}
+    {"context": "spec-drift",     "app_id": 15368},
+    {"context": "build",          "app_id": 15368},
+    {"context": "tex-oracle",     "app_id": 15368}
   ]
 }

--- a/.github/workflows/spacy-container.yml
+++ b/.github/workflows/spacy-container.yml
@@ -12,7 +12,13 @@ on:
       - 'ml/scripts/spacy_server.py'
 
 jobs:
-  build:
+  # RENAMED from the generic `build` (v27.1.63). The job id IS the status-check
+  # context, and ci.yml also declared a job called `build` -- the one that runs
+  # the false-READY monotone gate and the apply-fixes round-trip gate. With
+  # `build` in .github/required-status-checks.json, that collision would let this
+  # workflow -- which knows nothing about either gate -- satisfy the requirement.
+  # spec-drift.yml's own job comment records a prior instance of the same class.
+  spacy-build:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:

--- a/.github/workflows/tex-oracle.yml
+++ b/.github/workflows/tex-oracle.yml
@@ -213,16 +213,28 @@ jobs:
           docker run --rm "$TEX_IMAGE" bash -c 'python3 --version && command -v timeout' \
             || { echo "::error::pinned TeX image lacks python3 and/or coreutils timeout; property (b) cannot run here"; exit 2; }
 
-      # ADVISORY ON PURPOSE, matching this workflow's existing posture: tex-oracle
-      # is not among the nine required contexts, and the first runs are EXPECTED
-      # to be yellow rather than green. corpora/apply_fixes/manifest.json records
-      # pdflatex_graded=true but carries no oracle.version pin (unlike
-      # corpora/false_ready/manifest.json), so its five baseline rows were
-      # measured on a local engine, not this pinned TL2026 image. Any disagreement
-      # is a baseline-provenance artefact to be re-recorded here, NOT a new defect
-      # — which is exactly why this does not block on day one.
-      - name: Apply-fixes round-trip, property (b) — advisory
-        continue-on-error: true
+      # BLOCKING as of v27.1.63. This step was advisory, and the comment here used
+      # to give the reason: corpora/apply_fixes/manifest.json recorded
+      # pdflatex_graded=true but carried NO oracle.version pin, so its baseline
+      # rows had been measured on some local engine rather than this pinned TL2026
+      # image, and any disagreement would have been a provenance artefact rather
+      # than a real defect.
+      #
+      # That precondition is now satisfied on both counts, so the reason to mask
+      # it is gone:
+      #   * #528 added `oracle.version` to corpora/apply_fixes/manifest.json, and
+      #     the "Assert engine pin" step above now HARD-ASSERTS it against
+      #     TEX_EXPECT_VERSION — a mismatch fails before anything is graded.
+      #   * #527's first run reproduced the baseline exactly against this image:
+      #     "73 documents x 4 cells; fixer rewrote 94; pdflatex=yes;
+      #     known-broken 7 ... PASS — no new fixer damage", and every run since
+      #     has agreed.
+      #
+      # Leaving it masked now would be strictly worse than not running it: this is
+      # the ONLY check anywhere that can observe --apply-fixes turning a compiling
+      # document into a non-compiling one, and a masked step that silently starts
+      # failing is indistinguishable from one that passes.
+      - name: Apply-fixes round-trip, property (b)
         run: |
           set -euo pipefail
           docker run --rm \


### PR DESCRIPTION
> ⚠️ **Merge order: this must land _after_ #532.** Branch protection's `strict: true` enforces it by itself — this goes BEHIND when #532 lands and must be rebased. See *Combined end-state* below.

## The defect

Both gates that defend the project's worst two failure modes ran in jobs that **could not fail a merge**. A false-READY regression, or a fixer change that turns a compiling document into a non-compiling one, merged **9/9 green**.

| Gate | Lives in | Required? |
|---|---|---|
| `check_known_false_ready.py` (R7-INFRA-1) | `ci.yml` job `build` | ❌ |
| `check_apply_fixes_roundtrip.py` (a)+(c′) | `ci.yml` job `build` | ❌ |
| Real-pdflatex oracle — the only ground truth in the repo | `tex-oracle` workflow | ❌ |
| …and its property (b) step | — | also `continue-on-error: true` |

## The fix

**1. Break the job-name collision *first*.** The job id **is** the status-check context, and `build` was declared by **both** `ci.yml` and `spacy-container.yml`. Promoting `build` while that held would let `spacy-container` — which knows nothing about either gate — satisfy the requirement.

`spacy-container.yml`'s job is renamed to `spacy-build`, not `ci.yml`'s: it is path-filtered and rarely runs, so the blast radius is near zero, whereas `ci.yml`'s `build` carries hundreds of runs of history and is the context entering the required list. `spec-drift.yml`'s own job comment records a prior instance of this class.

**2. Un-mask property (b).** Its `continue-on-error` was justified by a *stated* precondition — `corpora/apply_fixes/manifest.json` recorded `pdflatex_graded=true` but carried **no** `oracle.version` pin, so its baseline had been measured on some local engine and disagreement would have been provenance noise.

That precondition is now satisfied on both counts: **#528** added the pin and the *Assert engine pin* step hard-asserts it against `TEX_EXPECT_VERSION`; **#527**'s first run reproduced the baseline exactly against the pinned image.

Verified **from the log, not the step conclusion** — a `continue-on-error` step can report `success` while failing. Run `30898024175`:

```
[fixer-roundtrip] 73 documents x 4 cells (profile x flag); fixer rewrote 94;
                  pdflatex=yes; known-broken 7
[fixer-roundtrip] PASS — no new fixer damage.
```

Non-vacuous (73 documents, 94 rewrites) and genuinely green on every run since.

**3. Promote `build` and `tex-oracle` to required** — in `.github/required-status-checks.json`, the file, never the API, since `branch-protection.yml` PUTs its contents on every push to main.

## What deliberately does *not* change

The **65-doc differential step stays advisory.** Its comment records a standing decision — *"Never make this one required"* — on grounds that still hold: it is blind to a CLI broken in the over-rejection direction, and an incomplete install manufactures spurious `FALSE-READY(NEW!)` rows. Not overridden here.

## Soak evidence

| Job | Record | Duration |
|---|---|---|
| `tex-oracle` | 39 success / 3 cancelled / **0 failure** over 42 runs — past the ~10-green bar its own notes set | ~11m50s |
| `build` | 15 success / 2 concurrency-cancelled over last 20 | ~13m — already runs on every PR, so promotion costs no wall-clock, only the ability to block |

## Combined end-state

Composing #532's scoped workflows with this branch's rename + promotion:

```
[workflow-triggers] PASS: 11 required context(s) each resolve to exactly one job,
                    none with an unfiltered push trigger (37 workflows scanned)
```

Six required `spec-drift` gates pass locally; both edited workflows parse. Zero application code touched.