### PR TITLE
chore(OPEN-011): refresh the real-paper measurement and gate its provenance

### DIFF
--- a/corpora/real_roots/results.json
+++ b/corpora/real_roots/results.json
@@ -12,8 +12,8 @@
   "n": 200
  },
  "counts": {
-  "true-READY": 107,
-  "false-NOT-READY": 75,
+  "true-READY": 125,
+  "false-NOT-READY": 57,
   "true-NOT-READY": 6,
   "FALSE-READY": 11,
   "ungraded-infra": 1
@@ -98,16 +98,13 @@
    "sha256_tree": "58db035cd5458a6be1a53f5605b36a35bb6a27144ce980f8399d658c3a63948f",
    "bytes": 56727,
    "size_bucket": "10-100KB",
-   "cli_rc": 1,
-   "cli_verdict": "NOT-READY",
-   "cli_reasons": [
-    "DELIM-007",
-    "T5"
-   ],
+   "cli_rc": 0,
+   "cli_verdict": "READY",
+   "cli_reasons": [],
    "pdflatex_rc": 0,
    "first_error": "",
    "pdflatex_verdict": "COMPILES",
-   "cell": "false-NOT-READY"
+   "cell": "true-READY"
   },
   {
    "arxiv_id": "2506.17634v2",
@@ -188,15 +185,13 @@
    "sha256_tree": "329923b32565ecde0b956b6661ca39c71d5b6337aefe919cff409ef63201006f",
    "bytes": 57355,
    "size_bucket": "10-100KB",
-   "cli_rc": 1,
-   "cli_verdict": "NOT-READY",
-   "cli_reasons": [
-    "T4"
-   ],
+   "cli_rc": 0,
+   "cli_verdict": "READY",
+   "cli_reasons": [],
    "pdflatex_rc": 0,
    "first_error": "",
    "pdflatex_verdict": "COMPILES",
-   "cell": "false-NOT-READY"
+   "cell": "true-READY"
   },
   {
    "arxiv_id": "2506.20361v1",
@@ -207,15 +202,13 @@
    "sha256_tree": "5699f440a53515cd7a84c8d1a199498afa37ca3abb6042173bb1c7c3744a351e",
    "bytes": 50250,
    "size_bucket": "10-100KB",
-   "cli_rc": 1,
-   "cli_verdict": "NOT-READY",
-   "cli_reasons": [
-    "T4"
-   ],
+   "cli_rc": 0,
+   "cli_verdict": "READY",
+   "cli_reasons": [],
    "pdflatex_rc": 0,
    "first_error": "",
    "pdflatex_verdict": "COMPILES",
-   "cell": "false-NOT-READY"
+   "cell": "true-READY"
   },
   {
    "arxiv_id": "2506.12904v1",
@@ -378,8 +371,7 @@
    "cli_rc": 1,
    "cli_verdict": "NOT-READY",
    "cli_reasons": [
-    "T3",
-    "T4"
+    "T3"
    ],
    "pdflatex_rc": 0,
    "first_error": "",
@@ -398,8 +390,7 @@
    "cli_rc": 1,
    "cli_verdict": "NOT-READY",
    "cli_reasons": [
-    "T2",
-    "T4"
+    "T2"
    ],
    "pdflatex_rc": 0,
    "first_error": "",
@@ -503,16 +494,13 @@
    "sha256_tree": "6537a08e8ee31dfdceeca5d7f739f2d9f022175fc468753ed9e6931f1312ab6d",
    "bytes": 52111,
    "size_bucket": "10-100KB",
-   "cli_rc": 1,
-   "cli_verdict": "NOT-READY",
-   "cli_reasons": [
-    "DELIM-007",
-    "T5"
-   ],
+   "cli_rc": 0,
+   "cli_verdict": "READY",
+   "cli_reasons": [],
    "pdflatex_rc": 0,
    "first_error": "",
    "pdflatex_verdict": "COMPILES",
-   "cell": "false-NOT-READY"
+   "cell": "true-READY"
   },
   {
    "arxiv_id": "2506.20191v1",
@@ -665,16 +653,13 @@
    "sha256_tree": "c03e70617b72966f637b2fe083a9cbe93f5a02536ecd0dc973c82d660b444c02",
    "bytes": 85906,
    "size_bucket": "10-100KB",
-   "cli_rc": 1,
-   "cli_verdict": "NOT-READY",
-   "cli_reasons": [
-    "DELIM-007",
-    "T5"
-   ],
+   "cli_rc": 0,
+   "cli_verdict": "READY",
+   "cli_reasons": [],
    "pdflatex_rc": 0,
    "first_error": "",
    "pdflatex_verdict": "COMPILES",
-   "cell": "false-NOT-READY"
+   "cell": "true-READY"
   },
   {
    "arxiv_id": "2507.09118v1",
@@ -910,7 +895,6 @@
    "cli_verdict": "NOT-READY",
    "cli_reasons": [
     "DELIM-003",
-    "DELIM-007",
     "T2",
     "T5"
    ],
@@ -948,8 +932,7 @@
    "cli_rc": 1,
    "cli_verdict": "NOT-READY",
    "cli_reasons": [
-    "T3",
-    "T4"
+    "T3"
    ],
    "pdflatex_rc": 0,
    "first_error": "",
@@ -965,15 +948,13 @@
    "sha256_tree": "6975200ddd1708d326b1b0bf4a00a1cefd95fac992075510d7c0b06404107e1d",
    "bytes": 105397,
    "size_bucket": ">100KB",
-   "cli_rc": 1,
-   "cli_verdict": "NOT-READY",
-   "cli_reasons": [
-    "T4"
-   ],
+   "cli_rc": 0,
+   "cli_verdict": "READY",
+   "cli_reasons": [],
    "pdflatex_rc": 0,
    "first_error": "",
    "pdflatex_verdict": "COMPILES",
-   "cell": "false-NOT-READY"
+   "cell": "true-READY"
   },
   {
    "arxiv_id": "2507.01405v1",
@@ -1071,15 +1052,13 @@
    "sha256_tree": "5ad4795a377919abbb81aeab31ff53919c57d4a4744d0aa11be9317ccac370f1",
    "bytes": 99314,
    "size_bucket": "10-100KB",
-   "cli_rc": 1,
-   "cli_verdict": "NOT-READY",
-   "cli_reasons": [
-    "T4"
-   ],
+   "cli_rc": 0,
+   "cli_verdict": "READY",
+   "cli_reasons": [],
    "pdflatex_rc": 0,
    "first_error": "",
    "pdflatex_verdict": "COMPILES",
-   "cell": "false-NOT-READY"
+   "cell": "true-READY"
   },
   {
    "arxiv_id": "2507.08995v1",
@@ -1293,7 +1272,6 @@
    "cli_reasons": [
     "ENC-012",
     "T2",
-    "T4",
     "T5"
    ],
    "pdflatex_rc": 0,
@@ -1543,15 +1521,13 @@
    "sha256_tree": "e1143e961d5cf4d10b6e646daa0686a6ee914db854393bf82880b114de2a5f2f",
    "bytes": 157497,
    "size_bucket": ">100KB",
-   "cli_rc": 1,
-   "cli_verdict": "NOT-READY",
-   "cli_reasons": [
-    "T4"
-   ],
+   "cli_rc": 0,
+   "cli_verdict": "READY",
+   "cli_reasons": [],
    "pdflatex_rc": 0,
    "first_error": "",
    "pdflatex_verdict": "COMPILES",
-   "cell": "false-NOT-READY"
+   "cell": "true-READY"
   },
   {
    "arxiv_id": "2507.10855v1",
@@ -1706,15 +1682,13 @@
    "sha256_tree": "38d9b1a553bf595defba4b85cf8a9e880a5d3eff479bd75f98591cb867246c98",
    "bytes": 77970,
    "size_bucket": "10-100KB",
-   "cli_rc": 1,
-   "cli_verdict": "NOT-READY",
-   "cli_reasons": [
-    "T4"
-   ],
+   "cli_rc": 0,
+   "cli_verdict": "READY",
+   "cli_reasons": [],
    "pdflatex_rc": 0,
    "first_error": "",
    "pdflatex_verdict": "COMPILES",
-   "cell": "false-NOT-READY"
+   "cell": "true-READY"
   },
   {
    "arxiv_id": "2507.00983v1",
@@ -1759,15 +1733,13 @@
    "sha256_tree": "8627301435fec8a9c5c85d433b18013ed2c318ab49c1e21817c6f53ab0f6a17f",
    "bytes": 37908,
    "size_bucket": "10-100KB",
-   "cli_rc": 1,
-   "cli_verdict": "NOT-READY",
-   "cli_reasons": [
-    "T4"
-   ],
+   "cli_rc": 0,
+   "cli_verdict": "READY",
+   "cli_reasons": [],
    "pdflatex_rc": 0,
    "first_error": "",
    "pdflatex_verdict": "COMPILES",
-   "cell": "false-NOT-READY"
+   "cell": "true-READY"
   },
   {
    "arxiv_id": "2507.07038v1",
@@ -1900,8 +1872,7 @@
    "cli_rc": 1,
    "cli_verdict": "NOT-READY",
    "cli_reasons": [
-    "T3",
-    "T4"
+    "T3"
    ],
    "pdflatex_rc": 0,
    "first_error": "",
@@ -2156,16 +2127,13 @@
    "sha256_tree": "ae94059b31428aad88b7bee0e1a98f8ff4d1b33a475a44dc8ed1337a1e7fdd6c",
    "bytes": 30719,
    "size_bucket": "10-100KB",
-   "cli_rc": 1,
-   "cli_verdict": "NOT-READY",
-   "cli_reasons": [
-    "DELIM-007",
-    "T5"
-   ],
+   "cli_rc": 0,
+   "cli_verdict": "READY",
+   "cli_reasons": [],
    "pdflatex_rc": 0,
    "first_error": "",
    "pdflatex_verdict": "COMPILES",
-   "cell": "false-NOT-READY"
+   "cell": "true-READY"
   },
   {
    "arxiv_id": "2507.10318v1",
@@ -2195,15 +2163,13 @@
    "sha256_tree": "9e51dac9d8293c6126413e7b1f086df0f0767fa37ccc84d7395ca8ba1cf8c88c",
    "bytes": 52426,
    "size_bucket": "10-100KB",
-   "cli_rc": 1,
-   "cli_verdict": "NOT-READY",
-   "cli_reasons": [
-    "T4"
-   ],
+   "cli_rc": 0,
+   "cli_verdict": "READY",
+   "cli_reasons": [],
    "pdflatex_rc": 0,
    "first_error": "",
    "pdflatex_verdict": "COMPILES",
-   "cell": "false-NOT-READY"
+   "cell": "true-READY"
   },
   {
    "arxiv_id": "2506.22536v1",
@@ -2305,7 +2271,6 @@
    "cli_verdict": "NOT-READY",
    "cli_reasons": [
     "DELIM-001",
-    "T4",
     "T5"
    ],
    "pdflatex_rc": 0,
@@ -2400,8 +2365,7 @@
    "cli_verdict": "NOT-READY",
    "cli_reasons": [
     "T2",
-    "T3",
-    "T4"
+    "T3"
    ],
    "pdflatex_rc": 0,
    "first_error": "",
@@ -2417,16 +2381,13 @@
    "sha256_tree": "555f48bf1e82a97340b85a690bbbb4238a8c0fc0fef9add4dcc37b4ad2c02c44",
    "bytes": 108329,
    "size_bucket": ">100KB",
-   "cli_rc": 1,
-   "cli_verdict": "NOT-READY",
-   "cli_reasons": [
-    "DELIM-007",
-    "T5"
-   ],
+   "cli_rc": 0,
+   "cli_verdict": "READY",
+   "cli_reasons": [],
    "pdflatex_rc": 0,
    "first_error": "",
    "pdflatex_verdict": "COMPILES",
-   "cell": "false-NOT-READY"
+   "cell": "true-READY"
   },
   {
    "arxiv_id": "2507.04190v1",
@@ -2741,7 +2702,6 @@
     "PRT-001",
     "T0",
     "T3",
-    "T4",
     "T5"
    ],
    "pdflatex_rc": 0,
