### PR TITLE
fix: no gate script may swallow a broad exception into a fallback value

### DIFF
--- a/scripts/tools/check_apply_fixes_roundtrip.py
+++ b/scripts/tools/check_apply_fixes_roundtrip.py
@@ -174,10 +174,17 @@ def main() -> int:
     # Checked HERE rather than at the write, so it costs nothing: the refusal
     # lands before the 73-document sweep instead of after it.
     if args.record and not have_tex and manifest_path.exists():
+        # Catch only what reading JSON can genuinely raise. A broad except here
+        # treated a CORRUPT manifest as "not pdflatex_graded" and then allowed
+        # the --record it exists to prevent — erasing every breaks_compile row.
+        # The safe reading of "I cannot tell" is REFUSE, not proceed.
         try:
             prior_graded = json.loads(manifest_path.read_text()).get("pdflatex_graded")
-        except Exception:  # noqa: BLE001
-            prior_graded = None
+        except (json.JSONDecodeError, OSError) as exc:
+            return die(f"cannot read {MANIFEST} to check whether it is "
+                       f"pdflatex-graded ({exc}); refusing to --record, because "
+                       f"if it IS graded this would erase every breaks_compile "
+                       f"row")
         if prior_graded:
             return die(
                 "refusing to re-record: the existing baseline is pdflatex_graded "
@@ -339,11 +346,16 @@ def main() -> int:
         owned = {"description", "properties", "pdflatex_graded", "known_broken"}
         carried: dict = {}
         if manifest_path.exists():
+            # [carried = {}] on failure performs exactly the destruction this
+            # block exists to prevent: it drops the `oracle` provenance block
+            # that tex-oracle.yml pin-asserts. Unreadable means STOP.
             try:
                 carried = {k: v for k, v in json.loads(manifest_path.read_text()).items()
                            if k not in owned}
-            except Exception:  # noqa: BLE001
-                carried = {}
+            except (json.JSONDecodeError, OSError) as exc:
+                return die(f"cannot read {MANIFEST} to carry its unowned keys "
+                           f"forward ({exc}); refusing to --record rather than "
+                           f"silently discarding the oracle provenance block")
         manifest_path.parent.mkdir(parents=True, exist_ok=True)
         manifest_path.write_text(json.dumps({
             "description": (

--- a/scripts/tools/check_code_quality.py
+++ b/scripts/tools/check_code_quality.py
@@ -151,6 +151,69 @@ TRIVIAL_EXPECT_PATTERNS = [
 TRIVIAL_EXPECT_CEILING = 40  # P1.10 baseline for `expect true` smoke tests
 
 
+def gate_python_silent_except(repo: Path) -> list[str]:
+    """No GATE SCRIPT may swallow a broad exception into a fallback value.
+
+    The OCaml arm above has policed this since P1.10. The Python gate scripts
+    were never covered, and it bit exactly as predicted: a broad
+    `except Exception` in check_project_state.py swallowed a NameError (`json`
+    was not imported) and reported "no measured_at_sha" — a specific, plausible
+    and completely wrong diagnostic that sent the author inspecting the data
+    instead of the code.
+
+    A broad except does not merely hide an error. In a gate it MANUFACTURES A
+    FINDING, and a wrong finding is worse than a crash: a crash gets fixed,
+    a wrong finding gets believed.
+
+    Two of the sites this gate was written for were actively destructive rather
+    than merely misleading — in check_apply_fixes_roundtrip.py, one treated a
+    corrupt manifest as "not pdflatex-graded" and would then permit the --record
+    that erases every breaks_compile row, and another silently dropped the
+    `oracle` provenance block that tex-oracle.yml pin-asserts.
+
+    The rule: inside scripts/tools/, a broad handler must either NARROW its
+    exception type, or visibly report — die(), raise, SystemExit, or append to a
+    findings list. Producing a fallback value and continuing is the banned shape.
+    """
+    import ast
+
+    failures: list[str] = []
+    scanned = 0
+    for p in sorted((repo / "scripts/tools").glob("*.py")):
+        try:
+            tree = ast.parse(p.read_text(errors="replace"))
+        except SyntaxError:
+            continue
+        scanned += 1
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.ExceptHandler):
+                continue
+            typ = node.type
+            broad = typ is None or (
+                isinstance(typ, ast.Name) and typ.id in ("Exception", "BaseException")
+            )
+            if not broad:
+                continue
+            src = ast.dump(node)
+            reports = (
+                "Raise(" in src
+                or "'die'" in src
+                or "SystemExit" in src
+                or "'append'" in src
+                or "'exit'" in src
+            )
+            if not reports:
+                failures.append(
+                    f"{p.relative_to(repo)}:{node.lineno}: broad `except "
+                    f"{'(bare)' if typ is None else typ.id}` produces a fallback "
+                    f"and continues. In a gate that MANUFACTURES a wrong finding. "
+                    f"Narrow the exception type, or die()/raise.")
+    if scanned < 15:
+        failures.append(
+            f"only {scanned} gate script(s) scanned — refusing to pass vacuously")
+    return failures
+
+
 def gate_test_triviality(repo: Path) -> list[str]:
     failures: list[str] = []
     smoke_count = 0
@@ -199,6 +262,7 @@ def main() -> int:
     for name, fn in [
         ("Defined. audit", gate_defined_audit),
         ("Exception swallow", gate_exception_swallow),
+        ("Python gate silent-except", gate_python_silent_except),
         ("Test triviality", gate_test_triviality),
     ]:
         failures = fn(repo)

--- a/scripts/tools/check_version_labels.py
+++ b/scripts/tools/check_version_labels.py
@@ -83,8 +83,16 @@ def tracked_md_files(repo: Path) -> list[Path]:
             ["git", "ls-files", "*.md"], cwd=repo, capture_output=True, text=True, check=True
         ).stdout
         rels = [r for r in out.splitlines() if r]
-    except Exception:
-        rels = [str(p.relative_to(repo)) for p in repo.rglob("*.md")]
+    except (subprocess.CalledProcessError, OSError) as exc:
+        # The old fallback rglob'd the worktree, which scans a DIFFERENT set:
+        # untracked files, _build artefacts and archives that git ls-files
+        # deliberately excludes. A gate that silently changes what it inspects
+        # is worse than one that stops.
+        raise SystemExit(
+            f"[version-labels] FAIL: `git ls-files *.md` failed ({exc}). "
+            f"Refusing to fall back to a filesystem walk — it would scan "
+            f"untracked and build files and silently change what this gate "
+            f"checks.")
     keep = []
     for rel in rels:
         if any(seg in f"/{rel}" for seg in EXCLUDE_SEGMENTS):

--- a/scripts/tools/diff_real_roots.py
+++ b/scripts/tools/diff_real_roots.py
@@ -89,13 +89,18 @@ def build_frame(root: Path) -> list[dict]:
     across this tree.
     """
     frame = []
+    skipped: list[str] = []
     for d in sorted(root.iterdir()):
         readme = d / "00README.json"
         if not readme.is_file():
             continue
         try:
             meta = json.loads(readme.read_text())
-        except Exception:  # noqa: BLE001
+        except (json.JSONDecodeError, OSError):
+            # An unreadable 00README.json silently shrank the FRAME, and the
+            # frame size is a published number ("frame 2719"). Count them so a
+            # systematic corpus problem is visible instead of rounding away.
+            skipped.append(d.name)
             continue
         if (meta.get("process") or {}).get("compiler") != "pdflatex":
             continue
@@ -112,6 +117,10 @@ def build_frame(root: Path) -> list[dict]:
             "declared_compiler": "pdflatex",
             "declared_texlive": (meta.get("process") or {}).get("texlive_version"),
         })
+    if skipped:
+        print(f"[real-roots] WARNING: {len(skipped)} package(s) have an "
+              f"unreadable 00README.json and are NOT in the frame: "
+              f"{', '.join(skipped[:5])}{'...' if len(skipped) > 5 else ''}")
     return frame
 
 


### PR DESCRIPTION
Yesterday a bare `except Exception` in `check_project_state.py` swallowed a `NameError` (`json` was never imported) and reported **"no measured_at_sha"** — a specific, plausible, entirely wrong diagnostic that sent me inspecting the *data* for two rounds before I questioned the *code*.

I fixed that one site and said so. **This fixes the class.**

A broad except doesn't merely hide an error. In a gate it **manufactures a finding** — and a wrong finding is worse than a crash: a crash gets fixed, a wrong finding gets believed and acted on.

## The census

An AST sweep of `scripts/`, `ml/`, `generator/`, `infra/` found **20 broad handlers, 11 silent**.

Reading each one mattered: **my own heuristic mislabelled three.** `check_apply_fixes_roundtrip.py:162`, `check_keystroke_budget.py:219` and `:229` all `return die(...)` — the classifier saw a `Return` node and called it silent.

**Four were genuinely dangerous, two of them destructive rather than merely misleading:**

| site | what the fallback did |
|---|---|
| `check_apply_fixes_roundtrip.py:179` | read a corrupt manifest as "not pdflatex_graded", which would then **permit the `--record` that erases every `breaks_compile` row** — the exact thing the block exists to prevent |
| `check_apply_fixes_roundtrip.py:345` | `carried = {}` silently drops the **`oracle` provenance block** that `tex-oracle.yml` pin-asserts — the destruction #531 was written to stop, reintroduced through the error path |
| `check_version_labels.py:86` | fell back from `git ls-files *.md` to an rglob of the worktree — a **different file set** (untracked, `_build`, archives) |
| `diff_real_roots.py:98` | an unreadable `00README.json` silently shrank the **frame**, and the frame size is a published number ("frame 2719") |

"I cannot tell" must mean **refuse**, not proceed.

`ml/` is deliberately untouched — those are training scripts, they gate nothing, and widening this would spend review attention for no safety.

## The class fix

`gate_python_silent_except` in `check_code_quality.py`, which has policed this shape in non-test **OCaml** since P1.10. The Python gate scripts were simply never covered — and they're the scripts whose wrong answers are most likely to be believed.

**The rule:** inside `scripts/tools/`, a broad handler must **narrow its exception type** or **visibly report** (`die` / `raise` / `SystemExit` / append to findings). Producing a fallback and continuing is banned. It also refuses to pass if it scans fewer than 15 files, so it can't go vacuous the way `unicode-smoke` did for 185 days.

## Verified both directions, five shapes

| shape | result |
|---|---|
| `except Exception: x = None` | **FAIL** |
| `except: pass` | **FAIL** |
| `except Exception: return None` | **FAIL** |
| `except (OSError,): x = None` | PASS (narrowed) |
| `except Exception: raise SystemExit` | PASS (reports) |

## ⚠ A probe of mine that proved nothing

My first injection test reported "the original bug is not caught". The injection had **silently no-opped** — I wrote the replace without asserting the anchor matched, and that anchor lives in the still-unmerged #546.

**A test that cannot fail looks exactly like a test that passes.** Every injection above now asserts its anchor. Third instance of this pattern from me this week.

`check_code_quality`, `check_version_labels`, `check_gates_meta`, `check_doc_refs`, `check_project_state` all pass; `check_apply_fixes_roundtrip` **passes with real pdflatex** (73 docs × 4 cells, known-broken 3, unchanged).