### PR TITLE
docs: stop calling --apply-fixes "proven-safe" — it is guard-gated, not proven

### DIFF
--- a/.github/workflows/spec-drift.yml
+++ b/.github/workflows/spec-drift.yml
@@ -121,6 +121,15 @@ jobs:
         # restating a stale count.
         run: python3 scripts/tools/check_roadmap_facts.py --repo .
 
+      - name: Fix-safety language (v27.1.63)
+        # No document may call the AUTO-FIX channel "proven-safe". Until
+        # v27.1.63 four places did, while `grep -rlniE 'fix_guard|apply_fixes'
+        # proofs/` returned nothing and corpora/apply_fixes/manifest.json
+        # recorded rows where --apply-fixes took a compiling document to a
+        # non-compiling one. check_doc_refs.py cannot see this class: its scope
+        # is path existence, not claims.
+        run: python3 scripts/tools/check_fix_safety_language.py --repo .
+
       - name: Doc version-label currency (v27.0.68.2)
         # Headings/stamps that name a version or fix-producer count
         # ("Current State (vN)", "latest tag vN", "N as of vN", ...) must

--- a/README.md
+++ b/README.md
@@ -43,14 +43,14 @@ dune exec latex-parse/src/validators_cli.exe -- paper.tex
 dune exec latex-parse/src/validators_cli.exe -- --layer l0 paper.tex
 dune exec latex-parse/src/validators_cli.exe -- --layer l2 paper.tex
 
-# Apply the mechanical (Bucket-A) auto-fixes in place
+# Apply the mechanical (Bucket-A) auto-fixes (writes to stdout, not in place)
 dune exec latex-parse/src/validators_cli.exe -- --apply-fixes paper.tex
 
 # List the review-only (Bucket-C) candidate fixes for an editor to offer
 dune exec latex-parse/src/validators_cli.exe -- --list-candidate-fixes paper.tex
 ```
 
-`--apply-fixes` applies only the proven-safe auto-fixes; intent-dependent
+`--apply-fixes` applies only the guard-gated auto-fixes; intent-dependent
 suggestions are surfaced separately via `--list-candidate-fixes` and never applied
 automatically. See [docs/CANDIDATE_FIXES.md](docs/CANDIDATE_FIXES.md).
 

--- a/docs/CANDIDATE_FIXES.md
+++ b/docs/CANDIDATE_FIXES.md
@@ -4,7 +4,7 @@ LaTeX-Perfectionist splits fixable rules into two channels:
 
 | Channel | Field on `result` | Applied by | Bucket |
 |---|---|---|---|
-| **Auto-fix** | `fix : Cst_edit.t list option` | `--apply-fixes` / `--apply-fixes-for` | A (mechanical, deterministic, always safe) |
+| **Auto-fix** | `fix : Cst_edit.t list option` | `--apply-fixes` / `--apply-fixes-for` | A (mechanical, deterministic, guard-gated) |
 | **Candidate** | `candidate_fixes : candidate_fix list` | never auto-applied — surfaced for author review | C (context/intent-dependent) |
 
 A **candidate fix** is a *suggested* edit whose correctness depends on author
@@ -82,7 +82,22 @@ set. See `Validators_common.candidates_drop_exempt` / `candidates_drop_vcu_exemp
 
 ## Rationale
 
-Auto-fixes (Bucket A) are proven byte-safe and applied silently. Candidates
-(Bucket C) require judgment, so they are surfaced only. This keeps `--apply-fixes`
-corruption-free while still offering the full breadth of assisted edits through a
-review surface. See `specs/v27/V27_FIX_PRODUCER_CADENCE.md` for the bucket model.
+Auto-fixes (Bucket A) are **guard-gated, not proven**, and applied silently.
+Candidates (Bucket C) require judgment, so they are surfaced only.
+
+The distinction matters, because "proven" was the word here and nothing in
+`proofs/` justifies it: `grep -rlniE 'fix_guard|apply_fixes' proofs/` returns
+nothing. The `Cst_edit` theorems are about the edit APPLIER under a non-overlap
+hypothesis — they say nothing about whether the bytes a producer chose to rewrite
+were safe to rewrite. What actually constrains the fixer is empirical and lives in
+two places: `Fix_guard` withholds edits landing in load-bearing byte ranges
+(control symbols, TikZ paths, filename and package arguments, cross-reference
+keys, tabular preambles), and `corpora/apply_fixes/manifest.json` records the
+residual damage measured against real pdflatex. That manifest currently records
+zero `breaks_compile` and zero `manufactured_false_ready` rows — a measurement
+over that corpus, not a guarantee over your document.
+
+⚠ The candidate channel is NOT guard-gated. `--list-candidate-fixes` prints its
+byte offers unfiltered, so an offer may land inside a protected region; review
+before applying. See `specs/v27/V27_FIX_PRODUCER_CADENCE.md` for the bucket
+model.

