### PR TITLE
fix(DELIM): count \left/\right as CONTROL WORDS, not substrings

### DIFF
--- a/corpora/false_ready/fr_thmtools_redeclare.tex
+++ b/corpora/false_ready/fr_thmtools_redeclare.tex
@@ -1,0 +1,10 @@
+\documentclass{article}
+\usepackage{amsthm}
+\usepackage{thmtools}
+\declaretheorem{lemma}
+\newtheorem{lemma}{Lemma}
+\begin{document}
+\begin{lemma}
+A statement.
+\end{lemma}
+\end{document}

--- a/corpora/false_ready/manifest.json
+++ b/corpora/false_ready/manifest.json
@@ -11,8 +11,8 @@
     ]
   },
   "baseline": {
-    "false_ready_total": 6,
-    "strong_fatal": 6,
+    "false_ready_total": 7,
+    "strong_fatal": 7,
     "error_halt": 0
   },
   "fixtures": [
@@ -256,6 +256,17 @@
       "pdflatex": "error-halt",
       "expected_cli": "NOT-READY",
       "note": "\\hyperref[l]{link text} moving-arg skip treats {link text} as a key; a double-superscript inside it is missed"
+    },
+    {
+      "id": "fr_thmtools_redeclare",
+      "path": "fr_thmtools_redeclare.tex",
+      "kind": "single",
+      "class": "closed-world",
+      "fix_rank": 1,
+      "tier": "lp-extended",
+      "pdflatex": "strong-fatal",
+      "expected_cli": "READY",
+      "note": "thmtools \\declaretheorem{lemma} already defines the environment and its counter; a following \\newtheorem{lemma} redefines it -> \"! LaTeX Error: Command \\lemma already defined.\", no PDF. Both packages are in the catalogue and every control sequence resolves, so nothing in the closed-world check fires. FOUND by fixing the DELIM-003/004 control-word boundary bug: on the real-paper corpus this class was being masked by a SPURIOUS DELIM rejection, so the document was NOT-READY for a reason that was not true. Measured on 2506.23970v1; this is the minimal distillation. The fixture contains no \\left/\\right, so it is READY on both sides of that fix -- the class is pre-existing, not introduced."
     }
   ]
 }

--- a/latex-parse/src/test_validators_delim.ml
+++ b/latex-parse/src/test_validators_delim.ml
@@ -233,6 +233,69 @@ let () =
         (Validators.precondition_of_rule_id "DELIM-011" = Validators.L1)
         (tag ^ ": DELIM-011 is L1"));
 
