### PR TITLE
feat(R7-3): fix-guard region 4 — cross-reference keys; fixer damage reaches ZERO

### DIFF
--- a/corpora/apply_fixes/adv_label_key.tex
+++ b/corpora/apply_fixes/adv_label_key.tex
@@ -14,9 +14,14 @@
 % It needs a MULTI-CHARACTER subscript: eq:a_b is left alone, eq:lower_bound is
 % not. A single-character variant of this fixture would be VACUOUS.
 %
-% Region 4 of Fix_guard (cross-reference key arguments) is the fix. Until then
-% this is recorded as a known defect so the class is measured rather than merely
-% believed to be absent.
+% Region 4 of Fix_guard (cross-reference key arguments) is the fix, and it has
+% now SHIPPED. This document stops being a recorded defect and becomes the pin
+% for that region: the key must survive --apply-fixes in BOTH the default and
+% pilot profiles, and the emitted document must still compile.
+%
+% Keep the multi-character subscript above. Region 4 protects the key GROUP, not
+% the whole command, so a fixture that only exercised \label's optional
+% argument or the surrounding prose would pass with the region disabled.
 \documentclass{article}
 \usepackage{amsmath}
 \begin{document}

--- a/corpora/apply_fixes/manifest.json
+++ b/corpora/apply_fixes/manifest.json
@@ -17,38 +17,6 @@
   },
   "known_broken": [
     {
-      "doc": "corpora/apply_fixes/adv_label_key.tex",
-      "mode": "default:--apply-fixes",
-      "breaks_compile": true,
-      "degrades_verdict": false,
-      "not_idempotent": false,
-      "manufactured_false_ready": true
-    },
-    {
-      "doc": "corpora/apply_fixes/adv_label_key.tex",
-      "mode": "default:--apply-fixes-best-effort",
-      "breaks_compile": false,
-      "degrades_verdict": false,
-      "not_idempotent": true,
-      "manufactured_false_ready": false
-    },
-    {
-      "doc": "corpora/apply_fixes/adv_label_key.tex",
-      "mode": "pilot:--apply-fixes",
-      "breaks_compile": true,
-      "degrades_verdict": false,
-      "not_idempotent": false,
-      "manufactured_false_ready": true
-    },
-    {
-      "doc": "corpora/apply_fixes/adv_label_key.tex",
-      "mode": "pilot:--apply-fixes-best-effort",
-      "breaks_compile": false,
-      "degrades_verdict": false,
-      "not_idempotent": true,
-      "manufactured_false_ready": false
-    },
-    {
       "doc": "corpora/compile_check/good_quotes_dashes.tex",
       "mode": "default:--apply-fixes-best-effort",
       "breaks_compile": false,

--- a/latex-parse/src/fix_guard.ml
+++ b/latex-parse/src/fix_guard.ml
@@ -4,19 +4,23 @@
 
    Regions implemented, all purely lexical: 1. control symbol arguments, 2.
    TikZ/PGF picture bodies, 3a. filename arguments, 3b. package-spec arguments,
-   5. tabular/array column preambles.
+   4. cross-reference key arguments, 5. tabular/array column preambles.
 
-   Regions NOT yet covered, in measured-damage order, and — this part matters —
-   with UNEQUAL evidence behind them: 4. key arguments (\label \ref \cite ...,
-   also the SCRIPT-001->007 cascade). NO fixture exists for this class anywhere
-   in the corpora, so the round-trip gate is SILENT on it. Its absence from the
-   gate's baseline is not evidence that it is harmless; it is evidence that
-   nobody has measured it. A key-argument corruption would ship with every gate
-   green. 5. tabular/array preamble. This one IS measured: good_longtable_free
-   under the pilot profile occupies two rows of
-   corpora/apply_fixes/manifest.json and is, after region 3, the ONLY remaining
-   manufactured false-READY. An earlier version of this comment claimed both
-   classes were fixture-tracked. Only region 5 is. *)
+   Every region is now fixture-tracked in corpora/apply_fixes/, and as of region
+   4 the manifest records ZERO breaks_compile and ZERO manufactured_false_ready
+   rows: the three that remain are not_idempotent under
+   --apply-fixes-best-effort, which is that flag's documented single-pass
+   contract rather than damage.
+
+   That is a statement about the CORPUS, not about the fixer. Two things it does
+   NOT mean. First, nothing in proofs/ constrains this module — `grep -rlniE
+   'fix_guard|apply_fixes' proofs/` returns nothing, and the Cst_edit theorems
+   are about the edit APPLIER under a non-overlap hypothesis, not about what a
+   producer chooses to rewrite. Second, the CANDIDATE channel
+   (--list-candidate-fixes) does not route through this module at all, so its
+   offers are unguarded and unmeasured. Absence from the baseline is evidence
+   that nobody has measured a class, not that the class is harmless — the
+   argument that put region 4 here in the first place. *)
 
 let is_letter c = (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')
 
@@ -172,6 +176,147 @@ let package_arg_cmds =
     "LoadClass";
     "LoadClassWithOptions";
   ]