--- a/docs/v27/ROADMAP.md
+++ b/docs/v27/ROADMAP.md
@@ -15,7 +15,7 @@ Running `pdflatex` gives **ground truth** — but only the answer to "did *this*
 **The wedge is the *combination* a compiler structurally cannot provide:**
 
 1. **REAL-TIME / incremental.** Sub-second, as-you-type. A compiler is inherently batch — it cannot run per keystroke. Our verified kernel can.
-2. **PRECISE, LOCALIZED, EXPLAINED diagnosis + safe fix.** pdflatex says "it failed" cryptically, often at the *wrong* line. We say exactly **what**, **where**, and **why**, and can **suggest or apply a proven-safe fix**. This is arguably the *stronger* wedge — it leverages the whole 660-rule engine + `--explain` + **167** fix-producers + **124** candidates, none of which a compiler has.
+2. **PRECISE, LOCALIZED, EXPLAINED diagnosis + safe fix.** pdflatex says "it failed" cryptically, often at the *wrong* line. We say exactly **what**, **where**, and **why**, and can **suggest or apply a guard-gated fix**. This is arguably the *stronger* wedge — it leverages the whole 660-rule engine + `--explain` + **167** fix-producers + **124** candidates, none of which a compiler has.
 3. **MACHINE-CHECKED TRUST.** A READY that is *provably never wrong in the safe direction*, so a high-stakes or automated consumer can **rely on it without re-compiling**. The value here is **trust-for-automation**. No competitor has it: texlab / ChkTeX / lacheck are heuristic; Overleaf just runs the compiler.
 4. **POLICY BEYOND COMPILABILITY.** A compiler only checks "does it compile." Our rule engine also checks "does this respect **this editor's template / house style / submission policy**" — provably, at scale, localized, **without a per-submission compile.**
 