+  (* ══════════════════════════════════════════════════════════════════════
+     CONTROL-WORD BOUNDARY (v27.1.63)
+
+     DELIM-003/004/011 counted \left and \right with count_substring, which has
+     no notion of where a control word ends. \rightarrow therefore counted as
+     \right and \leftarrow as \left, so $A \rightarrow B$ was rejected while
+     pdflatex exits 0 — verified against pdfTeX 3.141592653-2.6-1.40.29. On a
+     70-paper real-corpus sample this one defect drove 20 of 39 over-rejections.
+
+     The doubled-escape cases are the OTHER direction: in [$a \\left( b
+     \right)$] the [\\] is a line break and [left] is ordinary text, so there is
+     a genuine unmatched \right. count_substring found "\left" inside "\\left",
+     scored the segment balanced, and stayed silent — a FALSE-READY. pdflatex:
+     exit 1, "! Extra \right.", no PDF.
+     ══════════════════════════════════════════════════════════════════════ *)
+  List.iter
+    (fun cw ->
+      run
+        ("DELIM-003/004 clean: \\" ^ cw ^ " is not \\left or \\right")
+        (fun tag ->
+          let src = "$A \\" ^ cw ^ " B$" in
+          expect (does_not_fire "DELIM-003" src) (tag ^ ": DELIM-003 silent");
+          expect (does_not_fire "DELIM-004" src) (tag ^ ": DELIM-004 silent")))
+    [
+      "rightarrow";
+      "leftarrow";
+      "leftrightarrow";
+      "Rightarrow";
+      "Leftarrow";
+      "Leftrightarrow";
+      "longrightarrow";
+      "longleftarrow";
+      "rightharpoonup";
+      "leftharpoonup";
+      "rightleftharpoons";
+      "rightsquigarrow";
+      "leftroot";
+    ];
+
+  run "DELIM-003/004 clean: arrows do not perturb a matched pair" (fun tag ->
+      expect
+        (does_not_fire "DELIM-003" "$\\left( a \\rightarrow b \\right)$")
+        (tag ^ ": DELIM-003 silent");
+      expect
+        (does_not_fire "DELIM-004" "$\\left( a \\rightarrow b \\right)$")
+        (tag ^ ": DELIM-004 silent"));
+
+  run "DELIM-003 still fires when an arrow is present" (fun tag ->
+      expect
+        (fires "DELIM-003" "$\\left( a \\rightarrow b$")
+        (tag ^ ": genuine unmatched \\left"));
+
+  run "DELIM-004 fires on a doubled escape (was a false-READY)" (fun tag ->
+      (* pdflatex: exit 1, "! Extra \right.", no output PDF. *)
+      expect
+        (fires "DELIM-004" "$a \\\\left( b \\right)$")
+        (tag ^ ": \\\\ is a line break, so `left` is text"));
+
+  run "DELIM-011 clean: \\middleware is not \\middle" (fun tag ->
+      expect
+        (does_not_fire "DELIM-011" "$x \\middleware y$")
+        (tag ^ ": control word boundary"));
+
   (* Combined: document with multiple delimiter issues *)
   run "combined: multiple DELIM rules fire" (fun tag ->
       let src = "Text { unclosed.\n$\\left( no right$\n$\\langle missing$\n" in

--- a/latex-parse/src/validators_common.ml
+++ b/latex-parse/src/validators_common.ml
@@ -96,6 +96,45 @@ let count_substring (s : string) (sub : string) : int =
     in
     loop 0 0
 
+(* Count occurrences of the CONTROL WORD [\cw] in [s]. [cw] is the name only,
+   without its backslash.
+
+   [count_substring] cannot answer this question. A TeX control word ends at the
+   first NON-LETTER, so a raw substring count reads [\rightarrow] as [\right]
+   and [\leftarrow] as [\left]. DELIM-003/004 counted delimiters that way and
+   therefore rejected [$A \rightarrow B$]: CLI NOT-READY, pdflatex exit 0. On a
+   70-paper sample of the real-paper corpus that single defect accounted for 20
+   of 39 over-rejections — and [\rightarrow] is about as common as mathematical
+   notation gets.
+
+   Walks the string rather than searching it, so the second backslash of a
+   DOUBLED ESCAPE is never re-read as the start of a fresh command: in [$a
+   \\left(b$] the [\\] is a line break and [left] is ordinary text, not a
+   delimiter. Searching for the substring counts it; this does not.
+
+   Failure direction: this can only ever count FEWER occurrences than
+   [count_substring], never more, so a caller that was over-rejecting becomes
+   more permissive and one that was correct is unchanged. *)
+let count_control_word (s : string) (cw : string) : int =
+  let is_letter c = (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') in
+  let n = String.length s and m = String.length cw in
+  let cnt = ref 0 and i = ref 0 in
+  while !i < n do
+    if String.unsafe_get s !i = '\\' && !i + 1 < n then
+      if is_letter (String.unsafe_get s (!i + 1)) then (
+        let st = !i + 1 in
+        let j = ref st in
+        while !j < n && is_letter (String.unsafe_get s !j) do
+          incr j
+        done;
+        if !j - st = m && String.sub s st m = cw then incr cnt;
+        i := !j)
+      else (* Control SYMBOL: step past BOTH bytes. *)
+        i := !i + 2
+    else incr i
+  done;
+  !cnt
+
 let contains_substring (s : string) (needle : string) : bool =
   let slen = String.length s and nlen = String.length needle in
   if nlen = 0 then true

--- a/latex-parse/src/validators_l1.ml
+++ b/latex-parse/src/validators_l1.ml
@@ -523,8 +523,8 @@ let l1_delim_003_rule : rule =
     let cnt = ref 0 in
     List.iter
       (fun seg ->
-        let lefts = count_substring seg "\\left" in
-        let rights = count_substring seg "\\right" in
+        let lefts = count_control_word seg "left" in
+        let rights = count_control_word seg "right" in
         if lefts > rights then cnt := !cnt + (lefts - rights))
       math_segs;
     if !cnt > 0 then
@@ -542,8 +542,8 @@ let l1_delim_004_rule : rule =
     let cnt = ref 0 in
     List.iter
       (fun seg ->
-        let lefts = count_substring seg "\\left" in
-        let rights = count_substring seg "\\right" in
+        let lefts = count_control_word seg "left" in
+        let rights = count_control_word seg "right" in
         if rights > lefts then cnt := !cnt + (rights - lefts))
       math_segs;
     if !cnt > 0 then
@@ -912,11 +912,11 @@ let l1_delim_011_rule : rule =
     let cnt = ref 0 in
     List.iter
       (fun seg ->
-        let middles = count_substring seg "\\middle" in
+        let middles = count_control_word seg "middle" in
         if middles > 0 then
           (* Check if there are sufficient \left..\right pairs *)
-          let lefts = count_substring seg "\\left" in
-          let rights = count_substring seg "\\right" in
+          let lefts = count_control_word seg "left" in
+          let rights = count_control_word seg "right" in
           let pairs = min lefts rights in
           if middles > 0 && pairs = 0 then cnt := !cnt + middles)
       math_segs;


### PR DESCRIPTION
## The defect

`DELIM-003/004/011` counted delimiters with `count_substring seg "\\left"`. A TeX control word ends at the first **non-letter**, so that reads `\rightarrow` as `\right` and `\leftarrow` as `\left`.

```
$A \rightarrow B$   →   CLI NOT-READY [DELIM-004]   ·   pdflatex rc=0
```

`DELIM-003/004` are `Error` severity, which puts them in the compile-blocking T5 set — so this was a **verdict-changing** defect on one of the most common constructions in mathematical writing.

## Measured, first-party, on the real-paper corpus

2,719 arXiv packages declaring pdflatex with a single toplevel on disk; deterministic 120-paper sample ordered by `sha256(arxiv_id)`; the *same binary built twice*, once with the fix reverted.

| | before | after |
|---|---|---|
| DELIM-003/004 firings | 39 | **1** |
| verdict READY | 46 / 120 | **68 / 120** |
| NOT-READY → READY | — | 22 |
| READY → NOT-READY | — | **0** |

**40.0%** of the frame (1,088 / 2,719 toplevels) contains a `\left<letter>` or `\right<letter>` control word — *exposure*, not confirmed misclassification. The verdict only changes when the miscount makes a math segment asymmetric.

## ⚠ The 22 flips are not all wins

Every flipped paper was recompiled under the manifest's pinned protocol:

| | count | meaning |
|---|---|---|
| **COMPILES** | 20 | genuine over-rejection removed |
| **FAILS** | 2 | the DELIM bug was rejecting them for a reason that **wasn't true**, masking a real false-READY |

- `2506.23970v1` — `! LaTeX Error: Command \lemma already defined.` (thmtools `\declaretheorem{lemma}` then `\newtheorem{lemma}`)
- `2507.10419v1` — `! Package natbib Error: Bibliography not compatible with author-year citations.` Needs a `.bbl`; recorded as an observation, not distilled.

Accidental masking is not soundness. Rejecting that much real work to accidentally catch two is not a safety property worth keeping — and **either class is already a live false-READY today** in any paper that doesn't also contain an arrow.

But it must be *measured* rather than believed absent, so this PR also records it:

```
corpora/false_ready/fr_thmtools_redeclare.tex
fixture baseline 6 → 7   (strong_fatal 6 → 7, error_halt 0)
```

Verified **strong-fatal under both pinned protocols** (with and without `-halt-on-error`): rc=1, no PDF either way. The fixture contains no `\left`/`\right`/`\middle`, so it is READY on both sides of this change — **pre-existing and unmasked, not introduced.**

## The doubled-escape case was also a false-READY

In `$a \\left( b \right)$` the `\\` is a line break and `left` is ordinary text, so there's a genuine unmatched `\right`. `count_substring` found `\left` *inside* `\\left`, scored the segment balanced `(1,1)`, and stayed silent — while pdflatex exits 1 with `! Extra \right.` and no PDF. It now fires.

`count_control_word` **walks** the string rather than searching it, so the second backslash of a doubled escape is never re-read as a fresh command.

## Verification — both directions

- **90/90** delim cases green with the fix
- **12 FAILURES** with the counting reverted, naming exactly the boundary and doubled-escape cases

Full pre-push checklist, all green: `dune build latex-parse/src` (clean) · `dune runtest latex-parse/src` (every suite) · `check_producer_coverage.py` (167 producers × 1022 adversarial variants) · `check_verbatim_safety.py` (7 regions) · `dune build @fmt` fixpoint · `check_apply_fixes_roundtrip.py` **with real pdflatex** (73 docs × 4 cells, 94 rewrites, PASS) · `check_known_false_ready.py` · `git ls-files` = 1668.