+
+(* ── Region 4: cross-reference KEY arguments ──────────────────────────────
+
+   A cross-reference key is an opaque token string, not prose. TeX turns it into
+   a \csname, so any byte a typography rule rewrites there changes which label
+   is defined or referenced — and \text inside \csname is a hard error.
+
+   Measured (corpora/apply_fixes/adv_label_key.tex, TL2026): SCRIPT-001 rewrites
+   the multi-character subscript eq:lower_bound -> eq:lower_{bound}, SCRIPT-007
+   then -> eq:lower_{\text{bound}}, and pdflatex goes 0 -> 1 with "! Missing
+   \endcsname inserted", producing NO PDF — while --compile-check reports READY
+   on BOTH sides. A manufactured false-READY, in the DEFAULT profile, from the
+   tool asked to improve the document.
+
+   ⚠ RANGE SHAPE. This region protects the KEY GROUP ONLY — from its opening
+   brace to one past the matching close — and NOT the whole command the way
+   regions 3a/3b do. Both reasons are load-bearing:
+
+   * The optional argument of these commands is TYPESET.
+   \bibitem[Smith--Jones]{k} renders the bracket text as the bibliography label;
+   \citep[see][pp.~5--7]{k} renders both notes. A backslash-anchored range
+   swallows them and silently kills legitimate dash and quote fixes in every
+   real bibliography. * A backslash-anchored range starts exactly where package
+   INSERTERS insert. REF-011 emits its \usepackage insertion at the byte after
+   \documentclass's newline, which in three of its four registered goldens IS
+   the \autoref backslash; [intersects] counts a point on a range's INCLUSIVE
+   start as inside, so the legitimate fix would be withheld and
+   check_producer_coverage.py would go red. Anchoring at the key group's brace
+   puts every such insertion strictly before the range.
+
+   Completeness is unaffected: [filter] tests an edit's WHOLE span, so an edit
+   touching a key byte is blocked no matter where it starts.
+
+   Commands whose FIRST brace group is the key. Whole-name matched, so
+   \citetext, \crefname, \creflabelformat, \crefalias and \citestyle — whose
+   arguments are formats, not keys — never match. *)
+let crossref_key1_cmds =
+  [
+    (* kernel + amsmath *)
+    "label";
+    "ref";
+    "pageref";
+    "eqref";
+    "cite";
+    "nocite";
+    "bibitem";
+    (* hyperref / nameref *)
+    "autoref";
+    "autopageref";
+    "nameref";
+    "Nameref";
+    "hypertarget";
+    "hyperlink";
+    (* cleveref *)
+    "cref";
+    "Cref";
+    "cpageref";
+    "Cpageref";
+    "labelcref";
+    "labelcpageref";
+    "namecref";
+    "nameCref";
+    "lcnamecref";
+    "namecrefs";
+    "nameCrefs";
+    "lcnamecrefs";
+    (* varioref *)
+    "vref";
+    "Vref";
+    "vpageref";
+    "vpagerefnearby";
+    "fullref";
+    (* natbib *)
+    "citep";
+    "citet";
+    "Citep";
+    "Citet";
+    "citealt";
+    "citealp";
+    "Citealt";
+    "Citealp";
+    "citeauthor";
+    "Citeauthor";
+    "citeyear";
+    "citeyearpar";
+    "citefullauthor";
+    "citenum";
+    "citetalias";
+    "citepalias";
+    "defcitealias";
+    "shortcites";
+    (* biblatex *)
+    "parencite";
+    "Parencite";
+    "textcite";
+    "Textcite";
+    "autocite";
+    "Autocite";
+    "footcite";
+    "Footcite";
+    "footcitetext";
+    "Footcitetext";
+    "smartcite";
+    "Smartcite";
+    "supercite";
+    "Supercite";
+    "fullcite";
+    "footfullcite";
+    "notecite";
+    "Notecite";
+    "pnotecite";
+    "Pnotecite";
+    "fnotecite";
+    "Fnotecite";
+    "citetitle";
+    "citedate";
+    "citeurl";
+  ]
+
+(* Commands whose first TWO brace groups are keys; any later group is prose and
+   stays exposed (\vpagerefcompare{l1}{l2}{true}{false}). *)
+let crossref_key2_cmds =
+  [
+    "crefrange";
+    "Crefrange";
+    "cpagerefrange";
+    "Cpagerefrange";
+    "vrefrange";
+    "vpagerefrange";
+    "vpagerefcompare";
+  ]
+
+(* DELIBERATELY OMITTED, because their arity cannot be confirmed from a shipped
+   .sty and guessing an arity is exactly how a range ends up MISPLACED — the one
+   failure mode this module must never produce. None occurs anywhere in
+   corpora/**/*.tex. Revisit with the package sources in hand: \href{url}{text}
+   — the url is load-bearing but is not a key \hyperdef[k]{cat}{name}{text}
+   biblatex multicites \cites \parencites \textcites \footcites \smartcites
+   \supercites \autocites — unbounded (pre)(post)[p][q]{k}...
+   \volcite[pre]{volume}[page]{key} — key is group TWO \citefield \citelist
+   \citename — \citename has two incompatible contracts. *)
 
 let is_blank c = c = ' ' || c = '\t' || c = '\n' || c = '\r'
 