--- a/scripts/tools/check_fix_safety_language.py
+++ b/scripts/tools/check_fix_safety_language.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Gate: no document may claim the AUTO-FIX channel is *proven* safe.
+
+Why this exists. Until v27.1.63 the repo said, in four separate places, that
+`--apply-fixes` applies "proven-safe" / "proven byte-safe" / "always safe"
+auto-fixes. Nothing in proofs/ justified any of it:
+
+    $ grep -rlniE 'fix_guard|apply_fixes' proofs/
+    (nothing)
+
+The Cst_edit theorems that do exist are about the edit APPLIER under a
+non-overlap hypothesis; they say nothing about whether the bytes a producer
+chose to rewrite were safe to rewrite. Meanwhile the fixer was demonstrably
+corrupting documents: corpora/apply_fixes/manifest.json recorded rows where
+--apply-fixes took a compiling document to a non-compiling one while
+--compile-check reported READY on both sides.
+
+What IS true is empirical and should be said that way: Fix_guard withholds edits
+landing in load-bearing byte ranges, and the round-trip corpus measures the
+residual against real pdflatex. "Guard-gated", not "proven".
+
+The banned vocabulary is deliberately narrow -- words that assert a PROOF, plus
+the two absolutes. Weaker empirical phrasing ("corruption-free" about one
+specific mechanical swap) is left alone; this gate is about the word "proven",
+not about confidence in general.
+
+A hit only fails when the sentence is actually ABOUT the auto-fix channel
+(SCOPE) and is not talking about the review-only candidate channel (EXEMPT),
+which genuinely never mutates a document.
+
+Exit 1 on any violation.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+BANNED = re.compile(
+    r"proven[-\s]?(byte[-\s]?)?safe|provably[-\s]?safe|verified[-\s]?safe"
+    r"|guaranteed[-\s]?safe|always safe|safe everywhere",
+    re.I)
+
+SCOPE = re.compile(r"--apply-fixes|auto[-\s]?fix|bucket[-\s]?A|fix[-\s]producer", re.I)
+
+# Deliberately NARROW, and matched on the OFFENDING LINE ONLY.
+#
+# An earlier version matched bare "candidate"/"surfaced" across a +/-2 line
+# window and caught 1 of 4 restored claims: these documents discuss both channels
+# in adjacent lines, and ROADMAP:18 names "124 candidates" in a COUNT on the very
+# same line as its claim about applying fixes. A window-scoped exemption reads
+# every one of those as "this sentence is about candidates" and goes quiet.
+#
+# So the exemption must be a phrase that actually SCOPES the claim to the
+# review-only channel, not merely a mention of it.
+EXEMPT = re.compile(
+    r"never auto[-\s]?appl|review[-\s]only|surfaced only|candidate channel"
+    r"|not auto[-\s]?appl", re.I)
+
+# Historical release notes and archives are a RECORD of what was believed at the
+# time. Rewriting them would be dishonest in the other direction, and editing
+# CHANGELOG risks check_release_integrity.
+SKIP_PARTS = ("CHANGELOG.md", "/archive/", "docs/archive/", "proofs/archive/")
+
+SCAN_SUFFIXES = (".md",)
+SCAN_ROOTS = ("README.md", "docs", "specs")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--repo", default=".")
+    ns = ap.parse_args()
+    repo = Path(ns.repo).resolve()
+
+    files: list[Path] = []
+    for root in SCAN_ROOTS:
+        p = repo / root
+        if p.is_file():
+            files.append(p)
+        elif p.is_dir():
+            files.extend(q for q in p.rglob("*") if q.suffix in SCAN_SUFFIXES)
+    files = [f for f in files if not any(s in str(f) for s in SKIP_PARTS)]
+
+    # Non-vacuity. A gate that silently scans nothing reports PASS forever; this
+    # repo shipped one that did exactly that for 185 days.
+    if len(files) < 20:
+        print(f"FAIL: scanned only {len(files)} document(s) — refusing to pass "
+              f"vacuously. Check SCAN_ROOTS.", file=sys.stderr)
+        return 1
+
+    findings: list[str] = []
+    for f in sorted(files):
+        lines = f.read_text(errors="replace").split("\n")
+        for i, line in enumerate(lines):
+            m = BANNED.search(line)
+            if not m:
+                continue
+            # SCOPE may be established by nearby context (a heading, the line
+            # above), but EXEMPT must be on the offending line itself -- see the
+            # note on EXEMPT for why a windowed exemption silences real hits.
+            window = "\n".join(lines[max(0, i - 2): i + 3])
+            if not SCOPE.search(window) or EXEMPT.search(line):
+                continue
+            findings.append(
+                f"{f.relative_to(repo)}:{i + 1}: {m.group(0)!r} — "
+                f"the auto-fix channel is guard-gated, not proven. "
+                f"Nothing in proofs/ constrains it.\n      {line.strip()[:120]}")
+
+    if findings:
+        print(f"[fix-safety-language] FAIL: {len(findings)} unproven safety "
+              f"claim(s) about the auto-fix channel", file=sys.stderr)
+        for x in findings:
+            print(f"  - {x}", file=sys.stderr)
+        return 1
+
+    print(f"[fix-safety-language] PASS: {len(files)} documents carry no "
+          f"proof-claim about the auto-fix channel")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tools/check_gates_meta.py
+++ b/scripts/tools/check_gates_meta.py
@@ -52,6 +52,7 @@ GATE_SCRIPTS = [
     # v27.1.63: required-status-check topology (duplicate context / job-name
     # collision / orphaned requirement).
     ("scripts/tools/check_workflow_triggers.py", ["--repo", "."]),
+    ("scripts/tools/check_fix_safety_language.py", ["--repo", "."]),
     ("scripts/tools/check_perf_ratchet.py",
      ["--repo", ".", "--skip-exec", "--input", "/dev/null"]),
 ]