@@ -2865,10 +2825,8 @@
    "cli_rc": 1,
    "cli_verdict": "NOT-READY",
    "cli_reasons": [
-    "DELIM-007",
     "PRT-001",
     "T0",
-    "T4",
     "T5"
    ],
    "pdflatex_rc": 0,
@@ -3096,16 +3054,13 @@
    "sha256_tree": "15c63e53a9695e8ac2a71c11d81c90269ef92556624966071a8bd61867eb17b6",
    "bytes": 109670,
    "size_bucket": ">100KB",
-   "cli_rc": 1,
-   "cli_verdict": "NOT-READY",
-   "cli_reasons": [
-    "DELIM-007",
-    "T5"
-   ],
+   "cli_rc": 0,
+   "cli_verdict": "READY",
+   "cli_reasons": [],
    "pdflatex_rc": 0,
    "first_error": "",
    "pdflatex_verdict": "COMPILES",
-   "cell": "false-NOT-READY"
+   "cell": "true-READY"
   },
   {
    "arxiv_id": "2507.10078v1",
@@ -3154,15 +3109,13 @@
    "sha256_tree": "9f903c8aa266571a1fc03fe9be6399a16cdf02158bdf06a00ae47ddf379d4386",
    "bytes": 55085,
    "size_bucket": "10-100KB",
-   "cli_rc": 1,
-   "cli_verdict": "NOT-READY",
-   "cli_reasons": [
-    "T4"
-   ],
+   "cli_rc": 0,
+   "cli_verdict": "READY",
+   "cli_reasons": [],
    "pdflatex_rc": 0,
    "first_error": "",
    "pdflatex_verdict": "COMPILES",
-   "cell": "false-NOT-READY"
+   "cell": "true-READY"
   },
   {
    "arxiv_id": "2507.06861v1",
@@ -3209,16 +3162,13 @@
    "sha256_tree": "72fb883331e98289c6c5fa885fbf9eca6e27b73ebf9185269af4c668b3fd737d",
    "bytes": 109364,
    "size_bucket": ">100KB",
-   "cli_rc": 1,
-   "cli_verdict": "NOT-READY",
-   "cli_reasons": [
-    "DELIM-007",
-    "T5"
-   ],
+   "cli_rc": 0,
+   "cli_verdict": "READY",
+   "cli_reasons": [],
    "pdflatex_rc": 0,
    "first_error": "",
    "pdflatex_verdict": "COMPILES",
-   "cell": "false-NOT-READY"
+   "cell": "true-READY"
   },
   {
    "arxiv_id": "2507.09001v1",
@@ -3337,16 +3287,13 @@
    "sha256_tree": "1da1fee36ac537c899dc53913632fac165151c0ff64b843e8482b5597af15d31",
    "bytes": 52101,
    "size_bucket": "10-100KB",
-   "cli_rc": 1,
-   "cli_verdict": "NOT-READY",
-   "cli_reasons": [
-    "DELIM-007",
-    "T5"
-   ],
+   "cli_rc": 0,
+   "cli_verdict": "READY",
+   "cli_reasons": [],
    "pdflatex_rc": 0,
    "first_error": "",
    "pdflatex_verdict": "COMPILES",
-   "cell": "false-NOT-READY"
+   "cell": "true-READY"
   },
   {
    "arxiv_id": "2507.09980v1",
@@ -3578,16 +3525,13 @@
    "sha256_tree": "f104e9b1ec5101c4889f0e5a13d289d87d6722a6d405d7e890db48f8f1c394ca",
    "bytes": 44968,
    "size_bucket": "10-100KB",
-   "cli_rc": 1,
-   "cli_verdict": "NOT-READY",
-   "cli_reasons": [
-    "DELIM-007",
-    "T5"
-   ],
+   "cli_rc": 0,
+   "cli_verdict": "READY",
+   "cli_reasons": [],
    "pdflatex_rc": 0,
    "first_error": "",
    "pdflatex_verdict": "COMPILES",
-   "cell": "false-NOT-READY"
+   "cell": "true-READY"
   },
   {
    "arxiv_id": "2507.07602v1",
@@ -3657,5 +3601,7 @@
    "pdflatex_verdict": "COMPILES",
    "cell": "true-READY"
   }