@@ -398,6 +543,124 @@ let preamble_ranges (src : string) : (int * int) list =
         (find_all src b))
     preamble_envs
 
+(* End of the command's own paragraph: the offset of the first blank line at or
+   after [p], or [n]. Bounds the key search, so a BARE mention of \ref or \cite
+   in running prose cannot reach forward into the next paragraph and protect an
+   unrelated brace group. Region 3 bounds the same hazard at end of LINE; this
+   one must be looser, because \cite followed by a newline and then {key} is
+   idiomatic. *)
+let paragraph_end (src : string) (n : int) (p : int) : int =
+  let i = ref p and stop = ref (-1) in
+  while !stop < 0 && !i < n do
+    if String.unsafe_get src !i = '\n' then (
+      let j = ref (!i + 1) in
+      while
+        !j < n
+        && (String.unsafe_get src !j = ' '
+           || String.unsafe_get src !j = '\t'
+           || String.unsafe_get src !j = '\r')
+      do
+        incr j
+      done;
+      if !j < n && String.unsafe_get src !j = '\n' then stop := !i);
+    incr i
+  done;
+  if !stop >= 0 then !stop else n
+
+(* (start, one-past-end) of each of the first [want] brace groups after [p0],
+   skipping a leading star, any [...] option groups, blanks and comments.
+
+   On a SHORTFALL — fewer than [want] groups before the paragraph ends, or a
+   group that never closes — returns the groups it did find rather than []. They
+   are a genuine PREFIX of the key groups, because groups are consumed in order
+   and group i is a key for every i <= want, so a partial answer is over-wide at
+   worst and never MISPLACED. Per the polarity note in the .mli that is the safe
+   direction: refusing outright would leave every key of a malformed \crefrange
+   exposed, which is strictly worse than protecting the one group that is really
+   there. A command with no group at all still yields []. *)
+let scan_key_groups (src : string) (n : int) (p0 : int) ~(want : int) :
+    (int * int) list =
+  let limit = paragraph_end src n p0 in
+  let p = ref p0 in
+  let q0 = skip_blanks_and_comments src n !p in
+  if q0 < n && String.unsafe_get src q0 = '*' then p := q0 + 1;
+  let got = ref [] and count = ref 0 and go = ref true in
+  while !go do
+    let q = skip_blanks_and_comments src n !p in
+    if q >= limit || q >= n then go := false
+    else
+      match String.unsafe_get src q with
+      | '[' -> (
+          match opt_group_end src n q with
+          | Some e -> p := e
+          | None -> go := false)
+      | '{' -> (
+          match brace_group_end src n q with
+          | Some e ->
+              got := (q, e) :: !got;
+              incr count;
+              p := e;
+              if !count >= want then go := false
+          | None -> go := false)
+      | _ -> go := false
+  done;
+  List.rev !got
+
+(* \hyperref has INVERTED polarity, and two arities.
+
+   \hyperref[key]{link text} — the OPTIONAL group is the key and the brace group
+   is TYPESET. \hyperref{URL}{category}{name}{text} — groups 1-3 are opaque and
+   group 4 is typeset.
+
+   Listing \hyperref with the key1 commands would protect the link text and
+   EXPOSE the key: precisely the category error that hid a $a^b^c$ double
+   superscript behind \hyperref's optional argument (round-7 rank 7, fixture
+   fr_hyperref_linktext), run in reverse. Both directions verified under the
+   pin: \hyperref[fig:a_{\text{b}}]{link} exits 1 "! Missing \endcsname
+   inserted", and \hyperref[k]{$a^b^c$} exits 1 "! Double superscript".
+
+   cleveref's \label[type]{key} optional is a counter-type KEYWORD rather than
+   prose, so skipping it above costs nothing. *)
+let hyperref_key_ranges (src : string) (n : int) (k : int) : (int * int) list =
+  let q = skip_blanks_and_comments src n k in
+  if q < n && String.unsafe_get src q = '[' then
+    match opt_group_end src n q with Some e -> [ (q, e) ] | None -> []
+  else scan_key_groups src n k ~want:3
+
+(* One linear pass, whole-name dispatch. Advances past the last group it
+   consumed, so a command sitting inside an argument this pass already covered
+   is not rescanned. *)
+let crossref_ranges (src : string) : (int * int) list =
+  let n = String.length src in
+  let acc = ref [] and i = ref 0 in
+  while !i < n do
+    if String.unsafe_get src !i = '\\' && !i + 1 < n then
+      if is_letter (String.unsafe_get src (!i + 1)) then (
+        let st = !i + 1 in
+        let j = ref st in
+        while !j < n && is_letter (String.unsafe_get src !j) do
+          incr j
+        done;
+        let name = String.sub src st (!j - st) in
+        let rs =
+          if String.equal name "hyperref" then hyperref_key_ranges src n !j
+          else if List.mem name crossref_key1_cmds then
+            scan_key_groups src n !j ~want:1
+          else if List.mem name crossref_key2_cmds then
+            scan_key_groups src n !j ~want:2
+          else []
+        in
+        match rs with
+        | [] -> i := !j
+        | _ ->
+            acc := List.rev_append rs !acc;
+            i := List.fold_left (fun a (_, e) -> max a e) !j rs)
+      else (* Control SYMBOL: step past both bytes. *)
+        i := !i + 2
+    else incr i
+  done;
+  List.rev !acc
+
 let argument_ranges (src : string) : (int * int) list * (int * int) list =
   let n = String.length src in
   let fns = ref [] and pkgs = ref [] in