--- a/scripts/tools/generate_fix_producer_ledger.py
+++ b/scripts/tools/generate_fix_producer_ledger.py
@@ -328,7 +328,7 @@ def build_ledger(all_rules: list[str]) -> str:
     out.append("| Bucket | Description | Count | Shipped | Remaining |")
     out.append("|--------|-------------|-------|---------|-----------|")
     out.append(
-        f"| **A**  | Mechanical, safe everywhere       | {buckets['A']} | {statuses['shipped']} | {buckets['A']-statuses['shipped']} |"
+        f"| **A**  | Mechanical, guard-gated           | {buckets['A']} | {statuses['shipped']} | {buckets['A']-statuses['shipped']} |"
     )
     out.append(f"| **B**  | Sentence-aware (NLP-required)     | {buckets['B']} | 0 | {buckets['B']} |")
     out.append(

--- a/specs/v27/FIX_PRODUCER_LEDGER.md
+++ b/specs/v27/FIX_PRODUCER_LEDGER.md
@@ -20,7 +20,7 @@ The pre-release gate `check_fix_producer_ledger.py` runs the generator with
 
 | Bucket | Description | Count | Shipped | Remaining |
 |--------|-------------|-------|---------|-----------|
-| **A**  | Mechanical, safe everywhere       | 466 | 167 | 299 |
+| **A**  | Mechanical, guard-gated           | 466 | 167 | 299 |
 | **B**  | Sentence-aware (NLP-required)     | 49 | 0 | 49 |
 | **C**  | Context-required (--apply-fixes-with-prompt) | 83 | 0 | 83 |
 | **D**  | Defer indefinitely (compile/runtime) | 62 | 0 | 62 |

--- a/specs/v27/V27_FIX_PRODUCER_CADENCE.md
+++ b/specs/v27/V27_FIX_PRODUCER_CADENCE.md
@@ -28,7 +28,7 @@ release cycle**, taking ~1 session per producer in batched form.
 
 The 628 remaining rules split by feasibility:
 
-### Bucket A — mechanical, safe everywhere (~200–300 rules)
+### Bucket A — mechanical, guard-gated (~200–300 rules)
 Pattern-based regex / byte-level fixes that don't require sentence
 detection or semantic context. Examples:
 - TYPO-NN whitespace normalization between specific token pairs


### PR DESCRIPTION
## The claim, and why it's false

Four documents said the auto-fix channel was *proven* or *always* safe.

```
$ grep -rlniE 'fix_guard|apply_fixes' proofs/
(nothing)
```

The `Cst_edit` theorems that *do* exist are about the edit **applier** under a non-overlap hypothesis — `ApplyEditsAssoc.v` proves permutation-invariance over `bytes := list nat`; `RewritePreservesSemantics.v` covers whitespace-only edits against a toy tokenizer where `token := nat`. Neither says anything about whether the bytes a producer **chose** to rewrite were safe to rewrite, which is the entire question. `docs/COMPILATION_GUARANTEE_STACK.md` still lists "Fix preservation theorems" as an unbuilt T6 item.

Meanwhile the fixer was demonstrably corrupting documents: until region 4 (#536), `corpora/apply_fixes/manifest.json` recorded `--apply-fixes` taking `adv_label_key.tex` from compiling to not-compiling **in the default profile**, while `--compile-check` reported READY on both sides.

## The edits

| file:line | old | new |
|---|---|---|
| `README.md:53` | `proven-safe` | `guard-gated` |
| `README.md:46` | "in place" | "writes to stdout, not in place" |
| `docs/CANDIDATE_FIXES.md:7` | `always safe` | `guard-gated` |
| `docs/CANDIDATE_FIXES.md:85` | *rationale rewritten* | see below |
| `docs/v27/ROADMAP.md:18` | `proven-safe` | `guard-gated` |
| `V27_FIX_PRODUCER_CADENCE.md:31` | `safe everywhere` | `guard-gated` |
| `FIX_PRODUCER_LEDGER.md:23` | `safe everywhere` | `guard-gated` |

…plus **`generate_fix_producer_ledger.py:331`**, which emits that last row — otherwise a regeneration silently restores the old wording.

`README.md:46` is a **factual** bug, not a wording one: `--apply-fixes` writes to stdout and leaves the file untouched (`validators_cli.ml` prints at `:274/:287/:418`; the only `open_out` is the `--audit` path).

The `CANDIDATE_FIXES.md` rationale is rewritten rather than word-swapped, because the paragraph's whole argument rested on the word "proven". It now says what actually constrains the fixer, that the manifest records zero `breaks_compile` / zero `manufactured_false_ready` rows, that this is **a measurement over that corpus and not a guarantee over your document** — and, prominently, that **the candidate channel is not guard-gated at all**.

## Deliberately not touched

`CHANGELOG.md` and `docs/archive/**` (a record of what was believed at the time — rewriting history is dishonest in the other direction, and editing CHANGELOG risks `check_release_integrity`); `ROADMAP:274`'s "conservative over-invalidation is always safe" (about incremental invalidation, not the fixer); and the per-rule "corruption-free" assessments in `REMAINING_FIXABILITY_AUDIT.md`, which are specific empirical claims about lookup-table swaps rather than proof claims.

## New gate — so it can't come back

`scripts/tools/check_fix_safety_language.py`, wired into the **required** `spec-drift` job and registered in `check_gates_meta.py` (16 scripts). `check_doc_refs.py` can't catch this class — its scope is path existence, not claims.

**Verified in both directions — and the first version failed that check.** With `EXEMPT` matched over a ±2-line window it caught only **one of four** restored claims: these documents discuss both channels in adjacent lines, and `ROADMAP:18` names "124 candidates" in a count on the *very same line* as its claim. The exemption is now line-local and narrow — a phrase that actually **scopes** a claim to the review-only channel, not a bare mention of one.

| restored claim | exit |
|---|---|
| `README.md` | 1 |
| `docs/CANDIDATE_FIXES.md` | 1 |
| `docs/v27/ROADMAP.md` | 1 |
| `V27_FIX_PRODUCER_CADENCE.md` | 1 |
| `FIX_PRODUCER_LEDGER.md` | 1 |
| clean tree (96 documents) | **0** |

It also refuses to pass vacuously if it scans fewer than 20 files.

All seven required `spec-drift` doc gates pass locally. Zero application code touched.