- ]
+ ],
+ "measured_at_sha": "443ec7c15f51a5c1eb107c9e12bb855aca73759f",
+ "measured_at": "cli-only refresh; pdflatex verdicts carried forward"
 }

--- a/docs/v27/PROJECT_STATE.md
+++ b/docs/v27/PROJECT_STATE.md
@@ -56,15 +56,15 @@ Oracle `pdfTeX 3.141592653-2.6-1.40.29`, TeX Live 2026, protocol `-interaction=n
 
 | cell | n |
 |---|---|
-| true-READY | 107 |
+| true-READY | 125 |
 | true-NOT-READY | 6 |
 | FALSE-READY | 11 |
-| false-NOT-READY | 75 |
+| false-NOT-READY | 57 |
 | ungraded-infra | 1 |
 | ungraded-timeout | 0 |
 
-- **Correct verdicts: 113/199 = 56.8%**
-- **Over-rejection: 75/199 = 37.7%** — i.e. **92.6% of every NOT-READY verdict issued on a real paper is wrong**
+- **Correct verdicts: 131/199 = 65.8%**
+- **Over-rejection: 57/199 = 28.6%** — i.e. **90.5% of every NOT-READY verdict issued on a real paper is wrong**
 - **False-READY: 11/199 = 5.5%**, against a definition requiring zero
 
 ### Fixer residual (auto-fix channel)
@@ -123,7 +123,7 @@ Size: S ≤ a day · M ≤ a week · L multi-week · XL multi-month.
 | OPEN-008 | OVERREJ | **T4 duplicate-`\label` polarity** — 9 rescue-alone, all 9 compile. pdflatex only warns and exits 0. | same | S |
 | OPEN-009 | OVERREJ | **REAL, but the obvious fix MANUFACTURES A FALSE-READY — re-sized S → L.** The gap is real: `compile_gate_checks.ml`'s opt-skip loop accepts `' '`/`\t`/`\n`/`\r`/`[` but not `*`, so in math `\ref*{sec:x_a_b}` is NOT-READY while `\ref{...}` is READY. ⚠ **Do NOT just add `*`.** That makes the detector SKIP the span, and a document whose `\ref` is redefined in an `\input` CHILD (`\renewcommand{\ref}[1]{\textbf{#1}}`) then typesets the key: today NOT-READY with pdflatex rc 1 `! Double subscript.` and no PDF — **after the patch, READY**. Measured yield of the cheap patch is **zero**: 0 of 200 sampled papers and 0 of 2,961 in the frame change verdict. A safe fix must resolve `\ref` redefinition across the INCLUDE CLOSURE (and `\let`), not scan the root — hence L. Net of the cheap version: strictly negative. | **VERIFIED 2026-08-22** — both the gap and the refutation reproduced end-to-end | L |
 | OPEN-010 | OVERREJ | **DELIM-001 / DELIM-003 residual precision** — 2 and 1 rescue-alone, all compile. Unlike DELIM-007 these ARE real error classes, so the fix is precision, not demotion. | verified 2026-08-22 | M |
-| OPEN-011 | INSTR | **`corpora/real_roots` is ungated.** No workflow reads it; an ungated measurement decays exactly as the 65-doc banner did. Gate false-READY *set membership*, not a numeric over-rejection bound. | no workflow references it | M |
+| OPEN-011 | INSTR | **Real-paper measurement provenance — ADDRESSED.** `results.json` now records `measured_at_sha`, `diff_real_roots.py --refresh-cli` recomputes only the CLI verdict (asserting corpus shas and the engine pin, so pdflatex verdicts may be carried forward), and `check_project_state` fails when more than 5 commits touching `latex-parse/src` land after the measurement. ⚠ Still OPEN: nothing re-measures in CI, because the corpus is 12 GB of non-redistributable arXiv source. The ratchet bounds decay; it does not eliminate it. | **VERIFIED 2026-08-23** — ratchet fires at 8 commits, passes at 5 | M |
 | OPEN-012 | INSTR | **Extend 200 → 400** and publish the new-class discovery rate. Every instrument so far found more (round-7 +30, Aug audit +6, this corpus +2). It is the only real test of "is the residual enumerable". | — | L |
 | OPEN-013 | GATE | **No gate compares any version marker to a git tag.** 33 commits past `v27.1.62` with 11 green required contexts. | `git describe` vs `dune-project` | S |
 | OPEN-014 | HONEST | **`per_rule_soundness_count: 643`** is `rules.total_non_reserved` copied verbatim; the 803 generated theorems are 803/803 identical one-line instantiations of a `flat_map` triviality; `theorem_count_reported: 1543` vs 1456 line-anchored. | `generate_project_facts.py:104` | M |
@@ -162,6 +162,8 @@ out to be false, plus how it was caught, so the same mistake is not repeated.
 | C-13 | A generated block should carry every fact worth knowing, including release debt. | `git describe` changes on **every commit**, so the regenerate-and-diff gate fired on the very next one. A gate that fires on every PR trains people to regenerate without reading, which is worse than no gate. Volatile facts belong in prose as an instruction, not in a diffed block. | The gate failing on my own next commit. |
 | C-14 | OPEN-009's `\ref*` gap was "a one-character fix", cheap and safe. | **Strictly negative as scoped.** Adding `*` to the opt-skip makes the detector skip the span, and a document whose `\ref` is redefined in an `\input` child goes from correctly NOT-READY (pdflatex rc 1, no PDF) to READY. Measured yield of the "fix": **0 of 200** and **0 of 2,961**. So it trades a manufactured false-READY for nothing. | An adversarial agent tasked with REFUTING each "no false-READY risk" claim, then reproduced by hand. The ledger had been instructing the patch. |
 | C-15 | The `\verb` scanner's only defect was the optional-argument delimiter. | There is a third: the delimiter is read at a FIXED offset, but TeX absorbs a space after a control word. `X \verb |ab| Y` compiles with `|` as delimiter while the scanner takes the space. A "fix" that re-implements the same offset rule in the re-key inherits the bug. | Same hunt. |
+| C-16 | The generated-block gate meant the published position was correct. | It only proved the block matched its SOURCE. `results.json` went **three PRs stale** while the gate passed, publishing **56.8%** when main measured **65.8%**. A source-of-truth needs provenance on its sources, not just consistency with them. | Noticing the headline disagreed with a number I had measured an hour earlier. |
+| C-17 | A broad `except Exception` around a file read is harmless defensive coding. | It swallowed a `NameError` (`json` was never imported) and reported **"no measured_at_sha"** — a plausible, entirely wrong diagnostic that sent me inspecting the data instead of the code. Catch only what can genuinely go wrong; a broad except converts a programming error into a convincing finding. | The gate reporting a field missing that I could see was present. |
 
 ---
 

--- a/scripts/tools/check_project_state.py
+++ b/scripts/tools/check_project_state.py
@@ -28,6 +28,7 @@ Exit 1 on any violation.
 from __future__ import annotations
 
 import argparse
+import json
 import re
 import subprocess
 import sys
@@ -39,6 +40,9 @@ BEGIN = "<!-- BEGIN GENERATED: measured-position -->"
 END = "<!-- END GENERATED: measured-position -->"
 MIN_OPEN = 10
 MIN_CORRECTIONS = 5
+# Commits touching latex-parse/src that may land before the real-paper
+# measurement must be refreshed. Deliberately not 0: see C-13.
+MAX_MEASUREMENT_LAG = 5
 
 
 def main() -> int:
@@ -101,6 +105,55 @@ def main() -> int:
         if len(cells) < 3 or cells[-1] not in {"S", "M", "L", "XL"}:
             findings.append(f"{oid}: size must be one of S/M/L/XL, got "
                             f"{cells[-1] if cells else '(none)'!r}")
+
+    # ── 2b. the MEASUREMENT itself must not be silently stale ────────────
+    #
+    # The generated block is checked against its source, but nothing checked
+    # whether the SOURCE was current. It went three PRs stale while this gate
+    # passed, publishing 56.8% when main measured 65.8% — the block correctly
+    # matched a results.json that was simply out of date.
+    #
+    # This cannot re-measure (CI has no corpus, by design — it is 12 GB of
+    # non-redistributable arXiv source), so it checks PROVENANCE: results.json
+    # records the sha it was measured at, and this counts commits touching
+    # latex-parse/src since then.
+    #
+    # It is a RATCHET, not a treadmill. Failing on every source change would
+    # train people to refresh without reading, which is the failure mode C-13
+    # records. The threshold allows normal churn and stops long-term decay.
+    rr = repo / "corpora/real_roots/results.json"
+    if rr.is_file():
+        # Catch only what can genuinely go wrong with reading a JSON file. A
+        # bare `except Exception` here swallowed a NameError (json was not
+        # imported) and reported "no measured_at_sha" — a WRONG diagnostic that
+        # sent me looking at the data instead of the code. A broad except turns
+        # a programming error into a plausible-looking finding.
+        try:
+            sha = json.loads(rr.read_text()).get("measured_at_sha")
+        except (json.JSONDecodeError, OSError) as exc:
+            findings.append(f"corpora/real_roots/results.json is unreadable: {exc}")
+            sha = "unreadable"
+        if not sha:
+            findings.append(
+                "corpora/real_roots/results.json has no measured_at_sha, so its "
+                "staleness cannot be checked. Refresh with:\n"
+                "      python3 scripts/tools/diff_real_roots.py --repo . --refresh-cli")
+        else:
+            r = subprocess.run(
+                ["git", "--no-optional-locks", "rev-list", "--count",
+                 f"{sha}..HEAD", "--", "latex-parse/src"],
+                cwd=repo, capture_output=True, text=True)
+            if r.returncode == 0 and r.stdout.strip().isdigit():
+                behind = int(r.stdout.strip())
+                if behind > MAX_MEASUREMENT_LAG:
+                    findings.append(
+                        f"the real-paper measurement is {behind} commits behind "
+                        f"HEAD on latex-parse/src (limit {MAX_MEASUREMENT_LAG}). "
+                        f"The published position is probably wrong. Refresh:\n"
+                        f"      python3 scripts/tools/diff_real_roots.py --repo . "
+                        f"--refresh-cli\n"
+                        f"    A CLI-only refresh is valid while the corpus and "
+                        f"engine are unchanged — it asserts both.")
 
     # ── 3. the corrections log must not be empty ─────────────────────────
     m = re.search(r"^##\s*4\..*?corrections log.*?$(.*?)^##\s", text,

--- a/scripts/tools/diff_real_roots.py
+++ b/scripts/tools/diff_real_roots.py
@@ -216,6 +216,93 @@ def run_one(rec: dict, root: Path, cli: Path, timeout: int) -> dict:
     return out
 
 
+def refresh_cli_only(repo: Path, root: Path, outdir: Path, banner: str,
+                     timeout: int) -> int:
+    """Recompute ONLY the CLI verdict, reusing the recorded pdflatex results.
+
+    A full run recompiles 200 papers with pdflatex and takes ~20 minutes. That
+    is the right thing when the CORPUS or the ENGINE changed. It is waste when
+    only the tool changed — and the tool changes constantly, which is why
+    results.json went three PRs stale and the published headline read 56.8%
+    while main measured 65.8%.
+
+    The shortcut is sound under exactly two conditions, and BOTH are asserted
+    here rather than assumed:
+
+      * the corpus is unchanged — every paper's sha256_tree still matches the
+        manifest, so the documents are byte-identical;
+      * the engine is unchanged — pdflatex --version still matches the pin.
+
+    Given those, a pdflatex verdict is a property of the DOCUMENT, not of our
+    binary, so it can be carried forward. The CLI verdict cannot, so it is
+    recomputed. If either condition fails this refuses and tells you to run the
+    full sweep.
+    """
+    results_path = outdir / "results.json"
+    manifest_path = outdir / "manifest.json"
+    if not results_path.is_file() or not manifest_path.is_file():
+        return die(2, "no recorded results to refresh — run a full sweep first")
+    res = json.loads(results_path.read_text())
+    man = {d["arxiv_id"]: d for d in json.loads(manifest_path.read_text())["docs"]}
+
+    if res["oracle"]["version"] not in banner:
+        return die(3, f"engine skew: recorded {res['oracle']['version']!r}, local "
+                      f"{banner!r}. A CLI-only refresh cannot carry pdflatex "
+                      f"verdicts across an engine change — run the full sweep.")
+
+    cli = repo / "_build/default/latex-parse/src/validators_cli.exe"
+    env = dict(os.environ, L0_VALIDATORS="pilot")
+    changed = []
+    for i, d in enumerate(res["docs"], 1):
+        rec = man.get(d["arxiv_id"])
+        if rec is None:
+            return die(2, f"{d['arxiv_id']} missing from the manifest")
+        if sha256_tree(root / d["arxiv_id"]) != rec["sha256_tree"]:
+            return die(2, f"{d['arxiv_id']}: tree sha differs from the manifest — "
+                          f"the corpus changed, so pdflatex verdicts cannot be "
+                          f"carried forward. Run the full sweep.")
+        top = root / d["arxiv_id"] / d["toplevel"]
+        try:
+            r = subprocess.run([str(cli), "--compile-check", str(top)],
+                               capture_output=True, timeout=timeout, env=env)
+            rc = r.returncode
+            reasons = sorted(set(re.findall(r"\b(T\d|[A-Z]{2,8}-\d{3})\b",
+                                            r.stdout.decode("utf-8", "replace"))))
+        except subprocess.TimeoutExpired:
+            return die(2, f"{d['arxiv_id']}: CLI timeout — the run is void")
+        before = d["cell"]
+        d["cli_rc"], d["cli_verdict"] = rc, ("READY" if rc == 0 else "NOT-READY")
+        d["cli_reasons"] = reasons
+        if d["cell"].startswith("ungraded"):
+            pass                                   # infra/timeout stays as recorded
+        else:
+            compiles = d["pdflatex_rc"] == 0
+            ready = rc == 0
+            d["cell"] = ("true-READY" if (ready and compiles) else
+                         "FALSE-READY" if (ready and not compiles) else
+                         "false-NOT-READY" if compiles else "true-NOT-READY")
+        if d["cell"] != before:
+            changed.append((d["arxiv_id"], before, d["cell"]))
+        print(f"  [{i}/{len(res['docs'])}] {d['arxiv_id']:16s} {d['cell']}",
+              flush=True)
+
+    res["counts"] = dict(collections.Counter(d["cell"] for d in res["docs"]))
+    res["measured_at_sha"] = git_head(repo)
+    res["measured_at"] = "cli-only refresh; pdflatex verdicts carried forward"
+    results_path.write_text(json.dumps(res, indent=1) + "\n")
+    print(f"\n[real-roots] refreshed: {len(changed)} cell change(s)")
+    for a, b, c in changed:
+        print(f"    {a:16s} {b} -> {c}")
+    print(f"[real-roots] measured_at_sha = {res['measured_at_sha']}")
+    return 0
+
+
+def git_head(repo: Path) -> str:
+    r = subprocess.run(["git", "--no-optional-locks", "rev-parse", "HEAD"],
+                       cwd=repo, capture_output=True, text=True)
+    return r.stdout.strip() or "unknown"
+
+
 def main() -> int:  # noqa: C901
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("--corpus-root", default=os.environ.get("LP_REAL_CORPUS"))
@@ -225,6 +312,10 @@ def main() -> int:  # noqa: C901
     ap.add_argument("--record", action="store_true",
                     help="write the frame manifest and the results baseline")
     ap.add_argument("--out", default="corpora/real_roots")
+    ap.add_argument("--refresh-cli", action="store_true",
+                    help="recompute only the CLI verdict, carrying the recorded "
+                         "pdflatex results forward (asserts corpus + engine "
+                         "unchanged)")
     ns = ap.parse_args()
 
     repo = Path(ns.repo).resolve()
@@ -248,6 +339,9 @@ def main() -> int:  # noqa: C901
         return die(2, "pdflatex not on PATH")
     if PIN not in banner:
         return die(3, f"engine skew: local is {banner!r}, pinned is {PIN!r}")
+
+    if ns.refresh_cli:
+        return refresh_cli_only(repo, root, outdir, banner, ns.timeout)
 
     frame = build_frame(root)
     if len(frame) < ns.n:


### PR DESCRIPTION
**The published position was wrong and every gate was green.** `PROJECT_STATE` said 56.8% correct / 37.7% over-rejection while main measured **65.8% / 28.6%**. `results.json` had gone **three PRs stale** (#541, #543, #544), and `check_project_state` couldn't see it — the generated block correctly matched a source that was simply out of date.

That's C-16: **a source-of-truth needs provenance on its sources, not merely consistency with them.**

## The refresh

`diff_real_roots.py --refresh-cli` recomputes only the CLI verdict and carries the recorded pdflatex results forward. A full sweep recompiles 200 papers (~20 min) — right when the *corpus* or *engine* changed, waste when only the tool changed. And the tool changes constantly, which is exactly how the number decayed.

The shortcut is sound under two conditions, **both asserted rather than assumed**:

- every paper's `sha256_tree` still matches the manifest → the documents are byte-identical
- `pdflatex --version` still matches the pin

Given those, a pdflatex verdict is a property of the **document**, not of our binary. If either fails, it refuses and points at the full sweep.

**Result — 18 cell changes, every one `false-NOT-READY → true-READY`**, exactly the #541 + #544 rescues, nothing unexpected, no false-READY created:

| | before | after |
|---|---|---|
| true-READY | 107 | **125** |
| false-NOT-READY | 75 | **57** |
| FALSE-READY | 11 | 11 (unchanged) |
| **correct** | 113/199 (56.8%) | **131/199 (65.8%)** |
| **over-rejection** | 75/199 (37.7%) | **57/199 (28.6%)** |

## The gate

`results.json` records `measured_at_sha`; `check_project_state` fails when more than **five** commits touching `latex-parse/src` land after it. It cannot re-measure — CI has no corpus, by design, since it's 12 GB of non-redistributable arXiv source — so it checks provenance instead.

The threshold is deliberate. Failing on *every* source change would train people to refresh without reading — the failure mode **C-13** records about my own earlier use of `git describe` in a diffed block. This is a **ratchet**: normal churn passes, long-term decay doesn't.

Verified at the boundary: **5 commits behind passes, 8 fails** with the count named.

## ⚠ A bug of mine — C-17

The first version wrapped the read in a bare `except Exception`. `json` was never imported, so it swallowed a `NameError` and reported **"no measured_at_sha"** — a plausible and entirely *wrong* diagnostic that sent me inspecting the data instead of the code.

It now catches only `JSONDecodeError` and `OSError`, and an unreadable file is reported as unreadable. **A broad except turns a programming error into a convincing finding** — `check_code_quality.py` already polices this shape in OCaml.

## OPEN-011 is updated, not closed

The ratchet **bounds** decay; it doesn't eliminate it, because nothing re-measures in CI. That limit is stated in the row rather than glossed.

## Verified both directions

| | |
|---|---|
| baseline | pass |
| `measured_at_sha` removed | fail |
| measurement 8 commits stale | fail, naming the count |
| `results.json` corrupt | fail |

`check_project_state`, `check_doc_refs`, `check_gates_meta`, `check_roadmap_facts` all pass.