@@ -437,6 +700,7 @@ type regions = {
   filename : (int * int) list;
   package_spec : (int * int) list;
   preamble : (int * int) list;
+  crossref : (int * int) list;
 }
 
 let compute_regions (src : string) : regions =
@@ -447,6 +711,7 @@ let compute_regions (src : string) : regions =
     filename;
     package_spec;
     preamble = preamble_ranges src;
+    crossref = crossref_ranges src;
   }
 
 (* One-entry memo keyed on the buffer's PHYSICAL identity.
@@ -472,7 +737,12 @@ let regions_of (src : string) : regions =
 let protected_ranges (src : string) : (int * int) list =
   let r = regions_of src in
   let rs =
-    r.control_symbol @ r.picture @ r.filename @ r.package_spec @ r.preamble
+    r.control_symbol
+    @ r.picture
+    @ r.filename
+    @ r.package_spec
+    @ r.preamble
+    @ r.crossref
   in
   List.sort (fun (a, _) (b, _) -> compare a b) rs
 
@@ -528,11 +798,17 @@ let filter ~(src : string) ~(rule_id : string) (edits : Cst_edit.t list) :
       (* Exemptions are PER REGION, never global. A control-symbol-aware rule
          still gets the picture, filename and package regions; a package-aware
          reorderer is still blocked from filenames and TikZ paths. Nothing is
-         ever exempt from regions 2 and 3a. *)
+         ever exempt from regions 2, 3a and 4.
+
+         Region 4 belongs in the ALWAYS-ON list below, not appended after the
+         trailing [if ... else [ r.package_spec ]]: there are no parentheses
+         there, so an appended element would parse as part of the else branch
+         and region 4 would silently become conditional on the package-spec
+         exemption. *)
       let active =
         (if List.mem rule_id control_symbol_aware then []
          else [ r.control_symbol ])
-        @ [ r.picture; r.filename; r.preamble ]
+        @ [ r.picture; r.filename; r.preamble; r.crossref ]
         @ if List.mem rule_id package_spec_aware then [] else [ r.package_spec ]
       in
       let blocked span =

--- a/latex-parse/src/fix_guard.mli
+++ b/latex-parse/src/fix_guard.mli
@@ -68,6 +68,19 @@ val package_spec_aware : string list
     end and therefore outside it, so the region never withholds them — a
     property the coverage gate checks rather than one this list asserts. *)
 
+(* No [crossref_aware] list exists, and its absence is deliberate rather than an
+   omission: no rule reaching {!filter} has editing a cross-reference key as its
+   contract. The only fix-channel consumption site is [collect_fix_edits] in
+   validators_cli.ml, which reads [r.fix]; every key-editing rule in the tool
+   (REF-002/003/004/005/007) is built with [mk_result_with_candidates] and so
+   travels the CANDIDATE channel, which does not call this module. The ten rules
+   measured writing inside keys — SCRIPT-001, SCRIPT-007, MATH-009, TYPO-001,
+   TYPO-002, TYPO-005, TYPO-013, TYPO-018 and the pilot-only TYPO-023, TYPO-052
+   — are all doing so by ACCIDENT, which is the damage region 4 exists to stop.
+
+   If candidates are ever auto-applied through {!filter}, those five REF ids are
+   the initial exemption list. *)
+
 val filter : src:string -> rule_id:string -> Cst_edit.t list -> Cst_edit.t list
 (** [filter ~src ~rule_id edits] — drop every edit whose half-open span
     intersects a protected range of [src].

--- a/latex-parse/src/test_fix_guard.ml
+++ b/latex-parse/src/test_fix_guard.ml
@@ -286,6 +286,163 @@ let () =
         (survives "\\begin{tabular}{ll\n\nprose -- here\n" "-- here")
         (tag ^ ": unbalanced group yields None, not a short range"));
 
+  (* ── Region 4: cross-reference key arguments ─────────────────────────────
+
+     The key is an opaque token string: TeX turns it into a \csname, so any byte
+     rewritten there changes which label is referenced, and \text inside \csname
+     is a hard error. Measured in corpora/apply_fixes/adv_label_key.tex.
+
+     Range shape matters as much as coverage here. This region protects the KEY
+     GROUP ONLY, never the whole command, because the OPTIONAL argument of these
+     commands is typeset (\bibitem's bracket becomes the bibliography label) and
+     because a backslash-anchored range starts exactly where REF-011 inserts its
+     \usepackage line. Both directions are pinned below. *)
+  List.iter
+    (fun cmd ->
+      run
+        ("the key argument of \\" ^ cmd ^ " is protected")
+        (fun tag ->
+          expect
+            (not (survives ("\\" ^ cmd ^ "{eq:a--b}\n") "--"))
+            (tag ^ ": key bytes are syntax, not prose")))
+    [
+      "label";
+      "ref";
+      "eqref";
+      "pageref";
+      "autoref";
+      "nameref";
+      "cref";
+      "Cref";
+      "vref";
+      "cite";
+      "citep";
+      "citet";
+      "nocite";
+      "bibitem";
+      "hypertarget";
+      "hyperlink";
+      "parencite";
+      "textcite";
+      "labelcref";
+      "citeauthor";
+    ];
+
+  run "the measured SCRIPT-001 subscript shape is withheld" (fun tag ->
+      expect
+        (not
+           (survives ~rule_id:"SCRIPT-001" "\\label{eq:lower_bound}\n" "_bound"))
+        (tag ^ ": the adv_label_key.tex corruption"));
+
+  run "optional groups are consumed before the key" (fun tag ->
+      expect
+        (not (survives "\\cite[see][p.~5]{k--y}\n" "--"))
+        (tag ^ ": [..] groups skipped, key still found"));
+
+  run "the starred form is consumed" (fun tag ->
+      expect
+        (not (survives "\\ref*{a--b}\n" "--"))
+        (tag ^ ": leading star skipped"));
+
+  run "both keys of a range command are protected" (fun tag ->
+      expect
+        (not (survives "\\crefrange{a--b}{c--d}\n" "a--b"))
+        (tag ^ ": first key");
+      expect
+        (not (survives "\\crefrange{a--b}{c--d}\n" "c--d"))
+        (tag ^ ": second key"));
+
+  run "a comment between the command and its key is skipped" (fun tag ->
+      expect
+        (not (survives "\\cite%c\n{a--b}\n" "--"))
+        (tag ^ ": TeX swallows the comment before reading the argument"));
+
+  (* ── Region 4 must NOT become a blanket refusal ─────────────────────── *)
+  run "prose after a label is still fixable" (fun tag ->
+      expect
+        (survives "\\label{a}\n\nprose -- here\n" "-- here")
+        (tag ^ ": only the key group is protected"));
+
+  run "the TYPESET optional of bibitem is still fixable" (fun tag ->
+      expect
+        (survives "\\bibitem[Smith--Jones]{k}\n" "--")
+        (tag ^ ": the bracket is the rendered label, not a key"));
+
+  run "the TYPESET notes of citep are still fixable" (fun tag ->
+      expect
+        (survives "\\citep[see][pp.~5--7]{k}\n" "--")
+        (tag ^ ": both notes are rendered"));
+
+  run "a bare \\ref does not protect the next paragraph" (fun tag ->
+      expect
+        (survives "see \\ref\n\nprose -- here\n" "-- here")
+        (tag ^ ": the key search stops at the blank line"));
+
+  run "citetext is not a key command" (fun tag ->
+      expect
+        (survives "\\citetext{see -- p.~5}\n" "--")
+        (tag ^ ": whole-name match, its argument is prose"));
+
+  run "crefname arguments are not keys" (fun tag ->
+      expect
+        (survives "\\crefname{equation}{eq.~--}{eqs.}\n" "--")
+        (tag ^ ": those are display formats"));
+
+  (* ── \hyperref has INVERTED polarity ─────────────────────────────────── *)
+  run "the hyperref OPTIONAL key is protected" (fun tag ->
+      expect
+        (not (survives "\\hyperref[fig:a--b]{See figure}\n" "--"))
+        (tag ^ ": the bracket is the key here"));
+
+  run "the hyperref LINK TEXT is still fixable" (fun tag ->
+      expect
+        (survives "\\hyperref[k]{See figure -- here}\n" "-- here")
+        (tag ^ ": the brace group is typeset — the rank-7 lesson, inverted"));
+
+  run "the four-argument hyperref exposes only its link text" (fun tag ->
+      expect
+        (not (survives "\\hyperref{u--l}{c}{n}{t}\n" "u--l"))
+        (tag ^ ": groups 1-3 are opaque");
+      expect
+        (survives "\\hyperref{url}{c}{n}{text -- here}\n" "-- here")
+        (tag ^ ": group 4 is typeset"));
+
+  (* ── Sentinels for the range-shape decision ──────────────────────────── *)
+  run "REF-011's package insertion at the \\autoref backslash survives"
+    (fun tag ->
+      let src = "\\documentclass{article}\n\\autoref{x}\n" in
+      expect
+        (insertion_survives ~rule_id:"REF-011" src (find_sub src "\\autoref"))
+        (tag
+        ^ ": a backslash-anchored range would withhold this and redden \
+           check_producer_coverage"));
+
+  run "a package-aware rule is still blocked inside a key" (fun tag ->
+      expect
+        (not (survives ~rule_id:"PKG-002" "\\label{a--b}\n" "--"))
+        (tag ^ ": exemptions are per region, never global"));
+
+  (* ── Refusal shapes: shortfall protects NOTHING, never a partial range ── *)
+  run "an unclosed key group protects nothing" (fun tag ->
+      expect
+        (survives "\\label{eq:x\n\nprose -- here\n" "-- here")
+        (tag ^ ": refusing is only ever today's behaviour"));
+
+  run "a SHORTFALL still protects the groups that are really there" (fun tag ->
+      (* \crefrange wants two keys and this malformed call has one. Returning []
+         would leave that one key exposed; the prefix is a genuine key group, so
+         protecting it is the safe direction. This is the case that
+         distinguishes partial-protect from refuse-on-shortfall — without it,
+         either implementation passes. *)
+      expect
+        (not (survives "\\crefrange{a--b}\n\nprose here\n" "--"))
+        (tag ^ ": the one key present is still a key"));
+
+  run "a non-group after the command protects nothing" (fun tag ->
+      expect
+        (survives "\\ref\\relax\n\nprose -- here\n" "-- here")
+        (tag ^ ": no brace group, so no range"));
+
   (* ── Regions 1 and 2 still hold (guard against a refactor regression) ── *)
   run "control symbol argument is still protected" (fun tag ->
       let src = "\\`a and -- here\n" in

--- a/scripts/tools/check_verbatim_safety.py
+++ b/scripts/tools/check_verbatim_safety.py
@@ -87,6 +87,14 @@ REGIONS = [
     # closing brace is still found.
     ("include-filename", b"\\input{SREG_FA", b"SREG_FB}\n"),
     ("package-spec", b"\\usepackage{SREG_PA", b"SREG_PB}\n"),
+    # R7-3 region 4: cross-reference KEY arguments. TeX turns a key into a
+    # \csname, so a rewritten byte changes which label is referenced and a
+    # \text synthesised inside one is a hard error -- measured in
+    # corpora/apply_fixes/adv_label_key.tex, where the fixer took pdflatex 0 -> 1
+    # while --compile-check said READY on both sides. Note the region protects
+    # the KEY GROUP only, never the whole command, so this plants the battery
+    # inside the braces exactly as the two argument regions above do.
+    ("xref-key", b"\\label{SREG_KA", b"SREG_KB}\n"),
 ]
 
 


### PR DESCRIPTION
## The class

A cross-reference key is an opaque token string, not prose. TeX turns it into a `\csname`, so any byte a typography rule rewrites there changes which label is referenced — and a `\text` synthesised inside one is a hard error.

Measured in `corpora/apply_fixes/adv_label_key.tex` against the pinned engine:

```
SCRIPT-001:  eq:lower_bound  →  eq:lower_{bound}
SCRIPT-007:                  →  eq:lower_{\text{bound}}
pdflatex:    0 → 1   "! Missing \endcsname inserted"   no PDF
--compile-check: READY on BOTH sides
```

A manufactured false-READY, in the **default** profile, produced by the tool asked to improve the document.

## Result

`corpora/apply_fixes/manifest.json`, re-recorded with real pdflatex:

| | before | after |
|---|---|---|
| known_broken rows | 7 | **3** |
| `breaks_compile` | 2 | **0** |
| `manufactured_false_ready` | 2 | **0** |

The three survivors are `not_idempotent` under `--apply-fixes-best-effort` — that flag's documented single-pass contract, not damage.

This is a statement about the **corpus**, not a proof about the fixer. Nothing in `proofs/` constrains this module (`grep -rlniE 'fix_guard|apply_fixes' proofs/` → nothing), and the **candidate channel still bypasses it entirely**. Both caveats are now written into the module header rather than left implicit.

## ⚠ Range shape *is* the design

Region 4 protects the **key group only** — the opening brace to one past its match — not the whole command the way regions 3a/3b do. Both reasons are load-bearing:

1. **The optional argument is TYPESET.** `\bibitem[Smith--Jones]{k}` renders the bracket as the bibliography label; `\citep[see][pp.~5--7]{k}` renders both notes. A backslash-anchored range swallows them and silently kills legitimate dash and quote fixes in every real bibliography.
2. **A backslash-anchored range starts exactly where package inserters insert.** REF-011 emits its `\usepackage` insertion at the byte after `\documentclass`'s newline — which in **three of its four registered goldens is the `\autoref` backslash**. `intersects` counts a point on a range's *inclusive start* as inside, so the legitimate fix would be withheld and `check_producer_coverage.py` would go red. There's a unit test pinning exactly this.

## ⚠ `\hyperref` has inverted polarity

`\hyperref[key]{link text}` — the **bracket** is the key, the **brace** is typeset. Without a bracket it's `\hyperref{URL}{cat}{name}{text}`, groups 1–3 opaque.

Listing it with the ordinary key commands would protect the link text and **expose the key** — the rank-7 `fr_hyperref_linktext` category error, run backwards. It gets its own branch, tested in both directions.

## Departure from the design note: shortfall semantics

When fewer than `want` groups are found, `scan_key_groups` returns the groups it **did** find rather than `[]`. Refusing would leave every key of a malformed `\crefrange{a}` exposed, whereas the groups found are a genuine prefix (groups are consumed in order, so group *i* is a key for every *i ≤ want*) and protecting them is over-wide at worst, never misplaced — the direction `fix_guard.mli`'s polarity note mandates.

Note a test using only *unclosed* or *absent* groups cannot distinguish the two implementations. The distinguishing case is `\crefrange{a--b}` with one group, and it's in the suite.

## No `crossref_aware` exemption list

The `.mli` records **why**, so the absence isn't rediscovered later: every key-editing rule (`REF-002/003/004/005/007`) is Bucket-C and travels the candidate channel, which doesn't call this module. The ten rules measured writing inside keys are all doing so by accident.

## Verification — both directions

- **Fixture**: key survives in *both* profiles; emitted document now compiles (rc=0, PDF produced).
- **Second, independent document**: all **41** cross-reference keys in `corpora/lint/i18n_qa/i18n_qa_sv_paper.tex` preserved, while the fixer still changes the document elsewhere.
- **`test_fix_guard` 47 → 88 cases.** Four injections, each failing with its named signal:

| injection | failures |
|---|---|
| region 4 removed from `filter` | 7 |
| refuse-on-shortfall | 1 |
| `\hyperref` dispatched as an ordinary key command | 2 (one per polarity) |
| region 4 appended after `filter`'s trailing `if/else` (would become conditional on the package-spec exemption) | 1 |

- **Round-trip gate** failed first with *"recorded as broken but is now CLEAN"* in all four cells, then passed after `--record`. Re-recorded only after confirming `pdflatex --version` matches the pin byte-for-byte, with all four manifest invariants checked by hand.
- **New `check_verbatim_safety.py` sentinel region (7 → 8)**, battery planted inside `\label{}`. Non-vacuity shown directly: the *identical* battery is **preserved** inside `\label{...}` and **mutated** (en dash, `\dots`, curly quotes) in plain prose.

Full pre-push checklist green: `dune build` · `dune runtest` (rc 0, zero failures) · `check_producer_coverage.py` (167 × 1022) · `check_verbatim_safety.py` (8 regions) · ocamlformat fixpoint · `check_apply_fixes_roundtrip.py` with real pdflatex (73 docs × 4 cells) · `git ls-files` = 1668.

Independent of #535 (different files).